### PR TITLE
Add client support for drift detection

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -63,6 +63,9 @@ type ApiClientInterface interface {
 	EnvironmentSchedulingDelete(environmentId string) error
 	WorkflowTrigger(environmentId string) ([]WorkflowTrigger, error)
 	WorkflowTriggerUpsert(environmentId string, request WorkflowTriggerUpsertPayload) ([]WorkflowTrigger, error)
+	EnvironmentDriftDetection(environmentId string) (EnvironmentSchedulingExpression, error)
+	EnvironmentUpdateDriftDetection(environmentId string, payload EnvironmentSchedulingExpression) (EnvironmentSchedulingExpression, error)
+	EnvironmentStopDriftDetection(environmentId string) error
 }
 
 func NewApiClient(client http.HttpClientInterface) ApiClientInterface {

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -190,12 +190,6 @@ func (m *MockApiClientInterface) ConfigurationVariablesById(arg0 string) (Config
 	return ret0, ret1
 }
 
-// ConfigurationVariables indicates an expected call of ConfigurationVariables.
-func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariables(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariablesByScope", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariablesByScope), arg0, arg1)
-}
-
 // ConfigurationVariablesById indicates an expected call of ConfigurationVariablesById.
 func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariablesById(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
@@ -277,6 +271,21 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDestroy(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDestroy", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDestroy), arg0)
 }
 
+// EnvironmentDriftDetection mocks base method.
+func (m *MockApiClientInterface) EnvironmentDriftDetection(arg0 string) (EnvironmentSchedulingExpression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentDriftDetection", arg0)
+	ret0, _ := ret[0].(EnvironmentSchedulingExpression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnvironmentDriftDetection indicates an expected call of EnvironmentDriftDetection.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDriftDetection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDriftDetection", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDriftDetection), arg0)
+}
+
 // EnvironmentScheduling mocks base method.
 func (m *MockApiClientInterface) EnvironmentScheduling(arg0 string) (EnvironmentScheduling, error) {
 	m.ctrl.T.Helper()
@@ -321,6 +330,20 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentSchedulingUpdate(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentSchedulingUpdate", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentSchedulingUpdate), arg0, arg1)
 }
 
+// EnvironmentStopDriftDetection mocks base method.
+func (m *MockApiClientInterface) EnvironmentStopDriftDetection(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentStopDriftDetection", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnvironmentStopDriftDetection indicates an expected call of EnvironmentStopDriftDetection.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentStopDriftDetection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentStopDriftDetection", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentStopDriftDetection), arg0)
+}
+
 // EnvironmentUpdate mocks base method.
 func (m *MockApiClientInterface) EnvironmentUpdate(arg0 string, arg1 EnvironmentUpdate) (Environment, error) {
 	m.ctrl.T.Helper()
@@ -334,6 +357,21 @@ func (m *MockApiClientInterface) EnvironmentUpdate(arg0 string, arg1 Environment
 func (mr *MockApiClientInterfaceMockRecorder) EnvironmentUpdate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentUpdate", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentUpdate), arg0, arg1)
+}
+
+// EnvironmentUpdateDriftDetection mocks base method.
+func (m *MockApiClientInterface) EnvironmentUpdateDriftDetection(arg0 string, arg1 EnvironmentSchedulingExpression) (EnvironmentSchedulingExpression, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentUpdateDriftDetection", arg0, arg1)
+	ret0, _ := ret[0].(EnvironmentSchedulingExpression)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnvironmentUpdateDriftDetection indicates an expected call of EnvironmentUpdateDriftDetection.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentUpdateDriftDetection(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentUpdateDriftDetection", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentUpdateDriftDetection), arg0, arg1)
 }
 
 // EnvironmentUpdateTTL mocks base method.

--- a/client/environment_drift_detection.go
+++ b/client/environment_drift_detection.go
@@ -1,0 +1,31 @@
+package client
+
+func (self *ApiClient) EnvironmentDriftDetection(environmentId string) (EnvironmentSchedulingExpression, error) {
+	var result EnvironmentSchedulingExpression
+
+	err := self.http.Get("scheduling/drift-detection/environments/"+environmentId, nil, &result)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, payload EnvironmentSchedulingExpression) (EnvironmentSchedulingExpression, error) {
+	var result EnvironmentSchedulingExpression
+
+	err := self.http.Put("scheduling/drift-detection/environments/"+environmentId, payload, &result)
+	if err != nil {
+		return EnvironmentSchedulingExpression{}, err
+	}
+
+	return result, nil
+}
+
+func (self *ApiClient) EnvironmentStopDriftDetection(environmentId string) error {
+	err := self.http.Put("scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/environment_drift_detection.go
+++ b/client/environment_drift_detection.go
@@ -22,7 +22,7 @@ func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, pay
 }
 
 func (self *ApiClient) EnvironmentStopDriftDetection(environmentId string) error {
-	err := self.http.Patch("/scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
+	err := self.http.Patch("/scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false}, &EnvironmentScheduling{})
 	if err != nil {
 		return err
 	}

--- a/client/environment_drift_detection.go
+++ b/client/environment_drift_detection.go
@@ -3,7 +3,7 @@ package client
 func (self *ApiClient) EnvironmentDriftDetection(environmentId string) (EnvironmentSchedulingExpression, error) {
 	var result EnvironmentSchedulingExpression
 
-	err := self.http.Get("scheduling/drift-detection/environments/"+environmentId, nil, &result)
+	err := self.http.Get("/scheduling/drift-detection/environments/"+environmentId, nil, &result)
 	if err != nil {
 		return result, err
 	}
@@ -13,7 +13,7 @@ func (self *ApiClient) EnvironmentDriftDetection(environmentId string) (Environm
 func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, payload EnvironmentSchedulingExpression) (EnvironmentSchedulingExpression, error) {
 	var result EnvironmentSchedulingExpression
 
-	err := self.http.Put("scheduling/drift-detection/environments/"+environmentId, payload, &result)
+	err := self.http.Put("/scheduling/drift-detection/environments/"+environmentId, payload, &result)
 	if err != nil {
 		return EnvironmentSchedulingExpression{}, err
 	}
@@ -22,7 +22,7 @@ func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, pay
 }
 
 func (self *ApiClient) EnvironmentStopDriftDetection(environmentId string) error {
-	err := self.http.Put("scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
+	err := self.http.Put("/scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
 	if err != nil {
 		return err
 	}

--- a/client/environment_drift_detection.go
+++ b/client/environment_drift_detection.go
@@ -13,7 +13,7 @@ func (self *ApiClient) EnvironmentDriftDetection(environmentId string) (Environm
 func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, payload EnvironmentSchedulingExpression) (EnvironmentSchedulingExpression, error) {
 	var result EnvironmentSchedulingExpression
 
-	err := self.http.Put("/scheduling/drift-detection/environments/"+environmentId, payload, &result)
+	err := self.http.Patch("/scheduling/drift-detection/environments/"+environmentId, payload, &result)
 	if err != nil {
 		return EnvironmentSchedulingExpression{}, err
 	}
@@ -22,7 +22,7 @@ func (self *ApiClient) EnvironmentUpdateDriftDetection(environmentId string, pay
 }
 
 func (self *ApiClient) EnvironmentStopDriftDetection(environmentId string) error {
-	err := self.http.Put("/scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
+	err := self.http.Patch("/scheduling/drift-detection/environments/"+environmentId, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, &EnvironmentScheduling{})
 	if err != nil {
 		return err
 	}

--- a/client/environment_drift_detection_test.go
+++ b/client/environment_drift_detection_test.go
@@ -52,7 +52,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 		Describe("Success", func() {
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Put(path, schedulingExpression, gomock.Any()).
+					Patch(path, schedulingExpression, gomock.Any()).
 					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
 						*response = schedulingExpression
 					})
@@ -69,7 +69,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Put(path, schedulingExpression, gomock.Any()).
+					Patch(path, schedulingExpression, gomock.Any()).
 					Return(mockError)
 
 				_, err = apiClient.EnvironmentUpdateDriftDetection(environmentId, schedulingExpression)
@@ -85,7 +85,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 		Describe("Success", func() {
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Put(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Patch(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
 					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
 						*response = schedulingExpression
 					})
@@ -98,7 +98,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Put(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Patch(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
 					Return(mockError)
 
 				err = apiClient.EnvironmentStopDriftDetection(environmentId)

--- a/client/environment_drift_detection_test.go
+++ b/client/environment_drift_detection_test.go
@@ -85,7 +85,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 		Describe("Success", func() {
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Patch(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Patch(path, EnvironmentSchedulingExpression{Enabled: false}, gomock.Any()).
 					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
 						*response = schedulingExpression
 					})
@@ -98,7 +98,7 @@ var _ = Describe("EnvironmentDriftDetection", func() {
 
 			BeforeEach(func() {
 				httpCall = mockHttpClient.EXPECT().
-					Patch(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Patch(path, EnvironmentSchedulingExpression{Enabled: false}, gomock.Any()).
 					Return(mockError)
 
 				err = apiClient.EnvironmentStopDriftDetection(environmentId)

--- a/client/environment_drift_detection_test.go
+++ b/client/environment_drift_detection_test.go
@@ -1,0 +1,114 @@
+package client_test
+
+import (
+	"errors"
+	. "github.com/env0/terraform-provider-env0/client"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EnvironmentDriftDetection", func() {
+	environmentId := "env"
+	path := "/scheduling/drift-detection/environments/" + environmentId
+	mockError := errors.New("I don't like milk")
+	schedulingExpression := EnvironmentSchedulingExpression{Cron: "0 * * * *", Enabled: true}
+	var driftResponse EnvironmentSchedulingExpression
+
+	Describe("Get", func() {
+		Describe("Success", func() {
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get(path, nil, gomock.Any()).
+					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
+						*response = schedulingExpression
+					})
+				driftResponse, _ = apiClient.EnvironmentDriftDetection(environmentId)
+			})
+
+			It("Should return the drift scheduling response", func() {
+				Expect(driftResponse).To(Equal(schedulingExpression))
+			})
+		})
+
+		Describe("Fail", func() {
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get(path, gomock.Any(), gomock.Any()).
+					Return(mockError)
+
+				_, err = apiClient.EnvironmentDriftDetection(environmentId)
+
+			})
+
+			It("Should fail if API call fails", func() {
+				Expect(err).To(Equal(mockError))
+			})
+		})
+	})
+	Describe("Update", func() {
+		Describe("Success", func() {
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put(path, schedulingExpression, gomock.Any()).
+					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
+						*response = schedulingExpression
+					})
+				driftResponse, _ = apiClient.EnvironmentUpdateDriftDetection(environmentId, schedulingExpression)
+			})
+
+			It("Should return the drift scheduling response", func() {
+				Expect(driftResponse).To(Equal(schedulingExpression))
+			})
+		})
+
+		Describe("Fail", func() {
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put(path, schedulingExpression, gomock.Any()).
+					Return(mockError)
+
+				_, err = apiClient.EnvironmentUpdateDriftDetection(environmentId, schedulingExpression)
+
+			})
+
+			It("Should fail if API call fails", func() {
+				Expect(err).To(Equal(mockError))
+			})
+		})
+	})
+	Describe("Delete", func() {
+		Describe("Success", func() {
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Do(func(path string, request interface{}, response *EnvironmentSchedulingExpression) {
+						*response = schedulingExpression
+					})
+				_ = apiClient.EnvironmentStopDriftDetection(environmentId)
+			})
+		})
+
+		Describe("Fail", func() {
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put(path, EnvironmentSchedulingExpression{Enabled: false, Cron: ""}, gomock.Any()).
+					Return(mockError)
+
+				err = apiClient.EnvironmentStopDriftDetection(environmentId)
+
+			})
+
+			It("Should fail if API call fails", func() {
+				Expect(err).To(Equal(mockError))
+			})
+		})
+	})
+
+})

--- a/client/model.go
+++ b/client/model.go
@@ -392,8 +392,8 @@ type PolicyUpdatePayload struct {
 }
 
 type EnvironmentSchedulingExpression struct {
-	Cron    string `json:"cron"`
-	Enabled bool   `json:"enabled,omitempty"`
+	Cron    string `json:"cron,omitempty"`
+	Enabled bool   `json:"enabled"`
 }
 
 type EnvironmentScheduling struct {

--- a/client/model.go
+++ b/client/model.go
@@ -393,7 +393,7 @@ type PolicyUpdatePayload struct {
 
 type EnvironmentSchedulingExpression struct {
 	Cron    string `json:"cron"`
-	Enabled bool   `json:"enabled"`
+	Enabled bool   `json:"enabled,omitempty"`
 }
 
 type EnvironmentScheduling struct {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We want to add drift detection support for our terraform provider
for that, we first need to add API client support

### Solution
add client support :)
