### PR TITLE
Fix: We don't import the deployment_id when importing an environment

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -605,6 +605,7 @@ func resourceEnvironmentImport(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("could not get environment configuration variables: %v", err))
 	}
+	d.Set("deployment_id", environment.LatestDeploymentLogId)
 	setEnvironmentSchema(d, environment, environmentConfigurationVariables)
 
 	if getErr != nil {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We don't import `deployment_id` when importing an environment.
We should import the latest deployment log

### Solution
Import latest deployment log
No tests, because we don't have tests for imports + no integration tests yet
