### PR TITLE
add api client and model for cost cred

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -41,10 +41,14 @@ type ApiClientInterface interface {
 	AwsCredentialsCreate(request AwsCredentialsCreatePayload) (ApiKey, error)
 	CloudCredentialsDelete(id string) error
 	GcpCredentialsCreate(request GcpCredentialsCreatePayload) (ApiKey, error)
+	GoogleCostCredentialsCreate(request GoogleCostCredentialsCreatePayload) (ApiKey, error)
 	AzureCredentialsCreate(request AzureCredentialsCreatePayload) (ApiKey, error)
 	AssignCloudCredentialsToProject(projectId string, credentialId string) (CloudCredentialsProjectAssignment, error)
 	RemoveCloudCredentialsFromProject(projectId string, credentialId string) error
 	CloudCredentialIdsInProject(projectId string) ([]string, error)
+	AssignCostCredentialsToProject(projectId string, credentialId string) (CostCredentialProjectAssignment, error)
+	CostCredentialIdsInProject(projectId string) ([]CostCredentialProjectAssignment, error)
+	RemoveCostCredentialsFromProject(projectId string, credentialId string) error
 	Team(id string) (Team, error)
 	Teams() ([]Team, error)
 	TeamCreate(payload TeamCreatePayload) (Team, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -48,6 +48,21 @@ func (mr *MockApiClientInterfaceMockRecorder) AssignCloudCredentialsToProject(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignCloudCredentialsToProject", reflect.TypeOf((*MockApiClientInterface)(nil).AssignCloudCredentialsToProject), arg0, arg1)
 }
 
+// AssignCostCredentialsToProject mocks base method.
+func (m *MockApiClientInterface) AssignCostCredentialsToProject(arg0, arg1 string) (CostCredentialProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssignCostCredentialsToProject", arg0, arg1)
+	ret0, _ := ret[0].(CostCredentialProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssignCostCredentialsToProject indicates an expected call of AssignCostCredentialsToProject.
+func (mr *MockApiClientInterfaceMockRecorder) AssignCostCredentialsToProject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignCostCredentialsToProject", reflect.TypeOf((*MockApiClientInterface)(nil).AssignCostCredentialsToProject), arg0, arg1)
+}
+
 // AssignTemplateToProject mocks base method.
 func (m *MockApiClientInterface) AssignTemplateToProject(arg0 string, arg1 TemplateAssignmentToProjectPayload) (Template, error) {
 	m.ctrl.T.Helper()
@@ -224,6 +239,21 @@ func (m *MockApiClientInterface) ConfigurationVariablesByScope(arg0 Scope, arg1 
 func (mr *MockApiClientInterfaceMockRecorder) ConfigurationVariablesByScope(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigurationVariablesByScope", reflect.TypeOf((*MockApiClientInterface)(nil).ConfigurationVariablesByScope), arg0, arg1)
+}
+
+// CostCredentialIdsInProject mocks base method.
+func (m *MockApiClientInterface) CostCredentialIdsInProject(arg0 string) ([]CostCredentialProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CostCredentialIdsInProject", arg0)
+	ret0, _ := ret[0].([]CostCredentialProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CostCredentialIdsInProject indicates an expected call of CostCredentialIdsInProject.
+func (mr *MockApiClientInterfaceMockRecorder) CostCredentialIdsInProject(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CostCredentialIdsInProject", reflect.TypeOf((*MockApiClientInterface)(nil).CostCredentialIdsInProject), arg0)
 }
 
 // Environment mocks base method.
@@ -432,6 +462,21 @@ func (m *MockApiClientInterface) GcpCredentialsCreate(arg0 GcpCredentialsCreateP
 func (mr *MockApiClientInterfaceMockRecorder) GcpCredentialsCreate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GcpCredentialsCreate", reflect.TypeOf((*MockApiClientInterface)(nil).GcpCredentialsCreate), arg0)
+}
+
+// GoogleCostCredentialsCreate mocks base method.
+func (m *MockApiClientInterface) GoogleCostCredentialsCreate(arg0 GoogleCostCredentialsCreatePayload) (ApiKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GoogleCostCredentialsCreate", arg0)
+	ret0, _ := ret[0].(ApiKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GoogleCostCredentialsCreate indicates an expected call of GoogleCostCredentialsCreate.
+func (mr *MockApiClientInterfaceMockRecorder) GoogleCostCredentialsCreate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GoogleCostCredentialsCreate", reflect.TypeOf((*MockApiClientInterface)(nil).GoogleCostCredentialsCreate), arg0)
 }
 
 // Module mocks base method.
@@ -713,6 +758,20 @@ func (m *MockApiClientInterface) RemoveCloudCredentialsFromProject(arg0, arg1 st
 func (mr *MockApiClientInterfaceMockRecorder) RemoveCloudCredentialsFromProject(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCloudCredentialsFromProject", reflect.TypeOf((*MockApiClientInterface)(nil).RemoveCloudCredentialsFromProject), arg0, arg1)
+}
+
+// RemoveCostCredentialsFromProject mocks base method.
+func (m *MockApiClientInterface) RemoveCostCredentialsFromProject(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveCostCredentialsFromProject", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveCostCredentialsFromProject indicates an expected call of RemoveCostCredentialsFromProject.
+func (mr *MockApiClientInterfaceMockRecorder) RemoveCostCredentialsFromProject(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveCostCredentialsFromProject", reflect.TypeOf((*MockApiClientInterface)(nil).RemoveCostCredentialsFromProject), arg0, arg1)
 }
 
 // RemoveTemplateFromProject mocks base method.

--- a/client/cloud_credentials.go
+++ b/client/cloud_credentials.go
@@ -85,3 +85,18 @@ func (self *ApiClient) AzureCredentialsCreate(request AzureCredentialsCreatePayl
 func (self *ApiClient) CloudCredentialsDelete(id string) error {
 	return self.http.Delete("/credentials/" + id)
 }
+
+func (self *ApiClient) GoogleCostCredentialsCreate(request GoogleCostCredentialsCreatePayload) (ApiKey, error) {
+	organizationId, err := self.organizationId()
+	if err != nil {
+		return ApiKey{}, err
+	}
+
+	request.OrganizationId = organizationId
+	var result ApiKey
+	err = self.http.Post("/credentials", request, &result)
+	if err != nil {
+		return ApiKey{}, err
+	}
+	return result, nil
+}

--- a/client/cloud_credentials_test.go
+++ b/client/cloud_credentials_test.go
@@ -10,6 +10,14 @@ import (
 var _ = Describe("CloudCredentials", func() {
 	const credentialsName = "credential_test"
 	var apiKey ApiKey
+
+	mockApiKeyForGoogleCostCred := ApiKey{
+		Id:             "id1",
+		Name:           "key1",
+		OrganizationId: organizationId,
+		Type:           "GCP_CREDENTIALS",
+	}
+
 	mockApiKey := ApiKey{
 		Id:             "id1",
 		Name:           "key1",
@@ -25,6 +33,47 @@ var _ = Describe("CloudCredentials", func() {
 	}
 
 	keys := []ApiKey{mockApiKey, mockApiKeySecond}
+
+	Describe("GoogleCostCredentialsCreate", func() {
+		BeforeEach(func() {
+			mockOrganizationIdCall(organizationId)
+
+			payloadValue := GoogleCostCredentialsValeuPayload{
+				TableId: "table",
+				Secret:  "secret",
+			}
+
+			httpCall = mockHttpClient.EXPECT().
+				Post("/credentials", GoogleCostCredentialsCreatePayload{
+					Name:           credentialsName,
+					OrganizationId: organizationId,
+					Type:           "GCP_CREDENTIALS",
+					Value:          payloadValue,
+				},
+					gomock.Any()).
+				Do(func(path string, request interface{}, response *ApiKey) {
+					*response = mockApiKeyForGoogleCostCred
+				})
+
+			apiKey, _ = apiClient.GoogleCostCredentialsCreate(GoogleCostCredentialsCreatePayload{
+				Name:  credentialsName,
+				Value: payloadValue,
+				Type:  "GCP_CREDENTIALS",
+			})
+		})
+
+		It("Should get organization id", func() {
+			organizationIdCall.Times(1)
+		})
+
+		It("Should send POST request with params", func() {
+			httpCall.Times(1)
+		})
+
+		It("Should return key", func() {
+			Expect(apiKey).To(Equal(mockApiKeyForGoogleCostCred))
+		})
+	})
 
 	Describe("AwsCredentialsCreate", func() {
 		BeforeEach(func() {

--- a/client/cost_credentials_project_assignment.go
+++ b/client/cost_credentials_project_assignment.go
@@ -1,0 +1,25 @@
+package client
+
+func (self *ApiClient) AssignCostCredentialsToProject(projectId string, credentialId string) (CostCredentialProjectAssignment, error) {
+	var result CostCredentialProjectAssignment
+
+	err := self.http.Put("/costs/project/"+projectId+"/credentials", credentialId, &result)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (self *ApiClient) RemoveCostCredentialsFromProject(projectId string, credentialId string) error {
+	return self.http.Delete("/costs/project/" + projectId + "/credentials/" + credentialId)
+}
+
+func (self *ApiClient) CostCredentialIdsInProject(projectId string) ([]CostCredentialProjectAssignment, error) {
+	var result []CostCredentialProjectAssignment
+	err := self.http.Get("/costs/project/"+projectId, nil, &result)
+
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/client/cost_credentials_project_assignment_test.go
+++ b/client/cost_credentials_project_assignment_test.go
@@ -1,0 +1,127 @@
+package client_test
+
+import (
+	"errors"
+
+	. "github.com/env0/terraform-provider-env0/client"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe(" Cost Credentials Project Assignment", func() {
+	projectId := "projectId"
+	credentialId := "credentialId"
+
+	Describe("AssignCostCredentialsToProject", func() {
+		expectedResponse := CostCredentialProjectAssignment{
+			ProjectId:       "assigment id",
+			CredentialsId:   "credentialId",
+			CredentialsType: "GCP_CREDENTIALS",
+		}
+		Describe("Successful", func() {
+			var actualResult CostCredentialProjectAssignment
+			BeforeEach(func() {
+
+				httpCall = mockHttpClient.EXPECT().
+					Put("/costs/project/"+projectId+"/credentials", credentialId, gomock.Any()).
+					Do(func(path string, request interface{}, response *CostCredentialProjectAssignment) {
+						*response = expectedResponse
+					}).Times(1)
+				actualResult, _ = apiClient.AssignCostCredentialsToProject(projectId, credentialId)
+
+			})
+
+			It("should return the PUT result", func() {
+				Expect(actualResult).To(Equal(expectedResponse))
+			})
+		})
+		Describe("On Error", func() {
+			errorInfo := "error"
+			var actualError error
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put("/costs/project/"+projectId+"/credentials", credentialId, gomock.Any()).
+					Return(errors.New(errorInfo)).
+					Times(1)
+				_, actualError = apiClient.AssignCostCredentialsToProject(projectId, credentialId)
+
+			})
+
+			It("should return the error from the api call", func() {
+				Expect(actualError).ShouldNot(BeNil())
+				Expect(actualError.Error()).Should(Equal(errorInfo))
+			})
+		})
+	})
+
+	Describe("RemoveCostCredentialsFromProject", func() {
+		errorInfo := "error"
+		var actualError error
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().
+				Delete("/costs/project/" + projectId + "/credentials/" + credentialId).
+				Return(errors.New(errorInfo)).
+				Times(1)
+			actualError = apiClient.RemoveCostCredentialsFromProject(projectId, credentialId)
+
+		})
+
+		It("should return the error from the api call", func() {
+			Expect(actualError).ShouldNot(BeNil())
+			Expect(actualError.Error()).Should(Equal(errorInfo))
+		})
+	})
+
+	Describe("CostCredentialIdsInProject", func() {
+		Describe("Successful", func() {
+
+			var actualResult []CostCredentialProjectAssignment
+
+			firstResulteResponse := CostCredentialProjectAssignment{
+				ProjectId:       "assigment id",
+				CredentialsId:   "credentialId",
+				CredentialsType: "GCP_CREDENTIALS",
+			}
+
+			secondResulteResponse := CostCredentialProjectAssignment{
+				ProjectId:       "assigment id",
+				CredentialsId:   "credentialId-2",
+				CredentialsType: "GCP_CREDENTIALS",
+			}
+
+			expectedResponse := []CostCredentialProjectAssignment{firstResulteResponse, secondResulteResponse}
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get("/costs/project/"+projectId, nil, gomock.Any()).
+					Do(func(path string, request interface{}, response *[]CostCredentialProjectAssignment) {
+						*response = expectedResponse
+					}).Times(1)
+				actualResult, _ = apiClient.CostCredentialIdsInProject(projectId)
+
+			})
+
+			It("should return the GET result", func() {
+				Expect(actualResult).To(Equal(expectedResponse))
+			})
+		})
+		Describe("On Error", func() {
+			errorInfo := "error"
+			var actualError error
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get("/costs/project/"+projectId, nil, gomock.Any()).
+					Return(errors.New(errorInfo)).
+					Times(1)
+				_, actualError = apiClient.CostCredentialIdsInProject(projectId)
+
+			})
+
+			It("should return the error from the api call", func() {
+				Expect(actualError).ShouldNot(BeNil())
+				Expect(actualError.Error()).Should(Equal(errorInfo))
+			})
+		})
+
+	})
+})

--- a/client/model.go
+++ b/client/model.go
@@ -249,6 +249,12 @@ type CloudCredentialsProjectAssignment struct {
 	ProjectId    string `json:"projectId"`
 }
 
+type CostCredentialProjectAssignment struct {
+	ProjectId       string `json:"projectId"`
+	CredentialsId   string `json:"credentialsId"`
+	CredentialsType string `json:"credentialsType"`
+}
+
 type Template struct {
 	Author               User             `json:"author"`
 	AuthorId             string           `json:"authorId"`
@@ -325,6 +331,9 @@ type GcpCredentialsType string
 type AzureCredentialsType string
 
 const (
+	GoogleCostCredentiassType            GcpCredentialsType   = "GCP_CREDENTIALS"
+	AzureCostCredentialsType             AzureCredentialsType = "AZURE_CREDENTIALS"
+	AwsCostCredentialsType               AwsCredentialsType   = "AWS_ASSUMED_ROLE"
 	AwsAssumedRoleCredentialsType        AwsCredentialsType   = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 	AwsAccessKeysCredentialsType         AwsCredentialsType   = "AWS_ACCESS_KEYS_FOR_DEPLOYMENT"
 	GcpServiceAccountCredentialsType     GcpCredentialsType   = "GCP_SERVICE_ACCOUNT_FOR_DEPLOYMENT"
@@ -362,6 +371,18 @@ type AwsCredentialsValuePayload struct {
 type GcpCredentialsValuePayload struct {
 	ProjectId         string `json:"projectId"`
 	ServiceAccountKey string `json:"serviceAccountKey"`
+}
+
+type GoogleCostCredentialsValeuPayload struct {
+	TableId string `json:"tableid"`
+	Secret  string `json:"secret"`
+}
+
+type GoogleCostCredentialsCreatePayload struct {
+	Name           string                            `json:"name"`
+	OrganizationId string                            `json:"organizationId"`
+	Type           GcpCredentialsType                `json:"type"`
+	Value          GoogleCostCredentialsValeuPayload `json:"value"`
 }
 
 type AzureCredentialsValuePayload struct {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
This PR is part of other PRs when  combined fix #218 
fixes #218 
### Solution
This PR is part of the solution for adding cost cred resources and cost assignment to project

1. - add to model structs supporting those resources 
2. - add API call to `cloud_credentials ` for google cost credentials
3. - add file `cost_credentials_project_assignment` to client for APIs calls
4. - add to `api-client` the relevant function mentioned in 2,3
