### PR TITLE
Fix: template ssh keys read

### DIFF
--- a/client/template.go
+++ b/client/template.go
@@ -81,7 +81,7 @@ func (self *ApiClient) AssignTemplateToProject(id string, payload TemplateAssign
 	if payload.ProjectId == "" {
 		return result, errors.New("Must specify projectId on assignment to a template")
 	}
-	err := self.http.Patch("/blueprints/" + id + "/projects", payload, &result)
+	err := self.http.Patch("/blueprints/"+id+"/projects", payload, &result)
 	if err != nil {
 		return result, err
 	}

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -199,6 +199,13 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("revision", template.Revision)
 	d.Set("type", template.Type)
 	d.Set("terraform_version", template.TerraformVersion)
+
+	var rawSshKeys []map[string]string
+	for _, sshKey := range template.SshKeys {
+		rawSshKeys = append(rawSshKeys, map[string]string{"id": sshKey.Id, "name": sshKey.Name})
+	}
+	d.Set("ssh_keys", rawSshKeys)
+
 	if template.Retry.OnDeploy != nil {
 		d.Set("retries_on_deploy", template.Retry.OnDeploy.Times)
 		d.Set("retry_on_deploy_only_when_matches_regex", template.Retry.OnDeploy.ErrorRegex)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We aren't setting template ssh keys upon reading, so there's not drift detection for this attribute.
Fixes #100 

### Solution
Set `ssh_keys` attribute on read + convert `[]TemplateSshKey` `[]map[string]string` 

@RLRabinowitz this would probably affect your tests PR #105 
