### PR TITLE
Feat: Adding JSON Format to configuration variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Run from root directory:
 go test ./...
 ```
 
+#### Running a single provider test
+```shell
+export TEST_PATTERN="TestUnitConfigurationVariableResource/Create" && go test ./env0
+```
+
 #### How to use mocks
 
 1. Make sure `GOPATH` is in your `PATH`

--- a/client/configuration_variable_test.go
+++ b/client/configuration_variable_test.go
@@ -57,13 +57,16 @@ var _ = Describe("Configuration Variable", func() {
 			return request
 		}
 
-		var DoCreateRequest = func(mockConfig ConfigurationVariable, expectedRequest []map[string]interface{}) {
+		var SetCreateRequestExpectation = func(mockConfig ConfigurationVariable) {
+			expectedCreateRequest := GetExpectedRequest(mockConfig)
 			httpCall = mockHttpClient.EXPECT().
-				Post("configuration", expectedRequest, gomock.Any()).
+				Post("configuration", expectedCreateRequest, gomock.Any()).
 				Do(func(path string, request interface{}, response *[]ConfigurationVariable) {
 					*response = []ConfigurationVariable{mockConfig}
 				})
+		}
 
+		var DoCreateRequest = func(mockConfig ConfigurationVariable) {
 			createdConfigurationVariable, _ = apiClient.ConfigurationVariableCreate(
 				ConfigurationVariableCreateParams{
 					Name:        mockConfig.Name,
@@ -81,8 +84,8 @@ var _ = Describe("Configuration Variable", func() {
 
 		BeforeEach(func() {
 			mockOrganizationIdCall(organizationId)
-			expectedCreateRequest := GetExpectedRequest(mockConfigurationVariable)
-			DoCreateRequest(mockConfigurationVariable, expectedCreateRequest)
+			SetCreateRequestExpectation(mockConfigurationVariable)
+			DoCreateRequest(mockConfigurationVariable)
 		})
 
 		It("Should get organization id", func() {
@@ -101,9 +104,9 @@ var _ = Describe("Configuration Variable", func() {
 			var mockWithFormat = ConfigurationVariable{}
 			copier.Copy(&mockWithFormat, &mockConfigurationVariable)
 			mockWithFormat.Schema.Format = schemaFormat
-			requestWithFormat := GetExpectedRequest(mockWithFormat)
+			SetCreateRequestExpectation(mockWithFormat)
 
-			DoCreateRequest(mockWithFormat, requestWithFormat)
+			DoCreateRequest(mockWithFormat)
 
 			httpCall.Times(1)
 			Expect(createdConfigurationVariable).To(Equal(mockWithFormat))

--- a/client/configuration_variable_test.go
+++ b/client/configuration_variable_test.go
@@ -30,15 +30,15 @@ var _ = Describe("Configuration Variable", func() {
 		Schema:         &schema,
 	}
 
-	DescribeTable("ConfigurationVariableCreate", func(schemaFormat string) {
+	DescribeTable("ConfigurationVariableCreate", func(schemaFormat Format) {
 		var createdConfigurationVariable ConfigurationVariable
-		var mockVariableToCreate ConfigurationVariable
+		var mockVariableToCreate = ConfigurationVariable{}
 
 		BeforeEach(func() {
 			mockOrganizationIdCall(organizationId)
 
 			copier.Copy(&mockVariableToCreate, &mockConfigurationVariable)
-			mockVariableToCreate.Schema.Format = Format(schemaFormat)
+			mockVariableToCreate.Schema.Format = schemaFormat
 
 			expectedCreateRequest := []map[string]interface{}{{
 				"name":           mockVariableToCreate.Name,

--- a/client/model.go
+++ b/client/model.go
@@ -140,6 +140,7 @@ type Format string
 const (
 	Text Format = ""
 	HCL  Format = "HCL"
+	JSON Format = "JSON"
 )
 
 type Scope string

--- a/env0/data_configuration_variable.go
+++ b/env0/data_configuration_variable.go
@@ -94,7 +94,7 @@ func dataConfigurationVariable() *schema.Resource {
 			},
 			"format": {
 				Type:        schema.TypeString,
-				Description: "specifies the format of the configuration value (for example: HCL)",
+				Description: "specifies the format of the configuration value (HCL/JSON)",
 				Computed:    true,
 			},
 		},

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -33,7 +33,8 @@ var testUnitProviders = map[string]func() (*schema.Provider, error){
 func runUnitTest(t *testing.T, testCase resource.TestCase, mockFunc func(mockFunc *client.MockApiClientInterface)) {
 	testPattern := os.Getenv("TEST_PATTERN")
 	if testPattern != "" && !strings.Contains(t.Name(), testPattern) {
-		t.Skip()
+		t.SkipNow()
+		return
 	}
 
 	testReporter := utils.TestReporter{T: t}

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -31,6 +31,11 @@ var testUnitProviders = map[string]func() (*schema.Provider, error){
 }
 
 func runUnitTest(t *testing.T, testCase resource.TestCase, mockFunc func(mockFunc *client.MockApiClientInterface)) {
+	testPattern := os.Getenv("TEST_PATTERN")
+	if testPattern != "" && !strings.Contains(t.Name(), testPattern) {
+		t.Skip()
+	}
+
 	testReporter := utils.TestReporter{T: t}
 	ctrl = gomock.NewController(&testReporter)
 	defer ctrl.Finish()
@@ -64,7 +69,7 @@ func testExpectedProviderError(t *testing.T, diags diag.Diagnostics, expectedKey
 	}
 
 	if errorDetail == "" {
-		t.Fatalf("Error wasn't recieved, expected: %s", expectedError)
+		t.Fatalf("Error wasn't received, expected: %s", expectedError)
 	}
 }
 

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -79,17 +79,11 @@ func resourceConfigurationVariable() *schema.Resource {
 				},
 			},
 			"format": {
-				Type:        schema.TypeString,
-				Description: "specifies the format of the configuration value (for example: HCL)",
-				Default:     "",
-				Optional:    true,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					value := val.(string)
-					if value != string(client.HCL) && value != string(client.Text) {
-						errs = append(errs, fmt.Errorf("%q can be either \"HCL\" or empty, got: %q", key, value))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Description:  "specifies the format of the configuration value (HCL/JSON)",
+				Default:      "",
+				Optional:     true,
+				ValidateFunc: ValidateConfigurationPropertySchema,
 			},
 		},
 	}
@@ -205,8 +199,8 @@ func resourceConfigurationVariableRead(ctx context.Context, d *schema.ResourceDa
 					d.Set("enum", variable.Schema.Enum)
 				}
 
-				if variable.Schema.Format == client.HCL {
-					d.Set("format", string(client.HCL))
+				if variable.Schema.Format != "" {
+					d.Set("format", variable.Schema.Format)
 				}
 			}
 

--- a/env0/resource_configuration_variable_test.go
+++ b/env0/resource_configuration_variable_test.go
@@ -118,11 +118,11 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 		t.Run("Create "+string(format)+" Variable", func(t *testing.T) {
 
 			expectedVariable := `{
-	A = "A"
-	B = "B"
-	C = "C"
-	}
-	`
+A = "A"
+B = "B"
+C = "C"
+}
+`
 
 			schema := client.ConfigurationVariableSchema{
 				Type:   "string",
@@ -136,26 +136,26 @@ func TestUnitConfigurationVariableResource(t *testing.T) {
 				Schema:      &schema,
 			}
 			terraformDirective := `<<EOT
-	{
-	%{ for key, value in var.map ~}
-	${key} = "${value}"
-	%{ endfor ~}
-	}
-	EOT`
+{
+%{ for key, value in var.map ~}
+${key} = "${value}"
+%{ endfor ~}
+}
+EOT`
 			stepConfig := fmt.Sprintf(`
-					variable "map" {
-							description = "a mapped variable"
-							type        = map(string)
-							default = %s
-						}
-					
-					
-					resource "%s" "test" {
-							name = "%s"
-							description = "%s"
-							value = %s
-							format = "%s"
-		}`, expectedVariable, resourceType, configVar.Name, configVar.Description, terraformDirective, string(format))
+variable "map" {
+		description = "a mapped variable"
+		type        = map(string)
+		default = %s
+	}
+
+
+resource "%s" "test" {
+		name = "%s"
+		description = "%s"
+		value = %s
+		format = "%s"
+}`, expectedVariable, resourceType, configVar.Name, configVar.Description, terraformDirective, string(format))
 
 			createTestCase := resource.TestCase{
 				Steps: []resource.TestStep{

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -163,17 +163,11 @@ func resourceEnvironment() *schema.Resource {
 							},
 						},
 						"schema_format": &schema.Schema{
-							Type:        schema.TypeString,
-							Description: "the variable format:",
-							Default:     "",
-							Optional:    true,
-							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-								value := val.(string)
-								if value != string(client.HCL) && value != string(client.Text) {
-									errs = append(errs, fmt.Errorf("%q can be either \"HCL\" or empty, got: %q", key, value))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Description:  "the variable format:",
+							Default:      "",
+							Optional:     true,
+							ValidateFunc: ValidateConfigurationPropertySchema,
 						},
 					},
 				},

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -1,0 +1,15 @@
+package env0
+
+import (
+	"fmt"
+
+	"github.com/env0/terraform-provider-env0/client"
+)
+
+func ValidateConfigurationPropertySchema(val interface{}, key string) (warns []string, errs []error) {
+	value := val.(string)
+	if value != string(client.HCL) && value != string(client.Text) && value != string(client.JSON) {
+		errs = append(errs, fmt.Errorf("%q can be either \"HCL\", \"JSON\" or empty, got: %q", key, value))
+	}
+	return
+}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Add support for JSON Format configuration variables

### Solution
- Added JSON support - trying to keep it DRY between HCL and JSON where possible.
- Added `TEST_PATTERN` option when running provider tests, since those take like 10 minutes

