### PR TITLE
Chore: Add Sensitive on configuration variables

### DIFF
--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -66,6 +66,7 @@ func dataConfigurationVariable() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "value stored in the variable",
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"is_sensitive": {
 				Type:        schema.TypeBool,

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -31,6 +31,7 @@ func resourceConfigurationVariable() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "value for the configuration variable",
 				Required:    true,
+				Sensitive:   true,
 			},
 			"is_sensitive": {
 				Type:        schema.TypeBool,

--- a/tests/integration/003_configuration_variable/main.tf
+++ b/tests/integration/003_configuration_variable/main.tf
@@ -2,7 +2,8 @@ data "env0_configuration_variable" "region" {
   name = "AWS_DEFAULT_REGION"
 }
 output "region_value" {
-  value = data.env0_configuration_variable.region.value
+  value     = data.env0_configuration_variable.region.value
+  sensitive = true
 }
 output "region_id" {
   value = data.env0_configuration_variable.region.id
@@ -17,7 +18,8 @@ data "env0_configuration_variable" "region_in_project" {
   project_id = data.env0_project.default.id
 }
 output "region_in_project_value" {
-  value = data.env0_configuration_variable.region_in_project.value
+  value     = data.env0_configuration_variable.region_in_project.value
+  sensitive = true
 }
 output "region_in_project_id" {
   value = data.env0_configuration_variable.region_in_project.id
@@ -33,7 +35,8 @@ data "env0_configuration_variable" "tested1" {
 }
 
 output "tested1_value" {
-  value = data.env0_configuration_variable.tested1.value
+  value     = data.env0_configuration_variable.tested1.value
+  sensitive = true
 }
 
 data "env0_configuration_variable" "tested2" {
@@ -52,8 +55,10 @@ data "env0_configuration_variable" "tested3" {
 
 
 output "tested3_enum_1" {
-  value = data.env0_configuration_variable.tested3.enum[0]
+  value     = data.env0_configuration_variable.tested3.enum[0]
+  sensitive = true
 }
 output "tested3_enum_2" {
-  value = data.env0_configuration_variable.tested3.enum[1]
+  value     = data.env0_configuration_variable.tested3.enum[1]
+  sensitive = true
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Currently, the value of configuration variables with `isSensitive: true` is displayed in the CLI output of terraform, on `terraform plan` and `terraform apply`

### Solution
Mark configuration variable values to always be sensitive
