### PR TITLE
Fix: handle drift in all resources

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -34,7 +34,7 @@ type ApiClientInterface interface {
 	AssignTemplateToProject(id string, payload TemplateAssignmentToProjectPayload) (Template, error)
 	RemoveTemplateFromProject(templateId string, projectId string) error
 	SshKeys() ([]SshKey, error)
-	SshKeyCreate(payload SshKeyCreatePayload) (SshKey, error)
+	SshKeyCreate(payload SshKeyCreatePayload) (*SshKey, error)
 	SshKeyDelete(id string) error
 	CloudCredentials(id string) (Credentials, error)
 	CloudCredentialsList() ([]Credentials, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -922,10 +922,10 @@ func (mr *MockApiClientInterfaceMockRecorder) RemoveTemplateFromProject(arg0, ar
 }
 
 // SshKeyCreate mocks base method.
-func (m *MockApiClientInterface) SshKeyCreate(arg0 SshKeyCreatePayload) (SshKey, error) {
+func (m *MockApiClientInterface) SshKeyCreate(arg0 SshKeyCreatePayload) (*SshKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SshKeyCreate", arg0)
-	ret0, _ := ret[0].(SshKey)
+	ret0, _ := ret[0].(*SshKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/client/sshkey.go
+++ b/client/sshkey.go
@@ -1,31 +1,17 @@
 package client
 
-import (
-	"errors"
-)
-
-func (self *ApiClient) SshKeyCreate(payload SshKeyCreatePayload) (SshKey, error) {
-	if payload.Name == "" {
-		return SshKey{}, errors.New("Must specify ssh key name on creation")
-	}
-	if payload.Value == "" {
-		return SshKey{}, errors.New("Must specify ssh key value (private key in PEM format) on creation")
-	}
-	if payload.OrganizationId != "" {
-		return SshKey{}, errors.New("Must not specify organizationId")
-	}
+func (self *ApiClient) SshKeyCreate(payload SshKeyCreatePayload) (*SshKey, error) {
 	organizationId, err := self.organizationId()
 	if err != nil {
-		return SshKey{}, nil
+		return nil, err
 	}
 	payload.OrganizationId = organizationId
 
 	var result SshKey
-	err = self.http.Post("/ssh-keys", payload, &result)
-	if err != nil {
-		return SshKey{}, err
+	if err := self.http.Post("/ssh-keys", payload, &result); err != nil {
+		return nil, err
 	}
-	return result, nil
+	return &result, nil
 }
 
 func (self *ApiClient) SshKeyDelete(id string) error {

--- a/client/sshkey_test.go
+++ b/client/sshkey_test.go
@@ -18,7 +18,8 @@ var _ = Describe("SshKey", func() {
 	}
 
 	Describe("SshKeyCreate", func() {
-		var sshKey SshKey
+		var sshKey *SshKey
+
 		BeforeEach(func() {
 			mockOrganizationIdCall(organizationId)
 			expectedPayload := SshKeyCreatePayload{Name: sshKeyName, Value: sshKeyValue, OrganizationId: organizationId}
@@ -40,7 +41,7 @@ var _ = Describe("SshKey", func() {
 		})
 
 		It("Should return project", func() {
-			Expect(sshKey).To(Equal(mockSshKey))
+			Expect(*sshKey).To(Equal(mockSshKey))
 		})
 	})
 

--- a/env0/resource_sshkey_test.go
+++ b/env0/resource_sshkey_test.go
@@ -1,40 +1,76 @@
 package env0
 
 import (
-	"github.com/env0/terraform-provider-env0/client"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestUnitSshKeyResource(t *testing.T) {
 	resourceType := "env0_ssh_key"
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)
-	sshKey := client.SshKey{
+	sshKey := &client.SshKey{
 		Id:    "id0",
 		Name:  "name0",
 		Value: "Key🔑",
 	}
-
-	testCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"name":  sshKey.Name,
-					"value": sshKey.Value,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "id", sshKey.Id),
-					resource.TestCheckResourceAttr(accessor, "name", sshKey.Name),
-					resource.TestCheckResourceAttr(accessor, "value", sshKey.Value),
-				),
-			},
-		},
+	sshKeyCreatePayload := client.SshKeyCreatePayload{
+		Name:  sshKey.Name,
+		Value: sshKey.Value,
 	}
+	t.Run("Success", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":  sshKey.Name,
+						"value": sshKey.Value,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", sshKey.Id),
+						resource.TestCheckResourceAttr(accessor, "name", sshKey.Name),
+						resource.TestCheckResourceAttr(accessor, "value", sshKey.Value),
+					),
+				},
+			},
+		}
 
-	runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().SshKeyCreate(client.SshKeyCreatePayload{Name: sshKey.Name, Value: sshKey.Value}).Times(1).Return(sshKey, nil)
-		mock.EXPECT().SshKeys().Times(1).Return([]client.SshKey{sshKey}, nil)
-		mock.EXPECT().SshKeyDelete(sshKey.Id).Times(1).Return(nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().SshKeyCreate(sshKeyCreatePayload).Times(1).Return(sshKey, nil)
+			mock.EXPECT().SshKeys().Times(1).Return([]client.SshKey{*sshKey}, nil)
+			mock.EXPECT().SshKeyDelete(sshKey.Id).Times(1).Return(nil)
+		})
+	})
+
+	t.Run("SSH Key removed in UI", func(t *testing.T) {
+		stepConfig := resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+			"name":  sshKey.Name,
+			"value": sshKey.Value,
+		})
+
+		createTestCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: stepConfig,
+				},
+				{
+					Config: stepConfig,
+				},
+			},
+		}
+
+		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().SshKeyCreate(sshKeyCreatePayload).Times(1).Return(sshKey, nil),
+				mock.EXPECT().SshKeys().Times(1).Return([]client.SshKey{*sshKey}, nil),
+				mock.EXPECT().SshKeys().Times(1).Return(nil, nil),
+				mock.EXPECT().SshKeyCreate(sshKeyCreatePayload).Times(1).Return(sshKey, nil),
+				mock.EXPECT().SshKeys().Times(1).Return([]client.SshKey{*sshKey}, nil),
+				mock.EXPECT().SshKeyDelete(sshKey.Id).Times(1).Return(nil),
+			)
+		})
 	})
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #284 

### Solution
Some refactoring in ssh key resource, data and client.
Detects drift for sshkey and resets the id, instead of returning an error.
