### PR TITLE
Fix: handle drift in configuration variables

### DIFF
--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -199,6 +201,13 @@ func resourceConfigurationVariableRead(ctx context.Context, d *schema.ResourceDa
 	variable, err := apiClient.ConfigurationVariablesById(id)
 
 	if err != nil {
+		if frerr, ok := err.(*http.FailedResponseError); ok {
+			if frerr.NotFound() {
+				log.Printf("[WARN] Drift Detected: Terraform will remove %s from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
 		return diag.Errorf("could not get configurationVariable: %v", err)
 	}
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #278 

### Solution
If 404 is returned sets the configuration id to an empty string.
Added a test for the use case.

