### PR TITLE
Fix: handle drift in all resources

### DIFF
--- a/env0/resource_aws_credentials.go
+++ b/env0/resource_aws_credentials.go
@@ -2,7 +2,10 @@ package env0
 
 import (
 	"context"
+	"log"
+
 	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -100,6 +103,11 @@ func resourceAwsCredentialsRead(ctx context.Context, d *schema.ResourceData, met
 	id := d.Id()
 	_, err := apiClient.CloudCredentials(id)
 	if err != nil {
+		if frerr, ok := err.(*http.FailedResponseError); ok && frerr.NotFound() {
+			log.Printf("[WARN] Drift Detected: Terraform will remove %s from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("could not get credentials: %v", err)
 	}
 	return nil

--- a/env0/resource_azure_credentials.go
+++ b/env0/resource_azure_credentials.go
@@ -2,7 +2,10 @@ package env0
 
 import (
 	"context"
+	"log"
+
 	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -81,6 +84,11 @@ func resourceAzureCredentialsRead(ctx context.Context, d *schema.ResourceData, m
 	id := d.Id()
 	_, err := apiClient.CloudCredentials(id)
 	if err != nil {
+		if frerr, ok := err.(*http.FailedResponseError); ok && frerr.NotFound() {
+			log.Printf("[WARN] Drift Detected: Terraform will remove %s from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("could not get credentials: %v", err)
 	}
 	return nil

--- a/env0/resource_azure_credentials_test.go
+++ b/env0/resource_azure_credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -147,4 +148,29 @@ func TestUnitAzureCredentialsResource(t *testing.T) {
 		}
 	})
 
+	t.Run("Azure credentials removed in UI", func(t *testing.T) {
+		stepConfig := resourceConfigCreate(resourceType, resourceName, azureCredentialResource)
+
+		createTestCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: stepConfig,
+				},
+				{
+					Config: stepConfig,
+				},
+			},
+		}
+
+		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AzureCredentialsCreate(azureCredCreatePayload).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, http.NewMockFailedResponseError(404)),
+				mock.EXPECT().AzureCredentialsCreate(azureCredCreatePayload).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
 }

--- a/env0/resource_gcp_credentials.go
+++ b/env0/resource_gcp_credentials.go
@@ -2,7 +2,10 @@ package env0
 
 import (
 	"context"
+	"log"
+
 	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -68,6 +71,11 @@ func resourceGcpCredentialsRead(ctx context.Context, d *schema.ResourceData, met
 	id := d.Id()
 	_, err := apiClient.CloudCredentials(id)
 	if err != nil {
+		if frerr, ok := err.(*http.FailedResponseError); ok && frerr.NotFound() {
+			log.Printf("[WARN] Drift Detected: Terraform will remove %s from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.Errorf("could not get credentials: %v", err)
 	}
 	return nil


### PR DESCRIPTION
### Solution

Added drift handling for AWS, Azure, and GCP credentials resources.
Part of #284.