### PR TITLE
Add description to configuration variable

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -13,8 +13,8 @@ type ApiClient struct {
 
 type ApiClientInterface interface {
 	ConfigurationVariables(scope Scope, scopeId string) ([]ConfigurationVariable, error)
-	ConfigurationVariableCreate(name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string) (ConfigurationVariable, error)
-	ConfigurationVariableUpdate(id string, name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string) (ConfigurationVariable, error)
+	ConfigurationVariableCreate(name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string, description string) (ConfigurationVariable, error)
+	ConfigurationVariableUpdate(id string, name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string, description string) (ConfigurationVariable, error)
 	ConfigurationVariableDelete(id string) error
 	Organization() (Organization, error)
 	organizationId() (string, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -138,18 +138,18 @@ func (mr *MockApiClientInterfaceMockRecorder) CloudCredentialIdsInProject(arg0 i
 }
 
 // ConfigurationVariableCreate mocks base method.
-func (m *MockApiClientInterface) ConfigurationVariableCreate(arg0, arg1 string, arg2 bool, arg3 Scope, arg4 string, arg5 ConfigurationVariableType, arg6 []string) (ConfigurationVariable, error) {
+func (m *MockApiClientInterface) ConfigurationVariableCreate(arg0, arg1 string, arg2 bool, arg3 Scope, arg4 string, arg5 ConfigurationVariableType, arg6 []string, arg7 string) (ConfigurationVariable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigurationVariableCreate", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "ConfigurationVariableCreate", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(ConfigurationVariable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigurationVariableCreate indicates an expected call of ConfigurationVariableCreate.
-func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariableCreate(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariableCreate(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariableCreate", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariableCreate), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariableCreate", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariableCreate), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // ConfigurationVariableDelete mocks base method.
@@ -167,18 +167,18 @@ func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariableDelete(arg0 i
 }
 
 // ConfigurationVariableUpdate mocks base method.
-func (m *MockApiClientInterface) ConfigurationVariableUpdate(arg0, arg1, arg2 string, arg3 bool, arg4 Scope, arg5 string, arg6 ConfigurationVariableType, arg7 []string) (ConfigurationVariable, error) {
+func (m *MockApiClientInterface) ConfigurationVariableUpdate(arg0, arg1, arg2 string, arg3 bool, arg4 Scope, arg5 string, arg6 ConfigurationVariableType, arg7 []string, arg8 string) (ConfigurationVariable, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigurationVariableUpdate", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "ConfigurationVariableUpdate", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(ConfigurationVariable)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigurationVariableUpdate indicates an expected call of ConfigurationVariableUpdate.
-func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariableUpdate(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariableUpdate(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariableUpdate", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariableUpdate), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariableUpdate", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariableUpdate), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // ConfigurationVariables mocks base method.

--- a/client/configuration_variable.go
+++ b/client/configuration_variable.go
@@ -31,7 +31,7 @@ func (self *ApiClient) ConfigurationVariables(scope Scope, scopeId string) ([]Co
 	return result, nil
 }
 
-func (self *ApiClient) ConfigurationVariableCreate(name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string) (ConfigurationVariable, error) {
+func (self *ApiClient) ConfigurationVariableCreate(name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string, description string) (ConfigurationVariable, error) {
 	if scope == ScopeDeploymentLog || scope == ScopeDeployment {
 		return ConfigurationVariable{}, errors.New("Must not create variable on scope deployment / deploymentLog")
 	}
@@ -42,6 +42,7 @@ func (self *ApiClient) ConfigurationVariableCreate(name string, value string, is
 	var result []ConfigurationVariable
 	request := map[string]interface{}{
 		"name":           name,
+		"description":    description,
 		"value":          value,
 		"isSensitive":    isSensitive,
 		"scope":          scope,
@@ -69,7 +70,7 @@ func (self *ApiClient) ConfigurationVariableDelete(id string) error {
 	return self.http.Delete("configuration/" + id)
 }
 
-func (self *ApiClient) ConfigurationVariableUpdate(id string, name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string) (ConfigurationVariable, error) {
+func (self *ApiClient) ConfigurationVariableUpdate(id string, name string, value string, isSensitive bool, scope Scope, scopeId string, type_ ConfigurationVariableType, enumValues []string, description string) (ConfigurationVariable, error) {
 	if scope == ScopeDeploymentLog || scope == ScopeDeployment {
 		return ConfigurationVariable{}, errors.New("Must not create variable on scope deployment / deploymentLog")
 	}
@@ -81,6 +82,7 @@ func (self *ApiClient) ConfigurationVariableUpdate(id string, name string, value
 	request := map[string]interface{}{
 		"id":             id,
 		"name":           name,
+		"description":    description,
 		"value":          value,
 		"isSensitive":    isSensitive,
 		"scope":          scope,

--- a/client/configuration_variable_test.go
+++ b/client/configuration_variable_test.go
@@ -12,6 +12,7 @@ var _ = Describe("Configuration Variable", func() {
 	mockConfigurationVariable := ConfigurationVariable{
 		Id:             "config-var-id-789",
 		Name:           "configName",
+		Description:    "configDescription",
 		Value:          "configValue",
 		OrganizationId: organizationId,
 		IsSensitive:    true,
@@ -29,6 +30,7 @@ var _ = Describe("Configuration Variable", func() {
 
 			expectedCreateRequest := []map[string]interface{}{{
 				"name":           mockConfigurationVariable.Name,
+				"description":    mockConfigurationVariable.Description,
 				"isSensitive":    mockConfigurationVariable.IsSensitive,
 				"value":          mockConfigurationVariable.Value,
 				"organizationId": organizationId,
@@ -51,6 +53,7 @@ var _ = Describe("Configuration Variable", func() {
 				mockConfigurationVariable.ScopeId,
 				mockConfigurationVariable.Type,
 				nil,
+				mockConfigurationVariable.Description,
 			)
 		})
 
@@ -85,10 +88,12 @@ var _ = Describe("Configuration Variable", func() {
 			mockOrganizationIdCall(organizationId)
 
 			newName := "new-" + mockConfigurationVariable.Name
+			newDescription := "new-" + mockConfigurationVariable.Description
 			newValue := "new-" + mockConfigurationVariable.Value
 
 			expectedUpdateRequest := []map[string]interface{}{{
 				"name":           newName,
+				"description":    newDescription,
 				"value":          newValue,
 				"id":             mockConfigurationVariable.Id,
 				"isSensitive":    mockConfigurationVariable.IsSensitive,
@@ -113,6 +118,7 @@ var _ = Describe("Configuration Variable", func() {
 				mockConfigurationVariable.ScopeId,
 				mockConfigurationVariable.Type,
 				nil,
+				mockConfigurationVariable.Description,
 			)
 		})
 

--- a/client/configuration_variable_test.go
+++ b/client/configuration_variable_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Configuration Variable", func() {
 				mockConfigurationVariable.ScopeId,
 				mockConfigurationVariable.Type,
 				nil,
-				mockConfigurationVariable.Description,
+				newDescription,
 			)
 		})
 

--- a/client/model.go
+++ b/client/model.go
@@ -52,6 +52,7 @@ type ConfigurationVariable struct {
 	Scope          Scope                       `json:"scope"`
 	Id             string                      `json:"id"`
 	Name           string                      `json:"name"`
+	Description    string                      `json:"description"`
 	Type           ConfigurationVariableType   `json:"type"`
 	Schema         ConfigurationVariableSchema `json:"schema"`
 }

--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -27,6 +27,11 @@ func dataConfigurationVariable() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "id"},
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "a description of the variable",
+				Optional:    true,
+			},
 			"type": {
 				Type:        schema.TypeString,
 				Description: "'terraform' or 'environment'. If specified as an argument, limits searching by variable name only to variables of this type.",
@@ -116,6 +121,7 @@ func dataConfigurationVariableRead(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(variable.Id)
 	d.Set("name", variable.Name)
+	d.Set("description", variable.Description)
 	d.Set("value", variable.Value)
 	d.Set("is_sensitive", variable.IsSensitive)
 	d.Set("scope", variable.Scope)

--- a/env0/data_configuration_variable_test.go
+++ b/env0/data_configuration_variable_test.go
@@ -17,6 +17,7 @@ func TestUnitConfigurationVariableData(t *testing.T) {
 	configurationVariable := client.ConfigurationVariable{
 		Id:             "id0",
 		Name:           "name0",
+		Description:    "desc0",
 		ScopeId:        "scope0",
 		Value:          "value0",
 		OrganizationId: "organization0",
@@ -30,6 +31,7 @@ func TestUnitConfigurationVariableData(t *testing.T) {
 	checkResources := resource.ComposeAggregateTestCheckFunc(
 		resource.TestCheckResourceAttr(accessor, "id", configurationVariable.Id),
 		resource.TestCheckResourceAttr(accessor, "name", configurationVariable.Name),
+		resource.TestCheckResourceAttr(accessor, "description", configurationVariable.Description),
 		resource.TestCheckResourceAttr(accessor, "type", "environment"),
 		resource.TestCheckResourceAttr(accessor, "value", configurationVariable.Value),
 		resource.TestCheckResourceAttr(accessor, "scope", string(configurationVariable.Scope)),

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -27,6 +27,11 @@ func resourceConfigurationVariable() *schema.Resource {
 				Description: "name to give the configuration variable",
 				Required:    true,
 			},
+			"description": {
+				Type:        schema.TypeBool,
+				Description: "a description of the variables",
+				Optional:    true,
+			},
 			"value": {
 				Type:        schema.TypeString,
 				Description: "value for the configuration variable",
@@ -104,6 +109,7 @@ func resourceConfigurationVariableCreate(ctx context.Context, d *schema.Resource
 
 	scope, scopeId := whichScope(d)
 	name := d.Get("name").(string)
+	description := d.Get("description").(string)
 	value := d.Get("value").(string)
 	isSensitive := d.Get("is_sensitive").(bool)
 	typeAsString := d.Get("type").(string)
@@ -121,7 +127,7 @@ func resourceConfigurationVariableCreate(ctx context.Context, d *schema.Resource
 		return getEnumErr
 	}
 
-	configurationVariable, err := apiClient.ConfigurationVariableCreate(name, value, isSensitive, scope, scopeId, type_, actualEnumValues)
+	configurationVariable, err := apiClient.ConfigurationVariableCreate(name, value, isSensitive, scope, scopeId, type_, actualEnumValues, description)
 	if err != nil {
 		return diag.Errorf("could not create configurationVariable: %v", err)
 	}
@@ -162,6 +168,7 @@ func resourceConfigurationVariableRead(ctx context.Context, d *schema.ResourceDa
 	for _, variable := range variables {
 		if variable.Id == id {
 			d.Set("name", variable.Name)
+			d.Set("description", variable.Description)
 			d.Set("value", variable.Value)
 			d.Set("is_sensitive", variable.IsSensitive)
 			if variable.Type == client.ConfigurationVariableTypeTerraform {
@@ -184,6 +191,7 @@ func resourceConfigurationVariableUpdate(ctx context.Context, d *schema.Resource
 	id := d.Id()
 	scope, scopeId := whichScope(d)
 	name := d.Get("name").(string)
+	description := d.Get("description").(string)
 	value := d.Get("value").(string)
 	isSensitive := d.Get("is_sensitive").(bool)
 	typeAsString := d.Get("type").(string)
@@ -200,7 +208,7 @@ func resourceConfigurationVariableUpdate(ctx context.Context, d *schema.Resource
 	if getEnumErr != nil {
 		return getEnumErr
 	}
-	_, err := apiClient.ConfigurationVariableUpdate(id, name, value, isSensitive, scope, scopeId, type_, actualEnumValues)
+	_, err := apiClient.ConfigurationVariableUpdate(id, name, value, isSensitive, scope, scopeId, type_, actualEnumValues, description)
 	if err != nil {
 		return diag.Errorf("could not update configurationVariable: %v", err)
 	}

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -28,7 +28,7 @@ func resourceConfigurationVariable() *schema.Resource {
 				Required:    true,
 			},
 			"description": {
-				Type:        schema.TypeBool,
+				Type:        schema.TypeString,
 				Description: "a description of the variables",
 				Optional:    true,
 			},

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -199,6 +199,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configVar.Id),
+						resource.TestCheckResourceAttr(accessor, "description", configVar.Description),
 						resource.TestCheckResourceAttr(accessor, "name", configVar.Name),
 						resource.TestCheckResourceAttr(accessor, "value", configVar.Value),
 					),
@@ -244,20 +245,23 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":  configVar.Name,
-						"value": configVar.Value,
+						"name":        configVar.Name,
+						"description": configVar.Description,
+						"value":       configVar.Value,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configVar.Id),
 						resource.TestCheckResourceAttr(accessor, "name", configVar.Name),
+						resource.TestCheckResourceAttr(accessor, "description", configVar.Description),
 						resource.TestCheckResourceAttr(accessor, "value", configVar.Value),
 					),
 				},
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":  newConfigVar.Name,
-						"value": newConfigVar.Value,
-						"type":  newConfigVar.Type,
+						"name":        newConfigVar.Name,
+						"description": newConfigVar.Description,
+						"value":       newConfigVar.Value,
+						"type":        newConfigVar.Type,
 					}),
 					ExpectError: regexp.MustCompile(`'type' can only receive either 'environment' or 'terraform'`),
 				},

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -21,8 +21,9 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 		Value:       "Variable",
 	}
 	stepConfig := resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-		"name":  configVar.Name,
-		"value": configVar.Value,
+		"name":        configVar.Name,
+		"description": configVar.Description,
+		"value":       configVar.Value,
 	})
 
 	t.Run("Create", func(t *testing.T) {

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -15,9 +15,10 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)
 	configVar := client.ConfigurationVariable{
-		Id:    "id0",
-		Name:  "name0",
-		Value: "Variable",
+		Id:          "id0",
+		Name:        "name0",
+		Description: "desc0",
+		Value:       "Variable",
 	}
 	stepConfig := resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
 		"name":  configVar.Name,
@@ -94,7 +95,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 		description = "%s"
 		value= "%s"
 		enum = ["a","b"]
-	}`, resourceType, configVar.Name, configVar.Value)
+	}`, resourceType, configVar.Name, configVar.Description, configVar.Value)
 		createTestCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -194,8 +194,9 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":  configVar.Name,
-						"value": configVar.Value,
+						"name":        configVar.Name,
+						"description": configVar.Description,
+						"value":       configVar.Value,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configVar.Id),

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -34,6 +34,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configVar.Id),
 						resource.TestCheckResourceAttr(accessor, "name", configVar.Name),
+						resource.TestCheckResourceAttr(accessor, "description", configVar.Description),
 						resource.TestCheckResourceAttr(accessor, "value", configVar.Value),
 					),
 				},

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -70,6 +70,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configVar.Id),
 						resource.TestCheckResourceAttr(accessor, "name", configVar.Name),
+						resource.TestCheckResourceAttr(accessor, "description", configVar.Description),
 						resource.TestCheckResourceAttr(accessor, "value", configVar.Value),
 						resource.TestCheckResourceAttr(accessor, "enum.0", configVar.Schema.Enum[0]),
 						resource.TestCheckResourceAttr(accessor, "enum.1", configVar.Schema.Enum[1]),
@@ -89,6 +90,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 		stepConfig := fmt.Sprintf(`
 	resource "%s" "test" {
 		name = "%s"
+		description = "%s"
 		value= "%s"
 		enum = ["a","b"]
 	}`, resourceType, configVar.Name, configVar.Value)
@@ -177,9 +179,10 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		newConfigVar := client.ConfigurationVariable{
-			Id:    configVar.Id,
-			Name:  configVar.Name,
-			Value: "I want to be the config value",
+			Id:          configVar.Id,
+			Name:        configVar.Name,
+			Description: configVar.Description,
+			Value:       "I want to be the config value",
 		}
 
 		updateTestCase := resource.TestCase{
@@ -197,12 +200,14 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 				},
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":  newConfigVar.Name,
-						"value": newConfigVar.Value,
+						"name":        newConfigVar.Name,
+						"description": newConfigVar.Description,
+						"value":       newConfigVar.Value,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", newConfigVar.Id),
 						resource.TestCheckResourceAttr(accessor, "name", newConfigVar.Name),
+						resource.TestCheckResourceAttr(accessor, "description", newConfigVar.Description),
 						resource.TestCheckResourceAttr(accessor, "value", newConfigVar.Value),
 					),
 				},

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -41,16 +41,17 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, configVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Times(1).Return([]client.ConfigurationVariable{configVar}, nil)
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})
 	})
 	t.Run("Create Enum", func(t *testing.T) {
 		configVar := client.ConfigurationVariable{
-			Id:    "id0",
-			Name:  "name0",
-			Value: "Variable",
+			Id:          "id0",
+			Name:        "name0",
+			Description: "desc0",
+			Value:       "Variable",
 			Schema: client.ConfigurationVariableSchema{
 				Type: "string",
 				Enum: []string{"Variable", "a"},
@@ -81,7 +82,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				configVar.Schema.Enum).Times(1).Return(configVar, nil)
+				configVar.Schema.Enum, configVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Times(1).Return([]client.ConfigurationVariable{configVar}, nil)
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})
@@ -137,7 +138,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, configVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Times(1).Return([]client.ConfigurationVariable{}, errors.New("error"))
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})
@@ -155,7 +156,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, configVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Times(1).Return([]client.ConfigurationVariable{}, nil)
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})
@@ -173,7 +174,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(client.ConfigurationVariable{}, errors.New("error"))
+				nil, configVar.Description).Times(1).Return(client.ConfigurationVariable{}, errors.New("error"))
 		})
 	})
 
@@ -216,13 +217,13 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, updateTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, configVar.Description).Times(1).Return(configVar, nil)
 			gomock.InOrder(
 				mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Return([]client.ConfigurationVariable{configVar}, nil).Times(2),
 				mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Return([]client.ConfigurationVariable{newConfigVar}, nil),
 			)
 			mock.EXPECT().ConfigurationVariableUpdate(newConfigVar.Id, newConfigVar.Name, newConfigVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, newConfigVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})
 	})
