### PR TITLE
Fix: template resource token_id attribute validation

### DIFF
--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -104,7 +104,6 @@ func resourceTemplate() *schema.Resource {
 				Type:          schema.TypeString,
 				Description:   "The token id used for private git repos or for integration with GitLab, you can get this value by using a data resource of an existing Gitlab template or contact our support team",
 				Optional:      true,
-				RequiredWith:  []string{"gitlab_project_id"},
 				ConflictsWith: []string{"github_installation_id"},
 			},
 			"gitlab_project_id": {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
On #224 we introduced some new schema validations for the template resource. Specifically the validation that requires `token_id` attribute to be set with `gitlab_project_id` attribute is incorrect as `token_id` is used as git token for simple git fetch when template is of type "Other"

### Solution
Remove that validation
