### PR TITLE
Fix: Template creation model to omit empty github installation id

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -34,8 +34,8 @@ type Project struct {
 }
 
 type UpdateProjectPayload struct {
-	Name           string `json:"name,omitempty"`
-	Description    string `json:"description,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type ConfigurationVariableSchema struct {
@@ -107,7 +107,7 @@ type TemplateCreatePayload struct {
 	IsGitLab             bool             `json:"isGitLab"`
 	TokenName            string           `json:"tokenName"`
 	TokenId              string           `json:"tokenId"`
-	GithubInstallationId int              `json:"githubInstallationId"`
+	GithubInstallationId int              `json:"githubInstallationId,omitempty"`
 	Revision             string           `json:"revision"`
 	ProjectIds           []string         `json:"projectIds,omitempty"`
 	OrganizationId       string           `json:"organizationId"`

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -5,17 +5,25 @@ import (
 
 	. "github.com/env0/terraform-provider-env0/client"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 var _ = Describe("Models", func() {
 	Describe("TemplateCreatePayload", func() {
-		It("Should omit Github Installation Id when it's not there", func() {
-			payload := TemplateCreatePayload{}
-			jsonPayload, _ := json.Marshal(payload)
-			var parsedPayload map[string]interface{}
-			json.Unmarshal(jsonPayload, &parsedPayload)
-			Expect(parsedPayload["githubInstallationId"]).To(BeNil())
-		})
+		DescribeTable("Github Installation Id",
+			func(value int, expected types.GomegaMatcher) {
+				payload := TemplateCreatePayload{
+					GithubInstallationId: value,
+				}
+				jsonPayload, _ := json.Marshal(payload)
+				var parsedPayload map[string]interface{}
+				json.Unmarshal(jsonPayload, &parsedPayload)
+				Expect(parsedPayload["githubInstallationId"]).To(expected)
+			},
+			Entry("Has value", 123, BeEquivalentTo(123)),
+			Entry("No value", nil, BeNil()),
+		)
 	})
 })

--- a/client/model_test.go
+++ b/client/model_test.go
@@ -1,0 +1,21 @@
+package client_test
+
+import (
+	"encoding/json"
+
+	. "github.com/env0/terraform-provider-env0/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Models", func() {
+	Describe("TemplateCreatePayload", func() {
+		It("Should omit Github Installation Id when it's not there", func() {
+			payload := TemplateCreatePayload{}
+			jsonPayload, _ := json.Marshal(payload)
+			var parsedPayload map[string]interface{}
+			json.Unmarshal(jsonPayload, &parsedPayload)
+			Expect(parsedPayload["githubInstallationId"]).To(BeNil())
+		})
+	})
+})

--- a/tests/integration/005_ssh_key/main.tf
+++ b/tests/integration/005_ssh_key/main.tf
@@ -24,9 +24,9 @@ output "name" {
 }
 
 resource "env0_template" "usage" {
-  name          = "use a ssh key"
-  description   = "use a ssh key"
-  type          = "terraform"
-  repository    = "https://github.com/shlomimatichin/env0-template-jupyter-gpu"
-  ssh_keys = [env0_ssh_key.tested]
+  name                   = "use a ssh key"
+  description            = "use a ssh key"
+  type                   = "terraform"
+  repository             = "https://github.com/shlomimatichin/env0-template-jupyter-gpu"
+  ssh_keys               = [env0_ssh_key.tested]
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Creating a new template without specifying `github_installation_id` results in `githubInstallationId:0` which is not allowed.

### Solution
Make sure this property is also omitted when transforming to JSON.
