### PR TITLE
Fix: default true for requires approval. (was false)

### DIFF
--- a/env0/resource_project_policy.go
+++ b/env0/resource_project_policy.go
@@ -66,6 +66,7 @@ func resourcePolicy() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Requires approval default value when creating a new environment in the project",
 				Optional:    true,
+				Default:     true,
 			},
 			"include_cost_estimation": {
 				Type:        schema.TypeBool,

--- a/env0/resource_project_policy_test.go
+++ b/env0/resource_project_policy_test.go
@@ -20,7 +20,6 @@ func TestUnitPolicyResource(t *testing.T) {
 		ProjectId:                  "project0",
 		NumberOfEnvironments:       1,
 		NumberOfEnvironmentsTotal:  1,
-		RequiresApprovalDefault:    true,
 		IncludeCostEstimation:      true,
 		SkipApplyWhenPlanIsEmpty:   true,
 		DisableDestroyEnvironments: true,
@@ -62,7 +61,7 @@ func TestUnitPolicyResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(accessor, "project_id", policy.ProjectId),
 					resource.TestCheckResourceAttr(accessor, "number_of_environments", strconv.Itoa(policy.NumberOfEnvironments)),
-					// resource.TestCheckResourceAttr(accessor, "number_of_environments_total", strconv.Itoa(policy.NumberOfEnvironmentsTotal)),
+					resource.TestCheckResourceAttr(accessor, "number_of_environments_total", strconv.Itoa(policy.NumberOfEnvironmentsTotal)),
 					resource.TestCheckResourceAttr(accessor, "requires_approval_default", strconv.FormatBool(policy.RequiresApprovalDefault)),
 					resource.TestCheckResourceAttr(accessor, "include_cost_estimation", strconv.FormatBool(policy.IncludeCostEstimation)),
 					resource.TestCheckResourceAttr(accessor, "skip_apply_when_plan_is_empty", strconv.FormatBool(policy.SkipApplyWhenPlanIsEmpty)),


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
During the QA of https://trello.com/c/mMt3dwEd/4693-skipredundantdeploymenst-typo-fix
We've found out that the default value of `requires_approval_default` was false ( because it is a boolean variable )
### Solution
- Change the default value to true.
-  `number_of_environments_total` unit test that was commented out.