### PR TITLE
Chore: filter deleted Templates from data

### DIFF
--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -170,7 +170,7 @@ func getTemplateByName(name interface{}, meta interface{}) (client.Template, dia
 
 	var templatesByName []client.Template
 	for _, candidate := range templates {
-		if candidate.Name == name {
+		if candidate.Name == name && !candidate.IsDeleted {
 			templatesByName = append(templatesByName, candidate)
 		}
 	}

--- a/env0/data_template_test.go
+++ b/env0/data_template_test.go
@@ -78,7 +78,7 @@ func TestUnitTemplateData(t *testing.T) {
 		runUnitTest(t,
 			getValidTestCase(map[string]interface{}{"name": template.Name}),
 			func(mock *client.MockApiClientInterface) {
-				mock.EXPECT().Templates().AnyTimes().Return([]client.Template{template}, nil)
+				mock.EXPECT().Templates().AnyTimes().Return([]client.Template{template, deletedTemplate}, nil)
 			})
 	})
 }

--- a/env0/data_template_test.go
+++ b/env0/data_template_test.go
@@ -73,6 +73,8 @@ func TestUnitTemplateData(t *testing.T) {
 	})
 
 	t.Run("Template By Name", func(t *testing.T) {
+		deletedTemplate := template
+		deletedTemplate.IsDeleted = true
 		runUnitTest(t,
 			getValidTestCase(map[string]interface{}{"name": template.Name}),
 			func(mock *client.MockApiClientInterface) {

--- a/tests/integration/004_template/expected_outputs.json
+++ b/tests/integration/004_template/expected_outputs.json
@@ -1,6 +1,6 @@
 {
     "tested2_template_type": "terraform",
-    "tested2_template_name": "tested1",
+    "tested2_template_name": "tested1-",
     "tested2_template_repository": "https://github.com/env0/templates",
     "tested1_template_repository": "https://gitlab.com/env0/gitlab-vcs-integration-tests.git",
     "tested2_template_path": "second"

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -61,12 +61,12 @@ resource "env0_configuration_variable" "in_a_template2" {
 data "env0_template" "tested2" {
   depends_on = [
   env0_template.tested1]
-  name = "tested1"
+  name = "tested1-${random_string.random.result}"
 }
 data "env0_template" "tested1" {
   depends_on = [
   env0_template.tested2]
-  name = "GitLab Test"
+  name = "GitLab Test-${random_string.random.result}"
 }
 output "tested2_template_id" {
   value = data.env0_template.tested2.id
@@ -75,7 +75,7 @@ output "tested2_template_type" {
   value = data.env0_template.tested2.type
 }
 output "tested2_template_name" {
-  value = data.env0_template.tested2.name
+  value = replace(data.env0_template.tested2.name, random_string.random.result, "")
 }
 output "tested2_template_repository" {
   value = data.env0_template.tested2.repository

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -1,3 +1,11 @@
+provider "random" {}
+
+resource "random_string" "random" {
+  length = 8
+  special = false
+  min_lower = 8
+}
+
 # Github Integration must be done manually - so we expect an existing Github Template with this name -
 # It must be for https://github.com/env0/templates - We validate that in the outputs
 data "env0_template" "github_template" {
@@ -11,7 +19,7 @@ data "env0_template" "gitlab_template" {
 }
 
 resource "env0_template" "tested1" {
-  name                                    = "tested1"
+  name                                    = "tested1-${random_string.random.result}"
   description                             = "Tested 1 description"
   type                                    = "terraform"
   repository                              = data.env0_template.github_template.repository
@@ -24,7 +32,7 @@ resource "env0_template" "tested1" {
 }
 
 resource "env0_template" "tested2" {
-  name                                    = "GitLab Test"
+  name                                    = "GitLab Test-${random_string.random.result}"
   description                             = "Tested 2 description - Gitlab"
   type                                    = "terraform"
   repository                              = data.env0_template.gitlab_template.repository


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We still get errors on multiple templates with the same name, this is because we don't filter out deleted templates.

### Solution

- add it.
- append random string to template name for concurrency.