### PR TITLE
Fix: env0_gcp_credentials - apply after import will delete+create

### DIFF
--- a/env0/resource_gcp_credentials.go
+++ b/env0/resource_gcp_credentials.go
@@ -2,6 +2,7 @@ package env0
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -13,6 +14,8 @@ func resourceGcpCredentials() *schema.Resource {
 		CreateContext: resourceGcpCredentialsCreate,
 		ReadContext:   resourceGcpCredentialsRead,
 		DeleteContext: resourceGcpCredentialsDelete,
+
+		Importer: &schema.ResourceImporter{StateContext: resourceGcpCredentialsImport},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -40,12 +43,13 @@ func resourceGcpCredentials() *schema.Resource {
 }
 
 func resourceGcpCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	value := client.GcpCredentialsValuePayload{}
+	if err := readResourceData(&value, d); err != nil {
+		return diag.Errorf("schema resource data deserialization failed: %v", err)
+	}
+
 	apiClient := meta.(client.ApiClientInterface)
 
-	value := client.GcpCredentialsValuePayload{
-		ProjectId:         d.Get("project_id").(string),
-		ServiceAccountKey: d.Get("service_account_key").(string),
-	}
 	requestType := client.GcpServiceAccountCredentialsType
 
 	request := client.GcpCredentialsCreatePayload{
@@ -53,6 +57,7 @@ func resourceGcpCredentialsCreate(ctx context.Context, d *schema.ResourceData, m
 		Value: value,
 		Type:  requestType,
 	}
+
 	credentials, err := apiClient.GcpCredentialsCreate(request)
 	if err != nil {
 		return diag.Errorf("could not create credentials key: %v", err)
@@ -67,10 +72,15 @@ func resourceGcpCredentialsRead(ctx context.Context, d *schema.ResourceData, met
 	apiClient := meta.(client.ApiClientInterface)
 
 	id := d.Id()
-	_, err := apiClient.CloudCredentials(id)
+	credentials, err := apiClient.CloudCredentials(id)
 	if err != nil {
 		return ResourceGetFailure("gcp credentials", d, err)
 	}
+
+	if err := writeResourceData(&credentials, d); err != nil {
+		return diag.Errorf("schema resource data serialization failed: %v", err)
+	}
+
 	return nil
 }
 
@@ -83,4 +93,20 @@ func resourceGcpCredentialsDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("could not delete credentials: %v", err)
 	}
 	return nil
+}
+
+func resourceGcpCredentialsImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	credentials, err := getCredentials(d.Id(), "GCP_", meta)
+	if err != nil {
+		if _, ok := err.(*client.NotFoundError); ok {
+			return nil, fmt.Errorf("gcp credentials resource with id %v not found", d.Id())
+		}
+		return nil, err
+	}
+
+	if err := writeResourceData(&credentials, d); err != nil {
+		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/examples/resources/env0_gcp_credentials/import.sh
+++ b/examples/resources/env0_gcp_credentials/import.sh
@@ -1,0 +1,2 @@
+terraform import env0_gcp_credentials.by_id d31a6b30-5f69-4d24-937c-22322754934e
+terraform import env0_gcp_credentials.by_name "credentials name"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #99 
The last part of the effort to add import to all credential types (Azure and AWS is complete).

### Solution
1. Added import.
2. Fixed some bugs.
3. Added acceptance tests.
4. Added examples.

