### PR TITLE
Fix: project description removal

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -20,8 +20,8 @@ type ApiClientInterface interface {
 	organizationId() (string, error)
 	Projects() ([]Project, error)
 	Project(id string) (Project, error)
-	ProjectCreate(name string, description string) (Project, error)
-	ProjectUpdate(id string, payload UpdateProjectPayload) (Project, error)
+	ProjectCreate(payload ProjectCreatePayload) (Project, error)
+	ProjectUpdate(id string, payload ProjectCreatePayload) (Project, error)
 	ProjectDelete(id string) error
 	Template(id string) (Template, error)
 	Templates() ([]Template, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -227,18 +227,18 @@ func (mr *MockApiClientInterfaceMockRecorder) Project(arg0 interface{}) *gomock.
 }
 
 // ProjectCreate mocks base method.
-func (m *MockApiClientInterface) ProjectCreate(arg0, arg1 string) (Project, error) {
+func (m *MockApiClientInterface) ProjectCreate(arg0 ProjectCreatePayload) (Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProjectCreate", arg0, arg1)
+	ret := m.ctrl.Call(m, "ProjectCreate", arg0)
 	ret0, _ := ret[0].(Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProjectCreate indicates an expected call of ProjectCreate.
-func (mr *MockApiClientInterfaceMockRecorder) ProjectCreate(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockApiClientInterfaceMockRecorder) ProjectCreate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectCreate", reflect.TypeOf((*MockApiClientInterface)(nil).ProjectCreate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectCreate", reflect.TypeOf((*MockApiClientInterface)(nil).ProjectCreate), arg0)
 }
 
 // ProjectDelete mocks base method.
@@ -256,7 +256,7 @@ func (mr *MockApiClientInterfaceMockRecorder) ProjectDelete(arg0 interface{}) *g
 }
 
 // ProjectUpdate mocks base method.
-func (m *MockApiClientInterface) ProjectUpdate(arg0 string, arg1 UpdateProjectPayload) (Project, error) {
+func (m *MockApiClientInterface) ProjectUpdate(arg0 string, arg1 ProjectCreatePayload) (Project, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectUpdate", arg0, arg1)
 	ret0, _ := ret[0].(Project)

--- a/client/model.go
+++ b/client/model.go
@@ -33,9 +33,9 @@ type Project struct {
 	Description    string `json:"description"`
 }
 
-type UpdateProjectPayload struct {
-	Name        string `json:"name,omitempty"`
-	Description string `json:"description,omitempty"`
+type ProjectCreatePayload struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 type ConfigurationVariableSchema struct {

--- a/client/project.go
+++ b/client/project.go
@@ -22,14 +22,14 @@ func (self *ApiClient) Project(id string) (Project, error) {
 	return result, nil
 }
 
-func (self *ApiClient) ProjectCreate(name string, description string) (Project, error) {
+func (self *ApiClient) ProjectCreate(payload ProjectCreatePayload) (Project, error) {
 	var result Project
 	organizationId, err := self.organizationId()
 	if err != nil {
 		return Project{}, err
 	}
 
-	request := map[string]interface{}{"name": name, "organizationId": organizationId, "description": description}
+	request := map[string]interface{}{"name": payload.Name, "organizationId": organizationId, "description": payload.Description}
 	err = self.http.Post("/projects", request, &result)
 	if err != nil {
 		return Project{}, err
@@ -41,7 +41,7 @@ func (self *ApiClient) ProjectDelete(id string) error {
 	return self.http.Delete("/projects/" + id)
 }
 
-func (self *ApiClient) ProjectUpdate(id string, payload UpdateProjectPayload) (Project, error) {
+func (self *ApiClient) ProjectUpdate(id string, payload ProjectCreatePayload) (Project, error) {
 	var result Project
 	err := self.http.Put("/projects/"+id, payload, &result)
 

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -34,7 +34,10 @@ var _ = Describe("Project", func() {
 					*response = mockProject
 				})
 
-			project, _ = apiClient.ProjectCreate(projectName, projectDescription)
+			project, _ = apiClient.ProjectCreate(ProjectCreatePayload{
+				Name:        projectName,
+				Description: projectDescription,
+			})
 		})
 
 		It("Should get organization id", func() {
@@ -64,7 +67,7 @@ var _ = Describe("Project", func() {
 	Describe("ProjectUpdate", func() {
 		var mockedResponse Project
 		BeforeEach(func() {
-			payload := UpdateProjectPayload{
+			payload := ProjectCreatePayload{
 				Name:        "newName",
 				Description: "newDesc",
 			}

--- a/client/template.go
+++ b/client/template.go
@@ -81,7 +81,7 @@ func (self *ApiClient) AssignTemplateToProject(id string, payload TemplateAssign
 	if payload.ProjectId == "" {
 		return result, errors.New("Must specify projectId on assignment to a template")
 	}
-	err := self.http.Patch("/blueprints/" + id + "/projects", payload, &result)
+	err := self.http.Patch("/blueprints/"+id+"/projects", payload, &result)
 	if err != nil {
 		return result, err
 	}

--- a/env0/resource_project_test.go
+++ b/env0/resource_project_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"regexp"
 	"testing"
 )
 
@@ -52,8 +53,11 @@ func TestUnitProjectResource(t *testing.T) {
 	}
 
 	runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().ProjectCreate(project.Name, project.Description).Times(1).Return(project, nil)
-		mock.EXPECT().ProjectUpdate(updatedProject.Id, client.UpdateProjectPayload{
+		mock.EXPECT().ProjectCreate(client.ProjectCreatePayload{
+			Name:        project.Name,
+			Description: project.Description,
+		}).Times(1).Return(project, nil)
+		mock.EXPECT().ProjectUpdate(updatedProject.Id, client.ProjectCreatePayload{
 			Name:        updatedProject.Name,
 			Description: updatedProject.Description,
 		}).Times(1).Return(updatedProject, nil)
@@ -65,4 +69,17 @@ func TestUnitProjectResource(t *testing.T) {
 
 		mock.EXPECT().ProjectDelete(project.Id).Times(1)
 	})
+}
+
+func TestUnitProjectInvalidParams(t *testing.T) {
+	testCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config:      resourceConfigCreate("env0_project", "test", map[string]interface{}{"name": ""}),
+				ExpectError: regexp.MustCompile("Project name cannot be empty"),
+			},
+		},
+	}
+
+	runUnitTest(t, testCase, func(mockFunc *client.MockApiClientInterface) {})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,12 @@ go 1.16 // please change also in `ci.yml` and `release.yml`
 
 require (
 	github.com/go-resty/resty/v2 v2.6.0
-	github.com/jarcoal/httpmock v1.0.8
 	github.com/golang/mock v1.4.3
 	github.com/google/uuid v1.2.0
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.4.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/jinzhu/copier v0.3.2
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
When a user removed the description it didn't really removed it in env0.
Fixes #87 
Also solves half of #74 (only project model)

### Solution
1. Remove `omitempty` json tags from `UpdateProjectPayload`
2. Align `UpdateProjectPayload` to be `ProjectCreatePayload` (like all other payload types) and also use it in project creation API.
3. Add validation func for project's empty name (also opened a bug task for env0)
4. Fix tests
