### PR TITLE
Fix: add random string to notification names to prevent name collision

### DIFF
--- a/tests/integration/017_notification/main.tf
+++ b/tests/integration/017_notification/main.tf
@@ -1,11 +1,15 @@
+resource "random_string" "random_name" {
+  length = 20
+}
+
 resource "env0_notification" "test_notification" {
-  name  = var.second_run ? "Test-some-other-name" : "Test-Notification"
+  name  = var.second_run ? "Test-some-other-name ${random_string.random_name.result}" : "Test-Notification ${random_string.random_name.result}"
   type  = var.second_run ? "Slack" : "Teams"
   value = var.second_run ? "https://someotherurl.com" : "https://someurl.com"
 }
 
 resource "env0_project" "test_project" {
-  name        = "Test-Project-For-Notification"
+  name        = "Test-Project-For-Notification ${random_string.random_name.result}"
   description = "Test Description"
 }
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)

when running the integration tests ALOT the destroy take some time or sometimes failed which causes a flaky for the next run
### Solution

add a random string to notification names to prevent name collision 