### PR TITLE
Fix environment resource variables on create

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -41,15 +41,16 @@ type ProjectCreatePayload struct {
 }
 
 type EnvironmentCreate struct {
-	Name                        string         `json:"name"`
-	ProjectId                   string         `json:"projectId"`
-	DeployRequest               *DeployRequest `json:"deployRequest"`
-	WorkspaceName               string         `json:"workspaceName,omitempty"`
-	RequiresApproval            *bool          `json:"requiresApproval,omitempty"`
-	ContinuousDeployment        *bool          `json:"continuousDeployment,omitempty"`
-	PullRequestPlanDeployments  *bool          `json:"pullRequestPlanDeployments,omitempty"`
-	AutoDeployOnPathChangesOnly *bool          `json:"autoDeployOnPathChangesOnly,omitempty"`
-	AutoDeployByCustomGlob      string         `json:"autoDeployByCustomGlob,omitempty"`
+	Name                        string                `json:"name"`
+	ProjectId                   string                `json:"projectId"`
+	DeployRequest               *DeployRequest        `json:"deployRequest"`
+	WorkspaceName               string                `json:"workspaceName,omitempty"`
+	RequiresApproval            *bool                 `json:"requiresApproval,omitempty"`
+	ContinuousDeployment        *bool                 `json:"continuousDeployment,omitempty"`
+	PullRequestPlanDeployments  *bool                 `json:"pullRequestPlanDeployments,omitempty"`
+	AutoDeployOnPathChangesOnly *bool                 `json:"autoDeployOnPathChangesOnly,omitempty"`
+	AutoDeployByCustomGlob      string                `json:"autoDeployByCustomGlob,omitempty"`
+	ConfigurationChanges        *ConfigurationChanges `json:"configurationChanges,omitempty"`
 }
 
 type DeployRequest struct {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -281,6 +281,10 @@ func getCreatePayload(d *schema.ResourceData) client.EnvironmentCreate {
 	if autoDeployByCustomGlob, ok := d.GetOk("auto_deploy_by_custom_glob"); ok {
 		payload.AutoDeployByCustomGlob = autoDeployByCustomGlob.(string)
 	}
+	if configuration, ok := d.GetOk("configuration"); ok {
+		configurationChanges := getConfigurationVariables(configuration.([]interface{}))
+		payload.ConfigurationChanges = &configurationChanges
+	}
 
 	deployPayload := getDeployPayload(d)
 
@@ -364,7 +368,7 @@ func getConfigurationVariableForEnvironment(variable map[string]interface{}) cli
 	configurationVariable := client.ConfigurationVariable{
 		Name:  variable["name"].(string),
 		Value: variable["value"].(string),
-		Scope: client.ScopeDeployment,
+		Scope: client.ScopeEnvironment,
 		Type:  &varType,
 	}
 
@@ -381,7 +385,7 @@ func getConfigurationVariableForEnvironment(variable map[string]interface{}) cli
 		configurationVariable.Description = variable["description"].(string)
 	}
 
-	if variable["schema_type"] != nil && variable["schema_enum"] != nil {
+	if variable["schema_type"] != "" && len(variable["schema_enum"].([]interface{})) > 0 {
 		enumOfAny := variable["schema_enum"].([]interface{})
 		enum := make([]string, len(enumOfAny))
 		for i := range enum {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -368,7 +368,7 @@ func getConfigurationVariableForEnvironment(variable map[string]interface{}) cli
 	configurationVariable := client.ConfigurationVariable{
 		Name:  variable["name"].(string),
 		Value: variable["value"].(string),
-		Scope: client.ScopeEnvironment,
+		Scope: client.ScopeDeployment,
 		Type:  &varType,
 	}
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
For some reason when putting the variables in the deploy request doesn't take affect when creating an environment ( but it does work on deployment requests)
Fix: When creating an environment add configuration changes under the environment.
