### PR TITLE
Fix: deprecate environment_id field

### DIFF
--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -66,6 +66,7 @@ func resourceConfigurationVariable() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"template_id", "project_id", "is_required", "is_read_only"},
 				ForceNew:      true,
+				Deprecated:    "use \"configuration\" field in the environment resource instead. for more details check https://registry.terraform.io/providers/env0/env0/latest/docs/resources/environment#nested-schema-for-configuration",
 			},
 			"type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
### Solution

This does not solve the issue (I will keep the issue open and un-assign it from myself).
Instead, I deprecated the environment_id field.

```
Terraform will perform the following actions:

  # env0_configuration_variable.issue will be created
  + resource "env0_configuration_variable" "issue" {
      + environment_id = "4d60cf52-847d-49f3-a018-4f74ecee5dc8"
      + id             = (known after apply)
      + is_read_only   = false
      + is_required    = false
      + is_sensitive   = false
      + name           = "POOOOO"
      + type           = "environment"
      + value          = (sensitive value)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: Attribute is deprecated
│ 
│   with env0_configuration_variable.issue,
│   on main.tf line 52, in resource "env0_configuration_variable" "issue":
│   52:   environment_id = env0_environment.example.id
│ 
│ use "configuration" field in the environment resource instead. for more details check
│ https://registry.terraform.io/providers/env0/env0/latest/docs/resources/environment#nested-schema-for-configuration
```
