### PR TITLE
Fix template integration tests `data` flakiness

### DIFF
--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -1,8 +1,8 @@
 provider "random" {}
 
 resource "random_string" "random" {
-  length = 8
-  special = false
+  length    = 8
+  special   = false
   min_lower = 8
 }
 
@@ -69,21 +69,21 @@ resource "env0_configuration_variable" "in_a_template2" {
 
 # Temporary - Sleep to avoid eventual consistency issues with the data sources
 resource "time_sleep" "wait_for_all_templates" {
-  depends_on = [env0_template.tested1, env0_template.tested2, env0_template.template_tg]
+  depends_on      = [env0_template.tested1, env0_template.tested2, env0_template.template_tg]
   create_duration = "2s"
 }
 
 data "env0_template" "tested2" {
   depends_on = [time_sleep.wait_for_all_templates]
-  name = "tested1-${random_string.random.result}"
+  name       = "tested1-${random_string.random.result}"
 }
 data "env0_template" "tested1" {
   depends_on = [time_sleep.wait_for_all_templates]
-  name = "GitLab Test-${random_string.random.result}"
+  name       = "GitLab Test-${random_string.random.result}"
 }
 data "env0_template" "template_tg" {
   depends_on = [time_sleep.wait_for_all_templates]
-  name = "Template for environment resource - tg-${random_string.random.result}"
+  name       = "Template for environment resource - tg-${random_string.random.result}"
 }
 
 output "tested2_template_id" {

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -67,19 +67,30 @@ resource "env0_configuration_variable" "in_a_template2" {
   type        = "terraform"
 }
 
+# Temporary - Sleep to avoid eventual consistency issues with the data sources
+resource "time_sleep" "wait_for_tested1" {
+  depends_on = [env0_template.tested1]
+  create_duration = "2s"
+}
+resource "time_sleep" "wait_for_tested2" {
+  depends_on = [env0_template.tested2]
+  create_duration = "2s"
+}
+resource "time_sleep" "wait_for_template_tg" {
+  depends_on = [env0_template.template_tg]
+  create_duration = "2s"
+}
+
 data "env0_template" "tested2" {
-  depends_on = [
-  env0_template.tested1]
+  depends_on = [time_sleep.wait_for_tested2]
   name = "tested1-${random_string.random.result}"
 }
 data "env0_template" "tested1" {
-  depends_on = [
-  env0_template.tested2]
+  depends_on = [time_sleep.wait_for_tested1]
   name = "GitLab Test-${random_string.random.result}"
 }
 data "env0_template" "template_tg" {
-  depends_on = [
-  env0_template.template_tg]
+  depends_on = [time_sleep.wait_for_template_tg]
   name = "Template for environment resource - tg-${random_string.random.result}"
 }
 

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -70,6 +70,10 @@ resource "env0_configuration_variable" "in_a_template2" {
 # Temporary - Sleep to avoid eventual consistency issues with the data sources
 resource "time_sleep" "wait_for_all_templates" {
   depends_on      = [env0_template.tested1, env0_template.tested2, env0_template.template_tg]
+  triggers = {
+      # Only using depends_on doesn't work on re-apply. This makes sure the sleep happens on re-apply
+      second_run = var.second_run
+    }
   create_duration = "2s"
 }
 

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -68,29 +68,21 @@ resource "env0_configuration_variable" "in_a_template2" {
 }
 
 # Temporary - Sleep to avoid eventual consistency issues with the data sources
-resource "time_sleep" "wait_for_tested1" {
-  depends_on = [env0_template.tested1]
-  create_duration = "2s"
-}
-resource "time_sleep" "wait_for_tested2" {
-  depends_on = [env0_template.tested2]
-  create_duration = "2s"
-}
-resource "time_sleep" "wait_for_template_tg" {
-  depends_on = [env0_template.template_tg]
+resource "time_sleep" "wait_for_all_templates" {
+  depends_on = [env0_template.tested1, env0_template.tested2, env0_template.template_tg]
   create_duration = "2s"
 }
 
 data "env0_template" "tested2" {
-  depends_on = [time_sleep.wait_for_tested2]
+  depends_on = [time_sleep.wait_for_all_templates]
   name = "tested1-${random_string.random.result}"
 }
 data "env0_template" "tested1" {
-  depends_on = [time_sleep.wait_for_tested1]
+  depends_on = [time_sleep.wait_for_all_templates]
   name = "GitLab Test-${random_string.random.result}"
 }
 data "env0_template" "template_tg" {
-  depends_on = [time_sleep.wait_for_template_tg]
+  depends_on = [time_sleep.wait_for_all_templates]
   name = "Template for environment resource - tg-${random_string.random.result}"
 }
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
`004` tests are flaky, the `data` source is called immediately after the resource is created

### Solution
Wait a few seconds before calling the `data` source, using `time_sleep` resource
