### PR TITLE
Fix: failing API client tests

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -28,6 +28,8 @@ type ApiClientInterface interface {
 	TemplateCreate(payload TemplateCreatePayload) (Template, error)
 	TemplateUpdate(id string, payload TemplateCreatePayload) (Template, error)
 	TemplateDelete(id string) error
+	AssignTemplateToProject(id string, payload TemplateAssignmentToProjectPayload) (Template, error)
+	RemoveTemplateFromProject(templateId string, projectId string) error
 	SshKeys() ([]SshKey, error)
 	SshKeyCreate(payload SshKeyCreatePayload) (SshKey, error)
 	SshKeyDelete(id string) error

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -33,6 +33,21 @@ func (m *MockApiClientInterface) EXPECT() *MockApiClientInterfaceMockRecorder {
 	return m.recorder
 }
 
+// AssignTemplateToProject mocks base method.
+func (m *MockApiClientInterface) AssignTemplateToProject(arg0 string, arg1 TemplateAssignmentToProjectPayload) (Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssignTemplateToProject", arg0, arg1)
+	ret0, _ := ret[0].(Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignTemplateToProject indicates an expected call of AssignTemplateToProject.
+func (mr *MockApiClientInterfaceMockRecorder) AssignTemplateToProject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignTemplateToProject", reflect.TypeOf((*MockApiClientInterface)(nil).AssignTemplateToProject), arg0, arg1)
+}
+
 // AwsCredentials mocks base method.
 func (m *MockApiClientInterface) AwsCredentials(arg0 string) (ApiKey, error) {
 	m.ctrl.T.Helper()
@@ -238,6 +253,20 @@ func (m *MockApiClientInterface) Projects() ([]Project, error) {
 func (mr *MockApiClientInterfaceMockRecorder) Projects() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Projects", reflect.TypeOf((*MockApiClientInterface)(nil).Projects))
+}
+
+// RemoveTemplateFromProject mocks base method.
+func (m *MockApiClientInterface) RemoveTemplateFromProject(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveTemplateFromProject", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveTemplateFromProject indicates an expected call of RemoveTemplateFromProject.
+func (mr *MockApiClientInterfaceMockRecorder) RemoveTemplateFromProject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTemplateFromProject", reflect.TypeOf((*MockApiClientInterface)(nil).RemoveTemplateFromProject), arg0, arg1)
 }
 
 // SshKeyCreate mocks base method.

--- a/client/http/client_mock.go
+++ b/client/http/client_mock.go
@@ -61,6 +61,20 @@ func (mr *MockHttpClientInterfaceMockRecorder) Get(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockHttpClientInterface)(nil).Get), arg0, arg1, arg2)
 }
 
+// Patch mocks base method.
+func (m *MockHttpClientInterface) Patch(arg0 string, arg1, arg2 interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Patch", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Patch indicates an expected call of Patch.
+func (mr *MockHttpClientInterfaceMockRecorder) Patch(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockHttpClientInterface)(nil).Patch), arg0, arg1, arg2)
+}
+
 // Post mocks base method.
 func (m *MockHttpClientInterface) Post(arg0 string, arg1, arg2 interface{}) error {
 	m.ctrl.T.Helper()
@@ -73,20 +87,6 @@ func (m *MockHttpClientInterface) Post(arg0 string, arg1, arg2 interface{}) erro
 func (mr *MockHttpClientInterfaceMockRecorder) Post(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockHttpClientInterface)(nil).Post), arg0, arg1, arg2)
-}
-
-// patch mocks base method.
-func (m *MockHttpClientInterface) Patch(arg0 string, arg1, arg2 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Patch", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Patch indicates an expected call of Patch.
-func (mr *MockHttpClientInterfaceMockRecorder) Patch(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockHttpClientInterface)(nil).Patch), arg0, arg1, arg2)
 }
 
 // Put mocks base method.

--- a/env0/resource_template_project_assignment.go
+++ b/env0/resource_template_project_assignment.go
@@ -40,7 +40,7 @@ func templateProjectAssignmentPayloadFromParameters(d *schema.ResourceData) clie
 }
 
 func resourceTemplateProjectAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	templateId := d.Get("template_id").(string)
 	projectId := d.Get("project_id").(string)
@@ -55,7 +55,7 @@ func resourceTemplateProjectAssignmentCreate(ctx context.Context, d *schema.Reso
 }
 
 func resourceTemplateProjectAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	templateId := d.Get("template_id").(string)
 	template, err := apiClient.Template(templateId)
@@ -63,10 +63,10 @@ func resourceTemplateProjectAssignmentRead(ctx context.Context, d *schema.Resour
 		return diag.Errorf("could not get template: %v", err)
 	}
 	var assignProjectId = d.Get("project_id").(string)
-	isProjectIdInTemplate:= false 
+	isProjectIdInTemplate := false
 	for _, projectId := range template.ProjectIds {
 		if assignProjectId == projectId {
-			isProjectIdInTemplate = true 
+			isProjectIdInTemplate = true
 		}
 	}
 	if !isProjectIdInTemplate {
@@ -78,7 +78,7 @@ func resourceTemplateProjectAssignmentRead(ctx context.Context, d *schema.Resour
 }
 
 func resourceTemplateProjectAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	templateId := d.Get("template_id").(string)
 	projectId := d.Get("project_id").(string)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Template API client tests are failing.

### Solution
1. Add missing methods to `ApiClientInterface`
2. Regenerate mocks
