### PR TITLE
Chore: Increase wait time in `env0_template` data test

### DIFF
--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -74,7 +74,7 @@ resource "time_sleep" "wait_for_all_templates" {
       # Only using depends_on doesn't work on re-apply. This makes sure the sleep happens on re-apply
       second_run = var.second_run
     }
-  create_duration = "2s"
+  create_duration = "10s"
 }
 
 data "env0_template" "tested2" {

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -74,7 +74,7 @@ resource "time_sleep" "wait_for_all_templates" {
       # Only using depends_on doesn't work on re-apply. This makes sure the sleep happens on re-apply
       second_run = var.second_run
     }
-  create_duration = "10s"
+  create_duration = "5s"
 }
 
 data "env0_template" "tested2" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Harness tests still timeout from time to time, even after introducing sleep in https://github.com/env0/terraform-provider-env0/pull/312

### Solution
For now, raise the sleep time to ensure data consistency
