### PR TITLE
Chore: Fix terragrunt integration test

### DIFF
--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -46,7 +46,7 @@ resource "env0_template" "tested2" {
 }
 
 resource "env0_template" "template_tg" {
-  name               = "Template for environment resource - tg"
+  name               = "Template for environment resource - tg-${random_string.random.result}"
   type               = "terragrunt"
   repository         = "https://github.com/env0/templates"
   path               = "terragrunt/misc/null-resource"
@@ -80,7 +80,7 @@ data "env0_template" "tested1" {
 data "env0_template" "template_tg" {
   depends_on = [
   env0_template.template_tg]
-  name = "Template for environment resource - tg"
+  name = "Template for environment resource - tg-${random_string.random.result}"
 }
 
 output "tested2_template_id" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We get multiple templates (terragrunt) with same name error in our IT.
the tests sometimes can have a destruction failure, or can have a race condition when same tests run concurrently.
### Solution
add random string to the template name.
