### PR TITLE
UT cloud credentials project assignment

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -38,7 +38,7 @@ type ApiClientInterface interface {
 	AwsCredentialsCreate(request AwsCredentialsCreatePayload) (ApiKey, error)
 	AwsCredentialsDelete(id string) error
 	AssignCloudCredentialsToProject(projectId string, credentialId string) (CloudCredentialsProjectAssignment, error)
-	RemoveCloudCredentialsFromProject(credentialId string, projectId string) error
+	RemoveCloudCredentialsFromProject(projectId string, credentialId string) error
 	CloudCredentialIdsInProject(projectId string) ([]string, error)
 }
 

--- a/client/cloud_credentials_project_assignment.go
+++ b/client/cloud_credentials_project_assignment.go
@@ -10,7 +10,7 @@ func (self *ApiClient) AssignCloudCredentialsToProject(projectId string, credent
 	return result, nil
 }
 
-func (self *ApiClient) RemoveCloudCredentialsFromProject(credentialId string, projectId string) error {
+func (self *ApiClient) RemoveCloudCredentialsFromProject(projectId string, credentialId string) error {
 	return self.http.Delete("/credentials/deployment/" + credentialId + "/project/" + projectId)
 }
 

--- a/client/cloud_credentials_project_assignment_test.go
+++ b/client/cloud_credentials_project_assignment_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Credentials Project Assignment", func() {
 				Delete("/credentials/deployment/" + credentialId + "/project/" + projectId).
 				Return(errors.New(errorInfo)).
 				Times(1)
-			actualError = apiClient.RemoveCloudCredentialsFromProject(credentialId, projectId)
+			actualError = apiClient.RemoveCloudCredentialsFromProject(projectId, credentialId)
 
 		})
 

--- a/env0/resource_cloud_credentials_project_assignment.go
+++ b/env0/resource_cloud_credentials_project_assignment.go
@@ -77,7 +77,7 @@ func resourceCloudCredentialsProjectAssignmentDelete(ctx context.Context, d *sch
 
 	credentialId := d.Get("credential_id").(string)
 	projectId := d.Get("project_id").(string)
-	err := apiClient.RemoveCloudCredentialsFromProject(credentialId, projectId)
+	err := apiClient.RemoveCloudCredentialsFromProject(projectId, credentialId)
 	if err != nil {
 		return diag.Errorf("could not delete cloud credentials from project: %v", err)
 	}

--- a/env0/resource_cloud_credentials_project_assignment.go
+++ b/env0/resource_cloud_credentials_project_assignment.go
@@ -32,7 +32,7 @@ func resourceCloudCredentialsProjectAssignment() *schema.Resource {
 }
 
 func resourceCloudCredentialsProjectAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId := d.Get("credential_id").(string)
 	projectId := d.Get("project_id").(string)
@@ -45,7 +45,7 @@ func resourceCloudCredentialsProjectAssignmentCreate(ctx context.Context, d *sch
 }
 
 func resourceCloudCredentialsProjectAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId := d.Get("credential_id").(string)
 	projectId := d.Get("project_id").(string)
@@ -73,7 +73,7 @@ func getResourceId(credentialId string, projectId string) string {
 }
 
 func resourceCloudCredentialsProjectAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	apiClient := meta.(*client.ApiClient)
+	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId := d.Get("credential_id").(string)
 	projectId := d.Get("project_id").(string)

--- a/env0/resource_cloud_credentials_project_assignment.go
+++ b/env0/resource_cloud_credentials_project_assignment.go
@@ -75,9 +75,9 @@ func getResourceId(credentialId string, projectId string) string {
 func resourceCloudCredentialsProjectAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(*client.ApiClient)
 
-	credential_id := d.Get("credential_id").(string)
+	credentialId := d.Get("credential_id").(string)
 	projectId := d.Get("project_id").(string)
-	err := apiClient.RemoveCloudCredentialsFromProject(credential_id, projectId)
+	err := apiClient.RemoveCloudCredentialsFromProject(credentialId, projectId)
 	if err != nil {
 		return diag.Errorf("could not delete cloud credentials from project: %v", err)
 	}

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -1,8 +1,10 @@
 package env0
 
 import (
+	"errors"
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"regexp"
 	"testing"
 )
 
@@ -35,5 +37,29 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource_Create(t *testing
 		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
 		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId}, nil)
 		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+	})
+}
+func TestUnitResourceCloudCredentialsProjectAssignmentResource_CreateApiProb(t *testing.T) {
+	resourceType := "env0_cloud_credentials_project_assignment"
+	resourceName := "test"
+	assignment := client.CloudCredentialsProjectAssignment{
+		CredentialId: "cred-it",
+		ProjectId:    "proj-it",
+	}
+
+	createTestCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+					"credential_id": assignment.CredentialId,
+					"project_id":    assignment.ProjectId,
+				}),
+				ExpectError: regexp.MustCompile(`(could not assign cloud credentials to project)`),
+			},
+		},
+	}
+
+	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(client.CloudCredentialsProjectAssignment{}, errors.New("err"))
 	})
 }

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -89,3 +89,60 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadApiProb(t *te
 		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
 	})
 }
