### PR TITLE
remove passing env0 vars to terraform in harness

### DIFF
--- a/tests/harness.go
+++ b/tests/harness.go
@@ -14,10 +14,6 @@ import (
 
 const TESTS_FOLDER = "tests/integration"
 
-var ENV0_API_ENDPOINT = os.Getenv("ENV0_API_ENDPOINT")
-var ENV0_API_SECRET = os.Getenv("ENV0_API_SECRET")
-var ENV0_API_KEY = os.Getenv("ENV0_API_KEY")
-
 func main() {
 	err := compileProvider()
 	if err != nil {
@@ -72,11 +68,11 @@ func runTest(testName string, destroy bool) (bool, error) {
 		defer terraformDestory(testName)
 	}
 
-	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=0", "-var", "ENV0_API_ENDPOINT="+ENV0_API_ENDPOINT, "-var", "ENV0_API_KEY="+ENV0_API_KEY, "-var", "ENV0_API_SECRET="+ENV0_API_SECRET)
+	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=0")
 	if err != nil {
 		return false, err
 	}
-	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=1", "-var", "ENV0_API_ENDPOINT="+ENV0_API_ENDPOINT, "-var", "ENV0_API_KEY="+ENV0_API_KEY, "-var", "ENV0_API_SECRET="+ENV0_API_SECRET)
+	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=1")
 	if err != nil {
 		return false, err
 	}
@@ -105,7 +101,7 @@ func runTest(testName string, destroy bool) (bool, error) {
 		log.Printf("Verified expected '%s'='%s' in %s", key, value, testName)
 	}
 	if destroy {
-		_, err = terraformCommand(testName, "destroy", "-auto-approve", "-var", "second_run=0", "-var", "ENV0_API_ENDPOINT="+ENV0_API_ENDPOINT, "-var", "ENV0_API_KEY="+ENV0_API_KEY, "-var", "ENV0_API_SECRET="+ENV0_API_SECRET)
+		_, err = terraformCommand(testName, "destroy", "-auto-approve", "-var", "second_run=0")
 		if err != nil {
 			return false, err
 		}
@@ -147,7 +143,7 @@ func bytesOfJsonToStringMap(data []byte) (map[string]string, error) {
 
 func terraformDestory(testName string) {
 	log.Println("Running destroy to clean up in", testName)
-	destroy := exec.Command("terraform", "destroy", "-auto-approve", "-var", "second_run=0", "-var", "ENV0_API_ENDPOINT="+ENV0_API_ENDPOINT, "-var", "ENV0_API_KEY="+ENV0_API_KEY, "-var", "ENV0_API_SECRET="+ENV0_API_SECRET)
+	destroy := exec.Command("terraform", "destroy", "-auto-approve", "-var", "second_run=0")
 	destroy.Dir = TESTS_FOLDER + "/" + testName
 	destroy.CombinedOutput()
 	log.Println("Done running terraform destroy in", testName)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
on #202 we broke `harness.go` it didn't find env0 environment variables

### Solution
revert part of `harness.go` we did in #202
