### PR TITLE
Fix: harness test failures

### DIFF
--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -100,7 +100,7 @@ func dataConfigurationVariableRead(ctx context.Context, d *schema.ResourceData, 
 
 	params := ConfigurationVariableParams{scope, scopeId, parsedId, parsedName, parsedConfigurationType}
 
-	variable, err := getConfigurationVariable(params, scopeId)
+	variable, err := getConfigurationVariable(params, meta)
 	if err != nil {
 		return err
 	}

--- a/env0/data_sshkey.go
+++ b/env0/data_sshkey.go
@@ -34,7 +34,7 @@ func dataSshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	var sshKey client.SshKey
 	var err diag.Diagnostics
 	if nameSpecified {
-		sshKey, err = getSshKeyByName(meta, name)
+		sshKey, err = getSshKeyByName(name, meta)
 		if err != nil {
 			return err
 		}

--- a/env0/data_sshkey.go
+++ b/env0/data_sshkey.go
@@ -60,22 +60,25 @@ func getSshKeyByName(name interface{}, meta interface{}) (client.SshKey, diag.Di
 	apiClient := meta.(*client.ApiClient)
 
 	sshKeys, err := apiClient.SshKeys()
-	var sshKey client.SshKey
 	if err != nil {
 		return client.SshKey{}, diag.Errorf("Could not query ssh keys: %v", err)
 	}
-	if len(sshKeys) > 1 {
-		return client.SshKey{}, diag.Errorf("Found multiple SSH Keys for name: %s. Use ID instead or make sure SSH Keys names are unique %v", name, sshKeys)
-	}
+
+	var sshKeysByName []client.SshKey
 	for _, candidate := range sshKeys {
 		if candidate.Name == name {
-			sshKey = candidate
+			sshKeysByName = append(sshKeysByName, candidate)
 		}
 	}
-	if sshKey.Name == "" {
+
+	if len(sshKeysByName) > 1 {
+		return client.SshKey{}, diag.Errorf("Found multiple SSH Keys for name: %s. Use ID instead or make sure SSH Keys names are unique %v", name, sshKeysByName)
+	}
+	if len(sshKeysByName) == 0 {
 		return client.SshKey{}, diag.Errorf("Could not find an env0 ssh key with name %s", name)
 	}
-	return sshKey, nil
+
+	return sshKeysByName[0], nil
 }
 
 func getSshKeyById(id interface{}, meta interface{}) (client.SshKey, diag.Diagnostics) {
@@ -86,6 +89,7 @@ func getSshKeyById(id interface{}, meta interface{}) (client.SshKey, diag.Diagno
 	if err != nil {
 		return client.SshKey{}, diag.Errorf("Could not query ssh keys: %v", err)
 	}
+
 	for _, candidate := range sshKeys {
 		if candidate.Id == id.(string) {
 			sshKey = candidate

--- a/env0/data_sshkey.go
+++ b/env0/data_sshkey.go
@@ -43,7 +43,7 @@ func dataSshKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{
 		if !idSpecified {
 			return diag.Errorf("At lease one of 'id', 'name' must be specified")
 		}
-		sshKey, err = getSshKeyById(meta, id)
+		sshKey, err = getSshKeyById(id, meta)
 		if err != nil {
 			return err
 		}

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -148,27 +148,26 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 func getTemplateByName(name interface{}, meta interface{}) (client.Template, diag.Diagnostics) {
 	apiClient := meta.(*client.ApiClient)
 	templates, err := apiClient.Templates()
-	var templatesWithName []client.Template
-
 	if err != nil {
 		return client.Template{}, diag.Errorf("Could not query templates: %v", err)
 	}
 
+	var templatesByName []client.Template
 	for _, candidate := range templates {
 		if candidate.Name == name {
-			templatesWithName = append(templatesWithName, candidate)
+			templatesByName = append(templatesByName, candidate)
 		}
 	}
 
-	if len(templatesWithName) > 1 {
-		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique.", name)
+	if len(templatesByName) > 1 {
+		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique %v", name, templatesByName)
 	}
 
-	if len(templatesWithName) == 0 {
+	if len(templatesByName) == 0 {
 		return client.Template{}, diag.Errorf("Could not find an env0 template with name %s", name)
 	}
 
-	return templatesWithName[0], nil
+	return templatesByName[0], nil
 }
 
 func getTemplateById(id interface{}, meta interface{}) (client.Template, diag.Diagnostics) {

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -148,24 +148,27 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 func getTemplateByName(name interface{}, meta interface{}) (client.Template, diag.Diagnostics) {
 	apiClient := meta.(*client.ApiClient)
 	templates, err := apiClient.Templates()
-	var template client.Template
+	var templatesWithName []client.Template
 
 	if err != nil {
 		return client.Template{}, diag.Errorf("Could not query templates: %v", err)
 	}
-	if len(templates) > 1 {
-		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique.", name)
-	}
+
 	for _, candidate := range templates {
 		if candidate.Name == name {
-			template = candidate
+			templatesWithName = append(templatesWithName, candidate)
 		}
 	}
-	if template.Name == "" {
+
+	if len(templatesWithName) > 1 {
+		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique.", name)
+	}
+
+	if len(templatesWithName) == 0 {
 		return client.Template{}, diag.Errorf("Could not find an env0 template with name %s", name)
 	}
 
-	return template, nil
+	return templatesWithName[0], nil
 }
 
 func getTemplateById(id interface{}, meta interface{}) (client.Template, diag.Diagnostics) {

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -154,7 +154,7 @@ func getTemplateByName(name interface{}, meta interface{}) (client.Template, dia
 		return client.Template{}, diag.Errorf("Could not query templates: %v", err)
 	}
 	if len(templates) > 1 {
-		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique %v", name, templates)		
+		return client.Template{}, diag.Errorf("Found multiple Templates for name: %s. Use ID instead or make sure Template names are unique.", name)
 	}
 	for _, candidate := range templates {
 		if candidate.Name == name {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Fixes #53 

### Solution
1. Fixed wrong parameter passed to `getConfigurationVariable`, `getSshKeyById`, `getSshKeyByName`.
2. Fixed wrong logic of `getTemplateByName` and `getSshKeyByName`.
