### PR TITLE
Chore: add User-Agent header

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -23,19 +23,24 @@ type HttpClient struct {
 	client    *resty.Client
 }
 
-func NewHttpClient(apiKey string, apiSecret string, apiEndpoint string, restClient *resty.Client) (*HttpClient, error) {
+type HttpClientConfig struct {
+	ApiKey      string
+	ApiSecret   string
+	ApiEndpoint string
+	UserAgent   string
+	RestClient  *resty.Client
+}
+
+func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 	return &HttpClient{
-		ApiKey:    apiKey,
-		ApiSecret: apiSecret,
-		client:    restClient.SetHostURL(apiEndpoint),
+		ApiKey:    config.ApiKey,
+		ApiSecret: config.ApiSecret,
+		client:    config.RestClient.SetHostURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}, nil
 }
 
 func (self *HttpClient) request() *resty.Request {
-	headers := map[string]string{
-		"User-Agent": "terraform-provider-env0",
-	}
-	return self.client.R().SetBasicAuth(self.ApiKey, self.ApiSecret).SetHeaders(headers)
+	return self.client.R().SetBasicAuth(self.ApiKey, self.ApiSecret)
 }
 
 func (self *HttpClient) httpResult(response *resty.Response, err error) error {

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -32,7 +32,10 @@ func NewHttpClient(apiKey string, apiSecret string, apiEndpoint string, restClie
 }
 
 func (self *HttpClient) request() *resty.Request {
-	return self.client.R().SetBasicAuth(self.ApiKey, self.ApiSecret)
+	headers := map[string]string{
+		"User-Agent": "terraform-provider-env0",
+	}
+	return self.client.R().SetBasicAuth(self.ApiKey, self.ApiSecret).SetHeaders(headers)
 }
 
 func (self *HttpClient) httpResult(response *resty.Response, err error) error {

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -2,15 +2,15 @@ package env0
 
 import (
 	"context"
-
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
-func Provider(version string) func() *schema.Provider {
+func Provider(version string) plugin.ProviderFunc {
 	return func() *schema.Provider {
 		provider := &schema.Provider{
 			Schema: map[string]*schema.Schema{
@@ -59,7 +59,7 @@ func Provider(version string) func() *schema.Provider {
 	}
 }
 
-func configureProvider(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func configureProvider(version string, p *schema.Provider) schema.ConfigureContextFunc {
 	userAgent := p.UserAgent("terraform-provider-env0", version)
 
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -22,7 +22,7 @@ var (
 
 var testUnitProviders = map[string]func() (*schema.Provider, error){
 	"env0": func() (*schema.Provider, error) {
-		provider := Provider()
+		provider := Provider("")()
 		provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			return apiClientMock, nil
 		}
@@ -49,7 +49,7 @@ func runUnitTest(t *testing.T, testCase resource.TestCase, mockFunc func(mockFun
 }
 
 func TestProvider(t *testing.T) {
-	if err := Provider().InternalValidate(); err != nil {
+	if err := Provider("")().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
@@ -74,12 +74,12 @@ func testMissingEnvVar(t *testing.T, envVars map[string]string, expectedKey stri
 		defer os.Setenv(key, "")
 	}
 
-	diags := Provider().Validate(&terraform.ResourceConfig{})
+	diags := Provider("")().Validate(&terraform.ResourceConfig{})
 	testExpectedProviderError(t, diags, expectedKey)
 }
 
 func testMissingConfig(t *testing.T, config map[string]interface{}, expectedKey string) {
-	diags := Provider().Validate(terraform.NewResourceConfigRaw(config))
+	diags := Provider("")().Validate(terraform.NewResourceConfigRaw(config))
 	testExpectedProviderError(t, diags, expectedKey)
 }
 

--- a/main.go
+++ b/main.go
@@ -1,12 +1,35 @@
 package main
 
 import (
+	"context"
+	"flag"
 	"github.com/env0/terraform-provider-env0/env0"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"log"
+)
+
+//go:generate terraform fmt -recursive ./examples/
+
+var (
+	// these will be set by the goreleaser configuration
+	// to appropriate values for the compiled binary
+	version string = "dev"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: env0.Provider,
-	})
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: env0.Provider(version)}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/env0/env0", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
☝️ 
Fixes #22 

### Solution
1. Add `User-Agent` request header to all API calls as `terraform-provider-env0` incl. SDK + provider versions (using terraform's `UserAgent` functionality)
2. Add some debugging ability (inspired by [this scaffolding repository](https://github.com/hashicorp/terraform-provider-scaffolding))
3. Make sure `go generate` also properly formats the terraform `examples` files

P.S - seems like testing request headers via `httpmock` isn't trivial, so 🤷 
