### PR TITLE
Fix: env0_aws_credentials - apply after import will delete+create

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ Check [resource_module.go](./env0/resource_module.go) that uses the utilities vs
 
 Pay attention to the following caveats:
 * The utilities leverage golang reflection. And work well for most simple types. Complex types may need additional code to be implemented.
-* The golang fields are in CamalCase, while the terraform fields are in snake_case. They must match. E.g., ProjectName (golang) == project_name (Terraform).
+* The golang fields are in CamalCase, while the terraform fields are in snake_case. They must match. E.g., ProjectName (golang) == project_name (Terraform). To override the default CamalCase to snake_case conversion you may use the tag `tfschema`.
 
 ### Handling drifts
 

--- a/client/cloud_credentials.go
+++ b/client/cloud_credentials.go
@@ -33,7 +33,7 @@ type AwsCredentialsCreatePayload struct {
 }
 
 type AwsCredentialsValuePayload struct {
-	RoleArn         string `json:"roleArn" resource:"arn"`
+	RoleArn         string `json:"roleArn" tfschema:"arn"`
 	ExternalId      string `json:"externalId"`
 	AccessKeyId     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`

--- a/client/cloud_credentials.go
+++ b/client/cloud_credentials.go
@@ -1,9 +1,5 @@
 package client
 
-import (
-	"fmt"
-)
-
 type AwsCredentialsType string
 type GcpCredentialsType string
 type AzureCredentialsType string
@@ -37,7 +33,7 @@ type AwsCredentialsCreatePayload struct {
 }
 
 type AwsCredentialsValuePayload struct {
-	RoleArn         string `json:"roleArn"`
+	RoleArn         string `json:"roleArn" resource:"arn"`
 	ExternalId      string `json:"externalId"`
 	AccessKeyId     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
@@ -89,7 +85,7 @@ func (client *ApiClient) CloudCredentials(id string) (Credentials, error) {
 		}
 	}
 
-	return Credentials{}, fmt.Errorf("CloudCredentials: [%s] not found ", id)
+	return Credentials{}, &NotFoundError{}
 }
 
 func (client *ApiClient) CloudCredentialsList() ([]Credentials, error) {

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,7 @@
+package client
+
+type NotFoundError struct{}
+
+func (e *NotFoundError) Error() string {
+	return "not found"
+}

--- a/env0/credentials.go
+++ b/env0/credentials.go
@@ -1,0 +1,47 @@
+package env0
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/google/uuid"
+)
+
+func getCredentialsByName(name string, prefix string, meta interface{}) (client.Credentials, error) {
+	apiClient := meta.(client.ApiClientInterface)
+
+	credentialsList, err := apiClient.CloudCredentialsList()
+	if err != nil {
+		return client.Credentials{}, err
+	}
+
+	var foundCredentials []client.Credentials
+	for _, credentials := range credentialsList {
+		if credentials.Name == name && strings.HasPrefix(credentials.Type, prefix) {
+			foundCredentials = append(foundCredentials, credentials)
+		}
+	}
+
+	if len(foundCredentials) == 0 {
+		return client.Credentials{}, fmt.Errorf("credentials with name %v not found", name)
+	}
+
+	if len(foundCredentials) > 1 {
+		return client.Credentials{}, fmt.Errorf("found multiple credentials with name: %s. Use id instead or make sure credential names are unique %v", name, foundCredentials)
+	}
+
+	return foundCredentials[0], nil
+}
+
+func getCredentials(id string, prefix string, meta interface{}) (client.Credentials, error) {
+	_, err := uuid.Parse(id)
+	if err == nil {
+		log.Println("[INFO] Resolving credentials by id: ", id)
+		return meta.(client.ApiClientInterface).CloudCredentials(id)
+	} else {
+		log.Println("[INFO] Resolving credentials by name: ", id)
+		return getCredentialsByName(id, prefix, meta)
+	}
+}

--- a/env0/data_notification.go
+++ b/env0/data_notification.go
@@ -61,7 +61,7 @@ func dataNotificationRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := writeResourceData(notification, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil

--- a/env0/resource_agent_project_assignment.go
+++ b/env0/resource_agent_project_assignment.go
@@ -118,7 +118,7 @@ func resourceAgentProjectAssignmentRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if err := writeResourceData(assignment, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil
@@ -189,7 +189,7 @@ func resourceAgentProjectAssignmentImport(ctx context.Context, d *schema.Resourc
 	}
 
 	if err := writeResourceData(assignment, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_api_key.go
+++ b/env0/resource_api_key.go
@@ -60,7 +60,7 @@ func resourceApiKeyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err := writeResourceData(apiKey, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func resourceApiKeyImport(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := writeResourceData(apiKey, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_aws_credentials.go
+++ b/env0/resource_aws_credentials.go
@@ -107,8 +107,9 @@ func resourceAwsCredentialsRead(ctx context.Context, d *schema.ResourceData, met
 		return ResourceGetFailure("aws credentials", d, err)
 	}
 
-	d.Set("name", credentials.Name)
-	d.SetId(credentials.Id)
+	if err := writeResourceData(&credentials, d); err != nil {
+		return diag.Errorf("schema resource data serialization failed: %v", err)
+	}
 
 	return nil
 }
@@ -133,8 +134,9 @@ func resourceAwsCredentialsImport(ctx context.Context, d *schema.ResourceData, m
 		return nil, err
 	}
 
-	d.Set("name", credentials.Name)
-	d.SetId(credentials.Id)
+	if err := writeResourceData(&credentials, d); err != nil {
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/env0/resource_git_token.go
+++ b/env0/resource_git_token.go
@@ -64,7 +64,7 @@ func resourceGitTokenRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := writeResourceData(gitToken, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil
@@ -124,7 +124,7 @@ func resourceGitTokenImport(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if err := writeResourceData(gitToken, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_module.go
+++ b/env0/resource_module.go
@@ -117,7 +117,7 @@ func resourceModuleRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if err := writeResourceData(module, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil
@@ -192,7 +192,7 @@ func resourceModuleImport(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := writeResourceData(module, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_notification.go
+++ b/env0/resource_notification.go
@@ -121,7 +121,7 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if err := writeResourceData(notification, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil
@@ -175,7 +175,7 @@ func resourceNotificationImport(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if err := writeResourceData(notification, d); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_notification_project_assignment.go
+++ b/env0/resource_notification_project_assignment.go
@@ -114,7 +114,7 @@ func resourceNotificationProjectAssignmentRead(ctx context.Context, d *schema.Re
 	}
 
 	if err := writeResourceData(assignment, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil

--- a/env0/resource_organization_policy.go
+++ b/env0/resource_organization_policy.go
@@ -59,7 +59,7 @@ func resourceOrganizationPolicyRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if err := writeResourceData(&organization, d); err != nil {
-		diag.Errorf("schema resource data serialization failed: %v", err)
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
 	return nil

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -42,9 +42,9 @@ func readResourceData(i interface{}, d *schema.ResourceData) error {
 	for i := 0; i < val.NumField(); i++ {
 		fieldName := val.Type().Field(i).Name
 		// Assumes golang is CamalCase and Terraform is snake_case.
-		// This behavior can be overrided be used in the 'resource' tag.
+		// This behavior can be overrided be used in the 'tfschema' tag.
 		fieldNameSC := toSnakeCase(fieldName)
-		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("resource"); ok {
+		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("tfschema"); ok {
 			// 'resource' tag found. Override to tag value.
 			fieldNameSC = resFieldName
 		}
@@ -107,9 +107,9 @@ func writeResourceData(i interface{}, d *schema.ResourceData) error {
 	for i := 0; i < val.NumField(); i++ {
 		fieldName := val.Type().Field(i).Name
 		// Assumes golang is CamalCase and Terraform is snake_case.
-		// This behavior can be overrided be used in the 'resource' tag.
+		// This behavior can be overrided be used in the 'tfschema' tag.
 		fieldNameSC := toSnakeCase(fieldName)
-		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("resource"); ok {
+		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("tfschema"); ok {
 			// 'resource' tag found. Override to tag value.
 			fieldNameSC = resFieldName
 		}

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -42,7 +42,13 @@ func readResourceData(i interface{}, d *schema.ResourceData) error {
 	for i := 0; i < val.NumField(); i++ {
 		fieldName := val.Type().Field(i).Name
 		// Assumes golang is CamalCase and Terraform is snake_case.
+		// This behavior can be overrided be used in the 'resource' tag.
 		fieldNameSC := toSnakeCase(fieldName)
+		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("resource"); ok {
+			// 'resource' tag found. Override to tag value.
+			fieldNameSC = resFieldName
+		}
+
 		field := val.Field(i)
 		fieldType := field.Type()
 
@@ -101,7 +107,13 @@ func writeResourceData(i interface{}, d *schema.ResourceData) error {
 	for i := 0; i < val.NumField(); i++ {
 		fieldName := val.Type().Field(i).Name
 		// Assumes golang is CamalCase and Terraform is snake_case.
+		// This behavior can be overrided be used in the 'resource' tag.
 		fieldNameSC := toSnakeCase(fieldName)
+		if resFieldName, ok := val.Type().Field(i).Tag.Lookup("resource"); ok {
+			// 'resource' tag found. Override to tag value.
+			fieldNameSC = resFieldName
+		}
+
 		field := val.Field(i)
 		fieldType := field.Type()
 

--- a/env0/utils_test.go
+++ b/env0/utils_test.go
@@ -91,6 +91,24 @@ func TestReadResourceDataNotification(t *testing.T) {
 	assert.Equal(t, expectedPayload, payload)
 }
 
+func TestReadResourceDataWithTag(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAwsCredentials().Schema, map[string]interface{}{
+		"name":        "name",
+		"arn":         "tagged_arn",
+		"external_id": "external_id",
+	})
+
+	expectedPayload := client.AwsCredentialsValuePayload{
+		RoleArn:    "tagged_arn",
+		ExternalId: "external_id",
+	}
+
+	var payload client.AwsCredentialsValuePayload
+
+	assert.Nil(t, readResourceData(&payload, d))
+	assert.Equal(t, expectedPayload, payload)
+}
+
 func TestWriteResourceDataNotification(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceNotification().Schema, map[string]interface{}{})
 

--- a/examples/resources/env0_aws_credentials/import.sh
+++ b/examples/resources/env0_aws_credentials/import.sh
@@ -1,0 +1,2 @@
+terraform import env0_aws_credentials.by_id d31a6b30-5f69-4d24-937c-22322754934e
+terraform import env0_aws_credentials.by_name "credentials name"


### PR DESCRIPTION
I'm keeping open, to adding support for other credential types.

### Solution
Added import.
Removed a schema requirements and instead enforce during read.
Added acceptance tests.
Added a "resource" tag.
Added import examples.
Fixed some other issues I noticed.
