### PR TITLE
Fix: Add glob_pattern validation when cd/PrPlan enabled

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -84,7 +84,6 @@ func resourceEnvironment() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "redeploy on file filter pattern",
 				Optional:    true,
-				Default:     "",
 			},
 			"deployment_id": {
 				Type:        schema.TypeString,

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -695,15 +695,24 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						"project_id":                       environment.ProjectId,
 						"template_id":                      environment.LatestDeploymentLog.BlueprintId,
 						"auto_deploy_on_path_changes_only": true,
-						"force_destroy":                    true,
 						"run_plan_on_pull_requests":        true,
 						"auto_deploy_by_custom_glob":       "/**",
+						"force_destroy":                    true,
 					}),
+					ExpectNonEmptyPlan: true,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+						resource.TestCheckResourceAttr(accessor, "name", environment.Name),
+						resource.TestCheckResourceAttr(accessor, "project_id", environment.ProjectId),
+					),
 				},
 			},
 		}
 		runUnitTest(t, autoDeployWithCustomGlobEnabled, func(mock *client.MockApiClientInterface) {
-			mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1)
+			mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
+			mock.EXPECT().Environment(gomock.Any()).Times(1).Return(environment, nil)
+			mock.EXPECT().ConfigurationVariables(gomock.Any(), gomock.Any()).Times(1).Return(client.ConfigurationChanges{}, nil)
+			mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 		})
 	})
 

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -549,7 +549,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			ContinuousDeployment:       &falsey,
 			RequiresApproval:           &truthyFruity,
 			PullRequestPlanDeployments: &falsey,
-			//AutoDeployByCustomGlob:     autoDeployByCustomGlobDefault,
 		}
 
 		testCase := resource.TestCase{

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -690,7 +690,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					ExpectError: regexp.MustCompile("cannot set auto_deploy_by_custom_glob when auto_deploy_on_path_changes_only is disabled"),
 				},
 				{
-					Destroy: true,
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
 						"name":                             environment.Name,
 						"project_id":                       environment.ProjectId,
@@ -701,22 +700,10 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						"auto_deploy_by_custom_glob":       "/**",
 					}),
 				},
-				/*{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":                             environment.Name,
-						"project_id":                       environment.ProjectId,
-						"template_id":                      environment.LatestDeploymentLog.BlueprintId,
-						"auto_deploy_on_path_changes_only": false,
-						"force_destroy":                    true,
-						"run_plan_on_pull_requests":        true,
-						"auto_deploy_by_custom_glob":       "/**",
-					}),
-					ExpectError: regexp.MustCompile("cannot set auto_deploy_by_custom_glob when auto_deploy_on_path_changes_only is disabled"),
-				},*/
 			},
 		}
 		runUnitTest(t, autoDeployWithCustomGlobEnabled, func(mock *client.MockApiClientInterface) {
-			//mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1)
+			mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1)
 		})
 	})
 

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -19,6 +19,7 @@ resource "env0_environment" "example" {
     name  = "environment configuration variable"
     value = "value"
   }
+  approve_plan_automatically = true
 }
 
 data "env0_environment" "test" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Currently we don't validate that CD/PrPlan are enabled if the user set a custom_glob_pattern.  By default, the `runOnAnyChange` is enabled, so that should be true unless the user configured a glob pattern.
### Solution

1. Add validation in both create & update cases.
2. auth_deploy_on_path_changes_only must be `true` for the glob to take effect.