+func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadMultiValues(t *testing.T) {
+	resourceType := "env0_cloud_credentials_project_assignment"
+	resourceName := "test"
+	accessor := resourceAccessor(resourceType, resourceName)
+	assignment := client.CloudCredentialsProjectAssignment{
+		CredentialId: "cred-it",
+		ProjectId:    "proj-it",
+	}
+
+	createTestCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+					"credential_id": assignment.CredentialId,
+					"project_id":    assignment.ProjectId,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
+					resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
+					resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
+				),
+			},
+		},
+	}
+
+	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId, "1", "2"}, nil)
+		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+	})
+}
+func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadDidntReturnCorrect(t *testing.T) {
+	resourceType := "env0_cloud_credentials_project_assignment"
+	resourceName := "test"
+	assignment := client.CloudCredentialsProjectAssignment{
+		CredentialId: "cred-it",
+		ProjectId:    "proj-it",
+	}
+
+	createTestCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+					"credential_id": assignment.CredentialId,
+					"project_id":    assignment.ProjectId,
+				}),
+				ExpectError: regexp.MustCompile(`(could not find cloud credential project assignment)`),
+			},
+		},
+	}
+
+	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{"1", "2"}, nil)
+		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+	})
+}

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -63,3 +63,29 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource_CreateApiProb(t *
 		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(client.CloudCredentialsProjectAssignment{}, errors.New("err"))
 	})
 }
+func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadApiProb(t *testing.T) {
+	resourceType := "env0_cloud_credentials_project_assignment"
+	resourceName := "test"
+	assignment := client.CloudCredentialsProjectAssignment{
+		CredentialId: "cred-it",
+		ProjectId:    "proj-it",
+	}
+
+	createTestCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+					"credential_id": assignment.CredentialId,
+					"project_id":    assignment.ProjectId,
+				}),
+				ExpectError: regexp.MustCompile(`(could not get cloud_credentials:)`),
+			},
+		},
+	}
+
+	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{}, errors.New("err"))
+		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+	})
+}

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -1,0 +1,39 @@
+package env0
+
+import (
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestUnitResourceCloudCredentialsProjectAssignmentResource_Create(t *testing.T) {
+	resourceType := "env0_cloud_credentials_project_assignment"
+	resourceName := "test"
+	accessor := resourceAccessor(resourceType, resourceName)
+	assignment := client.CloudCredentialsProjectAssignment{
+		CredentialId: "cred-it",
+		ProjectId:    "proj-it",
+	}
+
+	createTestCase := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+					"credential_id": assignment.CredentialId,
+					"project_id":    assignment.ProjectId,
+				}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
+					resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
+					resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
+				),
+			},
+		},
+	}
+
+	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId}, nil)
+		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+	})
+}

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -16,15 +16,15 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		CredentialId: "cred-it",
 		ProjectId:    "proj-it",
 	}
-
+	stepConfig := resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+		"credential_id": assignment.CredentialId,
+		"project_id":    assignment.ProjectId,
+	})
 	t.Run("Create", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"credential_id": assignment.CredentialId,
-						"project_id":    assignment.ProjectId,
-					}),
+					Config: stepConfig,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
 						resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
@@ -44,10 +44,7 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"credential_id": assignment.CredentialId,
-						"project_id":    assignment.ProjectId,
-					}),
+					Config:      stepConfig,
 					ExpectError: regexp.MustCompile(`(could not assign cloud credentials to project)`),
 				},
 			},
@@ -61,10 +58,7 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"credential_id": assignment.CredentialId,
-						"project_id":    assignment.ProjectId,
-					}),
+					Config:      stepConfig,
 					ExpectError: regexp.MustCompile(`(could not get cloud_credentials:)`),
 				},
 			},
@@ -80,10 +74,7 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"credential_id": assignment.CredentialId,
-						"project_id":    assignment.ProjectId,
-					}),
+					Config: stepConfig,
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
 						resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
@@ -103,10 +94,7 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"credential_id": assignment.CredentialId,
-						"project_id":    assignment.ProjectId,
-					}),
+					Config:      stepConfig,
 					ExpectError: regexp.MustCompile(`(could not find cloud credential project assignment)`),
 				},
 			},

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestUnitResourceCloudCredentialsProjectAssignmentResource_Create(t *testing.T) {
+func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 	resourceType := "env0_cloud_credentials_project_assignment"
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)
@@ -17,132 +17,105 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource_Create(t *testing
 		ProjectId:    "proj-it",
 	}
 
-	createTestCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"credential_id": assignment.CredentialId,
-					"project_id":    assignment.ProjectId,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
-					resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
-					resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
-				),
+	t.Run("Create", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"credential_id": assignment.CredentialId,
+						"project_id":    assignment.ProjectId,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
+						resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
+						resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
+					),
+				},
 			},