@@ -261,7 +262,7 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 
 		runUnitTest(t, updateTestCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ConfigurationVariableCreate(configVar.Name, configVar.Value, false, client.ScopeGlobal, "", client.ConfigurationVariableTypeEnvironment,
-				nil).Times(1).Return(configVar, nil)
+				nil, configVar.Description).Times(1).Return(configVar, nil)
 			mock.EXPECT().ConfigurationVariables(client.ScopeGlobal, "").Return([]client.ConfigurationVariable{configVar}, nil).Times(2)
 			mock.EXPECT().ConfigurationVariableDelete(configVar.Id).Times(1).Return(nil)
 		})

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -63,9 +63,10 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 		stepConfig := fmt.Sprintf(`
 	resource "%s" "test" {
 		name = "%s"
+		description = "%s"
 		value= "%s"
 		enum = ["%s","%s"]
-	}`, resourceType, configVar.Name, configVar.Value, configVar.Schema.Enum[0], configVar.Schema.Enum[1])
+	}`, resourceType, configVar.Name, configVar.Description, configVar.Value, configVar.Schema.Enum[0], configVar.Schema.Enum[1])
 
 		createTestCase := resource.TestCase{
 			Steps: []resource.TestStep{


### PR DESCRIPTION
A configuration variable may have an optional short description.  
This PR adds it to both TF resource and data source so it may be set or consumed.  