### PR TITLE
feat: allow env0_environment creation to be synchronous

### DIFF
--- a/client/model.go
+++ b/client/model.go
@@ -293,6 +293,7 @@ type DeploymentLog struct {
 	BlueprintId         string `json:"blueprintId"`
 	BlueprintRepository string `json:"blueprintRepository"`
 	BlueprintRevision   string `json:"blueprintRevision"`
+	Status              string `json:"status"`
 }
 
 type SshKey struct {


### PR DESCRIPTION
This commit adds a new "wait" parameter to the env0_environment
resource. If this parameter is set to true, the resource waits for the
environment's latest deployment to hit a terminal state. This allows
multiple environments to be chained together with terraform
dependencies to deploy environments in a specific order. The parameter
defaults to false to preserve existing behaviour

FYI @away168