-		},
-	}
+		}
 
-	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
-		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId}, nil)
-		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+			mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId}, nil)
+			mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		})
 	})
-}
-func TestUnitResourceCloudCredentialsProjectAssignmentResource_CreateApiProb(t *testing.T) {
-	resourceType := "env0_cloud_credentials_project_assignment"
-	resourceName := "test"
-	assignment := client.CloudCredentialsProjectAssignment{
-		CredentialId: "cred-it",
-		ProjectId:    "proj-it",
-	}
-
-	createTestCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"credential_id": assignment.CredentialId,
-					"project_id":    assignment.ProjectId,
-				}),
-				ExpectError: regexp.MustCompile(`(could not assign cloud credentials to project)`),
+	t.Run("Create with api prob", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"credential_id": assignment.CredentialId,
+						"project_id":    assignment.ProjectId,
+					}),
+					ExpectError: regexp.MustCompile(`(could not assign cloud credentials to project)`),
+				},
 			},
-		},
-	}
+		}
 
-	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(client.CloudCredentialsProjectAssignment{}, errors.New("err"))
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(client.CloudCredentialsProjectAssignment{}, errors.New("err"))
+		})
 	})
-}
-func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadApiProb(t *testing.T) {
-	resourceType := "env0_cloud_credentials_project_assignment"
-	resourceName := "test"
-	assignment := client.CloudCredentialsProjectAssignment{
-		CredentialId: "cred-it",
-		ProjectId:    "proj-it",
-	}
-
-	createTestCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"credential_id": assignment.CredentialId,
-					"project_id":    assignment.ProjectId,
-				}),
-				ExpectError: regexp.MustCompile(`(could not get cloud_credentials:)`),
+	t.Run("Read with api prob", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"credential_id": assignment.CredentialId,
+						"project_id":    assignment.ProjectId,
+					}),
+					ExpectError: regexp.MustCompile(`(could not get cloud_credentials:)`),
+				},
 			},
-		},
-	}
+		}
 
-	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
-		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{}, errors.New("err"))
-		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+			mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{}, errors.New("err"))
+			mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		})
 	})
-}
-func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadMultiValues(t *testing.T) {
-	resourceType := "env0_cloud_credentials_project_assignment"
-	resourceName := "test"
-	accessor := resourceAccessor(resourceType, resourceName)
-	assignment := client.CloudCredentialsProjectAssignment{
-		CredentialId: "cred-it",
-		ProjectId:    "proj-it",
-	}
-
-	createTestCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"credential_id": assignment.CredentialId,
-					"project_id":    assignment.ProjectId,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
-					resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
-					resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
-				),
+	t.Run("Read with multi values", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"credential_id": assignment.CredentialId,
+						"project_id":    assignment.ProjectId,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", assignment.CredentialId+"|"+assignment.ProjectId),
+						resource.TestCheckResourceAttr(accessor, "credential_id", assignment.CredentialId),
+						resource.TestCheckResourceAttr(accessor, "project_id", assignment.ProjectId),
+					),
+				},
 			},
-		},
-	}
+		}
 
-	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
-		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId, "1", "2"}, nil)
-		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+			mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{assignment.CredentialId, "1", "2"}, nil)
+			mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		})
 	})
-}
-func TestUnitResourceCloudCredentialsProjectAssignmentResource_ReadDidntReturnCorrect(t *testing.T) {
-	resourceType := "env0_cloud_credentials_project_assignment"
-	resourceName := "test"
-	assignment := client.CloudCredentialsProjectAssignment{
-		CredentialId: "cred-it",
-		ProjectId:    "proj-it",
-	}
-
-	createTestCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"credential_id": assignment.CredentialId,
-					"project_id":    assignment.ProjectId,
-				}),
-				ExpectError: regexp.MustCompile(`(could not find cloud credential project assignment)`),
+	t.Run("Read didnt api didnt return correct stuff", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"credential_id": assignment.CredentialId,
+						"project_id":    assignment.ProjectId,
+					}),
+					ExpectError: regexp.MustCompile(`(could not find cloud credential project assignment)`),
+				},
 			},
-		},
-	}
+		}
 
-	runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
-		mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{"1", "2"}, nil)
-		mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().AssignCloudCredentialsToProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(assignment, nil)
+			mock.EXPECT().CloudCredentialIdsInProject(assignment.ProjectId).Times(1).Return([]string{"1", "2"}, nil)
+			mock.EXPECT().RemoveCloudCredentialsFromProject(assignment.ProjectId, assignment.CredentialId).Times(1).Return(nil)
+		})
 	})
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
UT for `resource_cloud_credentials_project_assignment.go`
### Solution
- Added UTs
- Fixed `*client.ApiClient`
- Set all client signs to have the same order of proj id and cred it
