### PR TITLE
Fix: env0_environment (Data Source) does not work when just the name …

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -97,11 +97,24 @@ func (Environment) getEndpoint() string {
 }
 
 func (client *ApiClient) Environments() ([]Environment, error) {
-	return getAll(client, nil)
+	organizationId, err := client.organizationId()
+	if err != nil {
+		return nil, err
+	}
+
+	return getAll(client, map[string]string{
+		"organizationId": organizationId,
+		"isActive":       "true",
+		"onlyMy":         "false",
+	})
 }
 
 func (client *ApiClient) ProjectEnvironments(projectId string) ([]Environment, error) {
-	return getAll(client, map[string]string{"projectId": projectId})
+	return getAll(client, map[string]string{
+		"projectId": projectId,
+		"isActive":  "true",
+		"onlyMy":    "false",
+	})
 }
 
 func (client *ApiClient) Environment(id string) (Environment, error) {

--- a/client/environment.go
+++ b/client/environment.go
@@ -104,16 +104,12 @@ func (client *ApiClient) Environments() ([]Environment, error) {
 
 	return getAll(client, map[string]string{
 		"organizationId": organizationId,
-		"isActive":       "true",
-		"onlyMy":         "false",
 	})
 }
 
 func (client *ApiClient) ProjectEnvironments(projectId string) ([]Environment, error) {
 	return getAll(client, map[string]string{
 		"projectId": projectId,
-		"isActive":  "true",
-		"onlyMy":    "false",
 	})
 }
 

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -30,6 +30,8 @@ var _ = Describe("Environment Client", func() {
 
 		Describe("Success", func() {
 			BeforeEach(func() {
+				mockOrganizationIdCall(organizationId)
+
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", gomock.Any(), gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
@@ -59,10 +61,15 @@ var _ = Describe("Environment Client", func() {
 			}
 
 			BeforeEach(func() {
+				mockOrganizationIdCall(organizationId)
+
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", map[string]string{
-						"offset": "0",
-						"limit":  "100",
+						"offset":         "0",
+						"limit":          "100",
+						"onlyMy":         "false",
+						"isActive":       "true",
+						"organizationId": organizationId,
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP1
@@ -70,8 +77,11 @@ var _ = Describe("Environment Client", func() {
 
 				httpCall2 = mockHttpClient.EXPECT().
 					Get("/environments", map[string]string{
-						"offset": "100",
-						"limit":  "100",
+						"offset":         "100",
+						"limit":          "100",
+						"onlyMy":         "false",
+						"isActive":       "true",
+						"organizationId": organizationId,
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP2
@@ -97,11 +107,15 @@ var _ = Describe("Environment Client", func() {
 			}
 
 			BeforeEach(func() {
+				mockOrganizationIdCall(organizationId)
+
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", map[string]string{
 						"offset":    "0",
 						"limit":     "100",
 						"projectId": projectId,
+						"onlyMy":    "false",
+						"isActive":  "true",
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP1
@@ -112,6 +126,8 @@ var _ = Describe("Environment Client", func() {
 						"offset":    "100",
 						"limit":     "100",
 						"projectId": projectId,
+						"onlyMy":    "false",
+						"isActive":  "true",
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP2
@@ -128,6 +144,9 @@ var _ = Describe("Environment Client", func() {
 		Describe("Failure", func() {
 			It("On error from server return the error", func() {
 				expectedErr := errors.New("some error")
+
+				mockOrganizationIdCall(organizationId)
+
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", gomock.Any(), gomock.Any()).
 					Return(expectedErr)

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Environment Client", func() {
 		Describe("Success", func() {
 			BeforeEach(func() {
 				mockOrganizationIdCall(organizationId)
-
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", gomock.Any(), gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
@@ -62,7 +61,6 @@ var _ = Describe("Environment Client", func() {
 
 			BeforeEach(func() {
 				mockOrganizationIdCall(organizationId)
-
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", map[string]string{
 						"offset":         "0",
@@ -107,8 +105,6 @@ var _ = Describe("Environment Client", func() {
 			}
 
 			BeforeEach(func() {
-				mockOrganizationIdCall(organizationId)
-
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", map[string]string{
 						"offset":    "0",
@@ -144,9 +140,7 @@ var _ = Describe("Environment Client", func() {
 		Describe("Failure", func() {
 			It("On error from server return the error", func() {
 				expectedErr := errors.New("some error")
-
 				mockOrganizationIdCall(organizationId)
-
 				httpCall = mockHttpClient.EXPECT().
 					Get("/environments", gomock.Any(), gomock.Any()).
 					Return(expectedErr)

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -65,8 +65,6 @@ var _ = Describe("Environment Client", func() {
 					Get("/environments", map[string]string{
 						"offset":         "0",
 						"limit":          "100",
-						"onlyMy":         "false",
-						"isActive":       "true",
 						"organizationId": organizationId,
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
@@ -77,8 +75,6 @@ var _ = Describe("Environment Client", func() {
 					Get("/environments", map[string]string{
 						"offset":         "100",
 						"limit":          "100",
-						"onlyMy":         "false",
-						"isActive":       "true",
 						"organizationId": organizationId,
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
@@ -110,8 +106,6 @@ var _ = Describe("Environment Client", func() {
 						"offset":    "0",
 						"limit":     "100",
 						"projectId": projectId,
-						"onlyMy":    "false",
-						"isActive":  "true",
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP1
@@ -122,8 +116,6 @@ var _ = Describe("Environment Client", func() {
 						"offset":    "100",
 						"limit":     "100",
 						"projectId": projectId,
-						"onlyMy":    "false",
-						"isActive":  "true",
 					}, gomock.Any()).
 					Do(func(path string, request interface{}, response *[]Environment) {
 						*response = environmentsP2


### PR DESCRIPTION
…is passed

### Issue & Steps to Reproduce / Feature Request
fixes #357 

### Solution
Modified the /environments call to add the new fields.
