### PR TITLE
Feat: support Non-Admin API key creation

### DIFF
--- a/client/api_key.go
+++ b/client/api_key.go
@@ -13,8 +13,13 @@ type ApiKey struct {
 	CreatedByUser    User   `json:"createdByUser"`
 }
 
+type ApiKeyPermissions struct {
+	OrganizationRole string `json:"organizationRole"`
+}
+
 type ApiKeyCreatePayload struct {
-	Name string `json:"name"`
+	Name        string            `json:"name"`
+	Permissions ApiKeyPermissions `json:"permissions"`
 }
 
 type ApiKeyCreatePayloadWith struct {

--- a/env0/resource_api_key.go
+++ b/env0/resource_api_key.go
@@ -28,7 +28,7 @@ func resourceApiKey() *schema.Resource {
 			},
 			"organization_role": {
 				Type:             schema.TypeString,
-				Description:      "the api key type. 'Admin' or 'User'. If not set defaults to 'Admin'. For more details check https://docs.env0.com/docs/api-keys",
+				Description:      "the api key type. 'Admin' or 'User'. Defaults to 'Admin'. For more details check https://docs.env0.com/docs/api-keys",
 				Default:          "Admin",
 				Optional:         true,
 				ForceNew:         true,
@@ -45,6 +45,9 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := readResourceData(&payload, d); err != nil {
 		return diag.Errorf("schema resource data deserialization failed: %v", err)
 	}
+
+	organizationRole := d.Get("organization_role").(string)
+	payload.Permissions.OrganizationRole = organizationRole
 
 	apiKey, err := apiClient.ApiKeyCreate(payload)
 	if err != nil {

--- a/tests/integration/020_api_key/main.tf
+++ b/tests/integration/020_api_key/main.tf
@@ -10,6 +10,11 @@ resource "env0_api_key" "test_api_key" {
   name = "my-little-api-key-${random_string.random.result}"
 }
 
+resource "env0_api_key" "test_user_api_key" {
+  name = "my-little-user-api-key-${random_string.random.result}"
+  organization_role = "User"
+}
+
 data "env0_api_key" "test_api_key1" {
   name       = env0_api_key.test_api_key.name
   depends_on = [env0_api_key.test_api_key]


### PR DESCRIPTION
### Solution

Updated the creation call.
Added some integration and acceptance tests for "User" permissions.
Part of #405 