### PR TITLE
Chore gitlab templates

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -158,6 +158,8 @@ type Template struct {
 	SshKeys              []TemplateSshKey `json:"sshKeys"`
 	Type                 string           `json:"type"`
 	GithubInstallationId int              `json:"githubInstallationId"`
+	GitlabTokenId        int              `json:"gitlabTokenId,omitempty"`
+	GitlabProjectId      int              `json:"gitlabProjectId,omitempty"`
 	UpdatedAt            string           `json:"updatedAt"`
 	TerraformVersion     string           `json:"terraformVersion"`
 }

--- a/client/model.go
+++ b/client/model.go
@@ -108,6 +108,8 @@ type TemplateCreatePayload struct {
 	TokenName            string           `json:"tokenName"`
 	TokenId              string           `json:"tokenId"`
 	GithubInstallationId int              `json:"githubInstallationId,omitempty"`
+	GitlabTokenId        int              `json:"gitlabTokenId,omitempty"`
+	GitlabProjectId      int              `json:"gitlabProjectId,omitempty"`
 	Revision             string           `json:"revision"`
 	OrganizationId       string           `json:"organizationId"`
 	TerraformVersion     string           `json:"terraformVersion"`

--- a/client/model.go
+++ b/client/model.go
@@ -108,7 +108,6 @@ type TemplateCreatePayload struct {
 	TokenName            string           `json:"tokenName"`
 	TokenId              string           `json:"tokenId"`
 	GithubInstallationId int              `json:"githubInstallationId,omitempty"`
-	GitlabTokenId        int              `json:"gitlabTokenId,omitempty"`
 	GitlabProjectId      int              `json:"gitlabProjectId,omitempty"`
 	Revision             string           `json:"revision"`
 	OrganizationId       string           `json:"organizationId"`
@@ -158,7 +157,7 @@ type Template struct {
 	SshKeys              []TemplateSshKey `json:"sshKeys"`
 	Type                 string           `json:"type"`
 	GithubInstallationId int              `json:"githubInstallationId"`
-	GitlabTokenId        int              `json:"gitlabTokenId,omitempty"`
+	TokenId              string           `json:"tokenId,omitempty"`
 	GitlabProjectId      int              `json:"gitlabProjectId,omitempty"`
 	UpdatedAt            string           `json:"updatedAt"`
 	TerraformVersion     string           `json:"terraformVersion"`

--- a/client/model.go
+++ b/client/model.go
@@ -113,6 +113,7 @@ type TemplateCreatePayload struct {
 	Revision             string           `json:"revision"`
 	OrganizationId       string           `json:"organizationId"`
 	TerraformVersion     string           `json:"terraformVersion"`
+	IsGitlab             bool             `json:"IsGitlab"`
 }
 
 type TemplateAssignmentToProjectPayload struct {

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -141,8 +141,8 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 		d.Set("github_installation_id", template.GithubInstallationId)
 	}
 
-	if template.GitlabTokenId != 0 {
-		d.Set("gitlab_token_id", template.GitlabTokenId)
+	if template.TokenId != "" {
+		d.Set("token_id", template.TokenId)
 		d.Set("gitlab_project_id", template.GitlabProjectId)
 	}
 

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -79,8 +79,8 @@ func dataTemplate() *schema.Resource {
 				Description: "The env0 application installation id on the relevant github repository",
 				Optional:    true,
 			},
-			"gitlab_token_id": {
-				Type:        schema.TypeInt,
+			"token_id": {
+				Type:        schema.TypeString,
 				Description: "The env0 application token id on the relevant gitlab account",
 				Optional:    true,
 			},

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -79,6 +79,16 @@ func dataTemplate() *schema.Resource {
 				Description: "The env0 application installation id on the relevant github repository",
 				Optional:    true,
 			},
+			"gitlab_token_id": {
+				Type:        schema.TypeInt,
+				Description: "The env0 application token id on the relevant gitlab account",
+				Optional:    true,
+			},
+			"gitlab_project_id": {
+				Type:        schema.TypeInt,
+				Description: "The project id of the relevant repository",
+				Optional:    true,
+			},
 			"terraform_version": {
 				Type:        schema.TypeString,
 				Description: "terraform version to use",
@@ -129,6 +139,11 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	if template.GithubInstallationId != 0 {
 		d.Set("github_installation_id", template.GithubInstallationId)
+	}
+
+	if template.GitlabTokenId != 0 {
+		d.Set("gitlab_token_id", template.GitlabTokenId)
+		d.Set("gitlab_project_id", template.GitlabProjectId)
 	}
 
 	return nil

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -238,6 +238,8 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("name", template.Name)
 	d.Set("description", template.Description)
 	d.Set("github_installation_id", template.GithubInstallationId)
+	d.Set("gitlab_token_id", template.GitlabTokenId)
+	d.Set("gitlab_project_id", template.GitlabProjectId)
 	d.Set("repository", template.Repository)
 	d.Set("path", template.Path)
 	d.Set("revision", template.Revision)

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -138,7 +138,7 @@ func templateCreatePayloadFromParameters(d *schema.ResourceData) (client.Templat
 	}
 
 	if result.GithubInstallationId != 0 && result.GitlabTokenId != 0 {
-		return client.TemplateCreatePayload{}, diag.Errorf("Cannot set gitlab_token_id and github_installation_id")
+		return client.TemplateCreatePayload{}, diag.Errorf("Cannot set gitlab_token_id and github_installation_id for the same template")
 	} else {
 		result.IsGitlab = result.GitlabTokenId != 0
 	}

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -130,17 +130,17 @@ func templateCreatePayloadFromParameters(d *schema.ResourceData) (client.Templat
 	if githubInstallationId, ok := d.GetOk("github_installation_id"); ok {
 		result.GithubInstallationId = githubInstallationId.(int)
 	}
-	if gitlabTokenId, ok := d.GetOk("gitlab_token_id"); ok {
-		result.GitlabTokenId = gitlabTokenId.(int)
+	if tokenId, ok := d.GetOk("token_id"); ok {
+		result.TokenId = tokenId.(string)
 	}
 	if gitlabProjectId, ok := d.GetOk("gitlab_project_id"); ok {
 		result.GitlabProjectId = gitlabProjectId.(int)
 	}
 
-	if result.GithubInstallationId != 0 && result.GitlabTokenId != 0 {
-		return client.TemplateCreatePayload{}, diag.Errorf("Cannot set gitlab_token_id and github_installation_id for the same template")
+	if result.GithubInstallationId != 0 && result.TokenId != "" {
+		return client.TemplateCreatePayload{}, diag.Errorf("Cannot set token_id and github_installation_id for the same template")
 	} else {
-		result.IsGitlab = result.GitlabTokenId != 0
+		result.IsGitlab = result.TokenId != ""
 	}
 
 	if path, ok := d.GetOk("path"); ok {
@@ -238,7 +238,7 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("name", template.Name)
 	d.Set("description", template.Description)
 	d.Set("github_installation_id", template.GithubInstallationId)
-	d.Set("gitlab_token_id", template.GitlabTokenId)
+	d.Set("token_id", template.TokenId)
 	d.Set("gitlab_project_id", template.GitlabProjectId)
 	d.Set("repository", template.Repository)
 	d.Set("path", template.Path)

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -99,8 +99,8 @@ func resourceTemplate() *schema.Resource {
 				Description: "The env0 application installation id on the relevant github repository",
 				Optional:    true,
 			},
-			"gitlab_token_id": {
-				Type:        schema.TypeInt,
+			"token_id": {
+				Type:        schema.TypeString,
 				Description: "The env0 application token id on the relevant gitlab account",
 				Optional:    true,
 			},

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -99,6 +99,16 @@ func resourceTemplate() *schema.Resource {
 				Description: "The env0 application installation id on the relevant github repository",
 				Optional:    true,
 			},
+			"gitlab_token_id": {
+				Type:        schema.TypeInt,
+				Description: "The env0 application token id on the relevant gitlab account",
+				Optional:    true,
+			},
+			"gitlab_project_id": {
+				Type:        schema.TypeInt,
+				Description: "The project id of the relevant repository",
+				Optional:    true,
+			},
 			"terraform_version": {
 				Type:        schema.TypeString,
 				Description: "Terraform version to use",
@@ -116,6 +126,15 @@ func templateCreatePayloadFromParameters(d *schema.ResourceData) (client.Templat
 	}
 	if description, ok := d.GetOk("description"); ok {
 		result.Description = description.(string)
+	}
+	if githubInstallationId, ok := d.GetOk("github_installation_id"); ok {
+		result.GithubInstallationId = githubInstallationId.(int)
+	}
+	if gitlabTokenId, ok := d.GetOk("gitlab_token_id"); ok {
+		result.GitlabTokenId = gitlabTokenId.(int)
+	}
+	if gitlabProjectId, ok := d.GetOk("gitlab_project_id"); ok {
+		result.GitlabProjectId = gitlabProjectId.(int)
 	}
 	if githubInstallationId, ok := d.GetOk("github_installation_id"); ok {
 		result.GithubInstallationId = githubInstallationId.(int)

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -136,9 +136,13 @@ func templateCreatePayloadFromParameters(d *schema.ResourceData) (client.Templat
 	if gitlabProjectId, ok := d.GetOk("gitlab_project_id"); ok {
 		result.GitlabProjectId = gitlabProjectId.(int)
 	}
-	if githubInstallationId, ok := d.GetOk("github_installation_id"); ok {
-		result.GithubInstallationId = githubInstallationId.(int)
+
+	if result.GithubInstallationId != 0 && result.GitlabTokenId != 0 {
+		return client.TemplateCreatePayload{}, diag.Errorf("Cannot set gitlab_token_id and github_installation_id")
+	} else {
+		result.IsGitlab = result.GitlabTokenId != 0
 	}
+
 	if path, ok := d.GetOk("path"); ok {
 		result.Path = path.(string)
 	}

--- a/env0/resource_template_test.go
+++ b/env0/resource_template_test.go
@@ -162,7 +162,7 @@ func TestUnitTemplateResource(t *testing.T) {
 				},
 			},
 			Type:             "terraform",
-			GitlabTokenId:    1,
+			TokenId:          "1",
 			GitlabProjectId:  1,
 			TerraformVersion: "0.12.24",
 		}
@@ -185,7 +185,7 @@ func TestUnitTemplateResource(t *testing.T) {
 				},
 			},
 			Type:             "terragrunt",
-			GitlabTokenId:    2,
+			TokenId:          "2",
 			GitlabProjectId:  2,
 			TerraformVersion: "0.15.1",
 		}
@@ -202,7 +202,7 @@ func TestUnitTemplateResource(t *testing.T) {
 				resource.TestCheckResourceAttr(resourceFullName, "retry_on_deploy_only_when_matches_regex", template.Retry.OnDeploy.ErrorRegex),
 				resource.TestCheckResourceAttr(resourceFullName, "retries_on_destroy", strconv.Itoa(template.Retry.OnDestroy.Times)),
 				resource.TestCheckResourceAttr(resourceFullName, "retry_on_destroy_only_when_matches_regex", template.Retry.OnDestroy.ErrorRegex),
-				resource.TestCheckResourceAttr(resourceFullName, "gitlab_token_id", strconv.Itoa(template.GitlabTokenId)),
+				resource.TestCheckResourceAttr(resourceFullName, "token_id", template.TokenId),
 				resource.TestCheckResourceAttr(resourceFullName, "gitlab_project_id", strconv.Itoa(template.GitlabProjectId)),
 				resource.TestCheckResourceAttr(resourceFullName, "terraform_version", template.TerraformVersion),
 			)
@@ -220,9 +220,9 @@ func TestUnitTemplateResource(t *testing.T) {
 				"retry_on_deploy_only_when_matches_regex":  template.Retry.OnDeploy.ErrorRegex,
 				"retries_on_destroy":                       template.Retry.OnDestroy.Times,
 				"retry_on_destroy_only_when_matches_regex": template.Retry.OnDestroy.ErrorRegex,
-				"gitlab_token_id":                          template.GitlabTokenId,
-				"gitlab_project_id":                        template.GitlabProjectId,
-				"terraform_version":                        template.TerraformVersion,
+				"token_id":          template.TokenId,
+				"gitlab_project_id": template.GitlabProjectId,
+				"terraform_version": template.TerraformVersion,
 			})
 		}
 
@@ -248,7 +248,7 @@ func TestUnitTemplateResource(t *testing.T) {
 				Name:             template.Name,
 				Repository:       template.Repository,
 				Description:      template.Description,
-				GitlabTokenId:    template.GitlabTokenId,
+				TokenId:          template.TokenId,
 				GitlabProjectId:  template.GitlabProjectId,
 				IsGitlab:         true,
 				Path:             template.Path,
@@ -261,7 +261,7 @@ func TestUnitTemplateResource(t *testing.T) {
 				Name:             updatedTemplate.Name,
 				Repository:       updatedTemplate.Repository,
 				Description:      updatedTemplate.Description,
-				GitlabTokenId:    updatedTemplate.GitlabTokenId,
+				TokenId:          updatedTemplate.TokenId,
 				GitlabProjectId:  updatedTemplate.GitlabProjectId,
 				IsGitlab:         true,
 				Path:             updatedTemplate.Path,
@@ -497,8 +497,8 @@ func TestUnitTemplateResource(t *testing.T) {
 		testCases = append(testCases, resource.TestCase{
 			Steps: []resource.TestStep{
 				{
-					Config:      resourceConfigCreate(resourceType, resourceName, map[string]interface{}{"name": "test", "repository": "env0/test", "github_installation_id": 1, "gitlab_token_id": 2}),
-					ExpectError: regexp.MustCompile("Cannot set gitlab_token_id and github_installation_id for the same template"),
+					Config:      resourceConfigCreate(resourceType, resourceName, map[string]interface{}{"name": "test", "repository": "env0/test", "github_installation_id": 1, "token_id": "2"}),
+					ExpectError: regexp.MustCompile("Cannot set token_id and github_installation_id for the same template"),
 				},
 			},
 		})


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
Allow the user to create gitlab templates
### Solution
Add terraform attributes `gitlab_token_id` and `gitlab_project_id`
calculate `isGitlab` using those attributes

Resolves #128