### PR TITLE
Feat import configuration variable

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -38,6 +38,7 @@ type ConfigurationVariableSchema struct {
 }
 
 type ConfigurationVariable struct {
+	ScopeId        string                      `json:"scopId"`
 	Value          string                      `json:"value"`
 	OrganizationId string                      `json:"organizationId"`
 	UserId         string                      `json:"userId"`
@@ -126,7 +127,7 @@ type Template struct {
 	Type                 string           `json:"type"`
 	GithubInstallationId int              `json:"githubInstallationId"`
 	UpdatedAt            string           `json:"updatedAt"`
-	TerraformVersion	 string			  `json:"terraformVersion"`
+	TerraformVersion     string           `json:"terraformVersion"`
 }
 
 type SshKey struct {

--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -85,24 +85,7 @@ func dataConfigurationVariable() *schema.Resource {
 }
 
 func dataConfigurationVariableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	scope := client.ScopeGlobal
-	scopeId := ""
-	if projectId, ok := d.GetOk("project_id"); ok {
-		scope = client.ScopeProject
-		scopeId = projectId.(string)
-	}
-	if templateId, ok := d.GetOk("template_id"); ok {
-		scope = client.ScopeTemplate
-		scopeId = templateId.(string)
-	}
-	if environmentId, ok := d.GetOk("environment_id"); ok {
-		scope = client.ScopeEnvironment
-		scopeId = environmentId.(string)
-	}
-	if deploymentLogId, ok := d.GetOk("deployment_log_id"); ok {
-		scope = client.ScopeDeploymentLog
-		scopeId = deploymentLogId.(string)
-	}
+	scope, scopeId := getScopeAndId(d)
 	id, idOk := d.GetOk("id")
 	name, nameOk := d.GetOk("name")
 	configurationType, configurationOk := d.GetOk("type")
@@ -139,6 +122,28 @@ func dataConfigurationVariableRead(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	return nil
+}
+
+func getScopeAndId(d *schema.ResourceData) (client.Scope, string) {
+	scope := client.ScopeGlobal
+	scopeId := ""
+	if projectId, ok := d.GetOk("project_id"); ok {
+		scope = client.ScopeProject
+		scopeId = projectId.(string)
+	}
+	if templateId, ok := d.GetOk("template_id"); ok {
+		scope = client.ScopeTemplate
+		scopeId = templateId.(string)
+	}
+	if environmentId, ok := d.GetOk("environment_id"); ok {
+		scope = client.ScopeEnvironment
+		scopeId = environmentId.(string)
+	}
+	if deploymentLogId, ok := d.GetOk("deployment_log_id"); ok {
+		scope = client.ScopeDeploymentLog
+		scopeId = deploymentLogId.(string)
+	}
+	return scope, scopeId
 }
 
 func getConfigurationVariable(params ConfigurationVariableParams, meta interface{}) (client.ConfigurationVariable, diag.Diagnostics) {

--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -12,11 +12,8 @@ type ConfigurationVariableParams struct {
 	Scope             client.Scope
 	ScopeId           string
 	Id                string
-	HaveId            bool
 	Name              string
-	HaveName          bool
 	configurationType string
-	HaveType          bool
 }
 
 func dataConfigurationVariable() *schema.Resource {
@@ -101,7 +98,7 @@ func dataConfigurationVariableRead(ctx context.Context, d *schema.ResourceData, 
 		parsedConfigurationType = configurationType.(string)
 	}
 
-	params := ConfigurationVariableParams{scope, scopeId, parsedId, idOk, parsedName, nameOk, parsedConfigurationType, configurationOk}
+	params := ConfigurationVariableParams{scope, scopeId, parsedId, parsedName, parsedConfigurationType}
 
 	variable, err := getConfigurationVariable(params, scopeId)
 	if err != nil {
@@ -154,9 +151,9 @@ func getConfigurationVariable(params ConfigurationVariableParams, meta interface
 		return client.ConfigurationVariable{}, diag.Errorf("Could not query variables: %v", err)
 	}
 
-	id, idOk := params.Id, params.HaveId
-	name, nameOk := params.Name, params.HaveName
-	typeString, ok := params.configurationType, params.HaveType
+	id, idOk := params.Id, params.Id != ""
+	name, nameOk := params.Name, params.Name != ""
+	typeString, ok := params.configurationType, params.configurationType != ""
 	type_ := int64(-1)
 	if ok {
 		if !nameOk {

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -2,8 +2,8 @@ package env0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -190,16 +190,16 @@ func resourceConfigurationVariableDelete(ctx context.Context, d *schema.Resource
 }
 
 func resourceConfigurationVariableImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	return nil, errors.New("Not implemented")
-	// apiClient := meta.(*client.ApiClient)
-
-	// id := d.Id()
-	// configurationVariable, err := apiClient.ConfigurationVariable(id)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// d.Set("name", configurationVariable.Name)
-
-	// return []*schema.ResourceData{d}, nil
+	var configurationParams ConfigurationVariableParams
+	inputData := d.Id()
+	err := json.Unmarshal([]byte(inputData), configurationParams)
+	if err != nil {
+		return nil, err
+	}
+	_, getErr := getConfigurationVariable(configurationParams, meta)
+	if getErr != nil {
+		return nil, errors.New(getErr[0].Summary)
+	} else {
+		return []*schema.ResourceData{d}, nil
+	}
 }

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -197,6 +197,10 @@ func resourceConfigurationVariableImport(ctx context.Context, d *schema.Resource
 	var configurationParams ConfigurationVariableParams
 	inputData := d.Id()
 	err := json.Unmarshal([]byte(inputData), &configurationParams)
+	// We need this conversion since getConfigurationVariable query by the scope and in our BE we use blueprint as the scope name instead of template
+	if string(configurationParams.Scope) == "TEMPLATE" {
+		configurationParams.Scope = "BLUEPRINT"
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
+
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -209,6 +212,10 @@ func resourceConfigurationVariableImport(ctx context.Context, d *schema.Resource
 		return nil, errors.New(getErr[0].Summary)
 	} else {
 		d.SetId(variable.Id)
+		scopeName := strings.ToLower(fmt.Sprintf("%s_id", variable.Scope))
+
+		d.Set(scopeName, configurationParams.ScopeId)
+
 		return []*schema.ResourceData{d}, nil
 	}
 }

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -192,14 +192,15 @@ func resourceConfigurationVariableDelete(ctx context.Context, d *schema.Resource
 func resourceConfigurationVariableImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	var configurationParams ConfigurationVariableParams
 	inputData := d.Id()
-	err := json.Unmarshal([]byte(inputData), configurationParams)
+	err := json.Unmarshal([]byte(inputData), &configurationParams)
 	if err != nil {
 		return nil, err
 	}
-	_, getErr := getConfigurationVariable(configurationParams, meta)
+	variable, getErr := getConfigurationVariable(configurationParams, meta)
 	if getErr != nil {
 		return nil, errors.New(getErr[0].Summary)
 	} else {
+		d.SetId(variable.Id)
 		return []*schema.ResourceData{d}, nil
 	}
 }

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -84,6 +84,10 @@ func whichScope(d *schema.ResourceData) (client.Scope, string) {
 		scope = client.ScopeTemplate
 		scopeId = templateId.(string)
 	}
+	if templateId, ok := d.GetOk("blueprint_id"); ok {
+		scope = client.ScopeTemplate
+		scopeId = templateId.(string)
+	}
 	if environmentId, ok := d.GetOk("environment_id"); ok {
 		scope = client.ScopeEnvironment
 		scopeId = environmentId.(string)


### PR DESCRIPTION
PR 3/4 for https://github.com/env0/terraform-provider-env0/issues/16
Enable `terraform import env0_configuration_variable`

Note that after the import terraform run read in order to refresh the state, so in read we query for the variable again, but this time we need to set more details about the variable as the scope and the scope id,
for example if the scope in the input is `PROJECT` we need to change it to `project_id` and set the property value to be the scope id

Input example
```
terraform import env0_configuration_variable.tested1 '{  "Scope": "TEMPLATE",  "ScopeId": "e4025694-8370-4ab8-954a-af6cd4167d78",  "name": "fasdf"}'   
```