### PR TITLE
Chore: fix docs generation updating PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Docs
 
 on:
   push:
+    branches:
+      - main
 
 env:
   GO_VERSION: 1.16

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.ENV0_BOT_PAT }}
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ go generate ./...
 
 ## Release
 To release a version to the [Terraform Public Registry](https://registry.terraform.io/providers/env0/env0/latest?pollNotifications=true) -
-1. Create and push a tag **locally**, in semver format - `git tag v0.0.9 && git push origin --tags`
-2. New release with binaries **will be automatically generated** by the GitHub action defined in `.github/workflows/release.yml`.
-3. The Registry will automatically pick up on the new version.
+1. Validate that all status checks are ✅ on `main` branch (specifically that docs generation is complete)
+2. Create and push a tag **locally**, in semver format - `git tag v0.0.9 && git push origin --tags`
+3. New release with binaries **will be automatically generated** by the GitHub action defined in `.github/workflows/release.yml`.
+4. The Registry will automatically pick up on the new version.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ go generate ./...
 ## Release
 To release a version to the [Terraform Public Registry](https://registry.terraform.io/providers/env0/env0/latest?pollNotifications=true) -
 1. Validate that all status checks are ✅ on `main` branch (specifically that docs generation is complete)
-2. Create and push a tag **locally**, in semver format - `git tag v0.0.9 && git push origin --tags`
-3. New release with binaries **will be automatically generated** by the GitHub action defined in `.github/workflows/release.yml`.
-4. The Registry will automatically pick up on the new version.
+2. Pull from remote first - `git pull origin main`
+3. Create and push a tag **locally**, in semver format - `git tag v0.0.9 && git push origin --tags`
+4. New release with binaries **will be automatically generated** by the GitHub action defined in `.github/workflows/release.yml`.
+5. The Registry will automatically pick up on the new version.


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
After #267 was merged, now docs generation runs on every push and pushes another commit in case docs has been generated. This might become disturbing sometimes.

### Solution
1. Run only on push to `main`
2. Use env0's bot PAT so there'd be some face on the pushed commit
3. Add note on README to validate docs has been generated before releasing
4. Removed docs generation as required status checks for PRs