### PR TITLE
Feat: implement notification assignments for http client

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -73,6 +73,8 @@ type ApiClientInterface interface {
 	NotificationCreate(payload NotificationCreatePayload) (*Notification, error)
 	NotificationDelete(id string) error
 	NotificationUpdate(id string, payload NotificationUpdatePayload) (*Notification, error)
+	NotificationProjectAssignments(projectId string) ([]NotificationProjectAssignment, error)
+	NotificationProjectAssignmentUpdate(projectId string, endpointId string, payload NotificationProjectAssignmentUpdatePayload) (*NotificationProjectAssignment, error)
 	ModuleCreate(payload ModuleCreatePayload) (*Module, error)
 	Module(id string) (*Module, error)
 	ModuleDelete(id string) error

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -537,6 +537,36 @@ func (mr *MockApiClientInterfaceMockRecorder) NotificationDelete(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotificationDelete", reflect.TypeOf((*MockApiClientInterface)(nil).NotificationDelete), arg0)
 }
 
+// NotificationProjectAssignmentUpdate mocks base method.
+func (m *MockApiClientInterface) NotificationProjectAssignmentUpdate(arg0, arg1 string, arg2 NotificationProjectAssignmentUpdatePayload) (*NotificationProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotificationProjectAssignmentUpdate", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*NotificationProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NotificationProjectAssignmentUpdate indicates an expected call of NotificationProjectAssignmentUpdate.
+func (mr *MockApiClientInterfaceMockRecorder) NotificationProjectAssignmentUpdate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotificationProjectAssignmentUpdate", reflect.TypeOf((*MockApiClientInterface)(nil).NotificationProjectAssignmentUpdate), arg0, arg1, arg2)
+}
+
+// NotificationProjectAssignments mocks base method.
+func (m *MockApiClientInterface) NotificationProjectAssignments(arg0 string) ([]NotificationProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NotificationProjectAssignments", arg0)
+	ret0, _ := ret[0].([]NotificationProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NotificationProjectAssignments indicates an expected call of NotificationProjectAssignments.
+func (mr *MockApiClientInterfaceMockRecorder) NotificationProjectAssignments(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotificationProjectAssignments", reflect.TypeOf((*MockApiClientInterface)(nil).NotificationProjectAssignments), arg0)
+}
+
 // NotificationUpdate mocks base method.
 func (m *MockApiClientInterface) NotificationUpdate(arg0 string, arg1 NotificationUpdatePayload) (*Notification, error) {
 	m.ctrl.T.Helper()

--- a/client/model.go
+++ b/client/model.go
@@ -484,6 +484,18 @@ type NotificationUpdatePayload struct {
 	Value string           `json:"value,omitempty"`
 }
 
+type NotificationProjectAssignment struct {
+	Id                     string   `json:"id"`
+	NotificationEndpointId string   `json:"notificationEndpointId"`
+	EventNames             []string `json:"eventNames"`
+	CreatedBy              string   `json:"createdBy"`
+	CreatedByUser          User     `json:"createdByUser"`
+}
+
+type NotificationProjectAssignmentUpdatePayload struct {
+	EventNames []string `json:"eventNames"`
+}
+
 type ModuleSshKey struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`

--- a/client/notification_project_assignment.go
+++ b/client/notification_project_assignment.go
@@ -1,0 +1,20 @@
+package client
+
+import "fmt"
+
+func (ac *ApiClient) NotificationProjectAssignments(projectId string) ([]NotificationProjectAssignment, error) {
+	var result []NotificationProjectAssignment
+	if err := ac.http.Get("/notifications/projects/"+projectId, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (ac *ApiClient) NotificationProjectAssignmentUpdate(projectId string, endpointId string, payload NotificationProjectAssignmentUpdatePayload) (*NotificationProjectAssignment, error) {
+	var result NotificationProjectAssignment
+	url := fmt.Sprintf("/notifications/projects/%s/endpoints/%s", projectId, endpointId)
+	if err := ac.http.Put(url, payload, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/client/notification_project_assignment_test.go
+++ b/client/notification_project_assignment_test.go
@@ -1,0 +1,73 @@
+package client_test
+
+import (
+	. "github.com/env0/terraform-provider-env0/client"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Notification Project Assignment Client", func() {
+	projectId := "pid"
+
+	mockNotificationProjectAssignment := NotificationProjectAssignment{
+		Id:                     "id",
+		NotificationEndpointId: "nid",
+		EventNames:             []string{"name1", "name2"},
+	}
+
+	Describe("Get Notification Project Assignments", func() {
+		var returnedAssignments []NotificationProjectAssignment
+
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().
+				Get("/notifications/projects/"+projectId, gomock.Nil(), gomock.Any()).
+				Do(func(path string, request interface{}, response *[]NotificationProjectAssignment) {
+					*response = []NotificationProjectAssignment{mockNotificationProjectAssignment}
+				})
+			returnedAssignments, _ = apiClient.NotificationProjectAssignments(projectId)
+		})
+
+		It("Should send GET request", func() {
+			httpCall.Times(1)
+		})
+
+		It("Should return assignment", func() {
+			Expect(returnedAssignments).To(Equal([]NotificationProjectAssignment{mockNotificationProjectAssignment}))
+		})
+	})
+
+	Describe("Update Notification Project Assignment", func() {
+		var updatedAssignment *NotificationProjectAssignment
+		var err error
+
+		updatedMockNotificationProjectAssignment := mockNotificationProjectAssignment
+		updatedMockNotificationProjectAssignment.EventNames = []string{"name3"}
+
+		BeforeEach(func() {
+			updateAssignmentPayload := NotificationProjectAssignmentUpdatePayload{
+				EventNames: []string{"name3"},
+			}
+
+			httpCall = mockHttpClient.EXPECT().
+				Put("/notifications/projects/"+projectId+"/endpoints/"+mockNotificationProjectAssignment.Id, updateAssignmentPayload, gomock.Any()).
+				Do(func(path string, request interface{}, response *NotificationProjectAssignment) {
+					*response = updatedMockNotificationProjectAssignment
+				})
+
+			updatedAssignment, err = apiClient.NotificationProjectAssignmentUpdate(projectId, mockNotificationProjectAssignment.Id, updateAssignmentPayload)
+		})
+
+		It("Should send Put request with expected payload", func() {
+			httpCall.Times(1)
+		})
+
+		It("Should not return an error", func() {
+			Expect(err).To(BeNil())
+		})
+
+		It("Should return assignment received from API", func() {
+			Expect(*updatedAssignment).To(Equal(updatedMockNotificationProjectAssignment))
+		})
+	})
+})


### PR DESCRIPTION
### Solution

This PR adds the http client functionality for assigning notifications to projects.
Part of #280 (more PRs to follow). 