### PR TITLE
Fix: env0_azure_credentials - apply after import will delete+create

### DIFF
--- a/examples/resources/env0_azure_credentials/import.sh
+++ b/examples/resources/env0_azure_credentials/import.sh
@@ -1,0 +1,2 @@
+terraform import env0_azure_credentials.by_id d31a6b30-5f69-4d24-937c-22322754934e
+terraform import env0_azure_credentials.by_name "credentials name"


### PR DESCRIPTION
Part of a larger effort to add import to all credentials types.
This one is for Azure (AWS complete and GCP pending).

### Solution
1. Fixed some bugs.
2. Added import functionality.
3. Added acceptance testing.
4. Added examples for import.
