### PR TITLE
Chore: use generics in pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,12 @@ jobs:
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-20.04
-    container: hashicorp/terraform:1.1.6
+    container: golang:1.18-alpine3.16
     timeout-minutes: 20
     steps:
-      - name: Install Go
-        run: apk add go
+      - name: Install Terraform
+        run: apk add terraform
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Harness tests
         run: go run tests/harness.go

--- a/client/pagination.go
+++ b/client/pagination.go
@@ -9,11 +9,8 @@ type Pagination struct {
 	params map[string]string
 }
 
-// Note: all the FIXME should be uncommented when Alpine adds support for go 1.18.
-// This will enable generics.
-
 type Paginated interface {
-	// FIXME: Environment
+	Environment
 	getEndpoint() string
 }
 
@@ -31,15 +28,13 @@ func (p *Pagination) next(currentPageSize int) bool {
 }
 
 // params - additional params. may be nil.
-// FIXME: func getAll[P Paginated](client *ApiClient, params map[string]string) ([]P, error) {
-func getAll(client *ApiClient, params map[string]string) ([]Environment, error) {
+func getAll[P Paginated](client *ApiClient, params map[string]string) ([]P, error) {
 	p := Pagination{
 		offset: 0,
 		params: params,
 	}
 
-	// FIXME: var allResults []P
-	var allResults []Environment
+	var allResults []P
 
 	for {
 		pageParams := p.getParams()
@@ -47,11 +42,9 @@ func getAll(client *ApiClient, params map[string]string) ([]Environment, error) 
 			pageParams[k] = v
 		}
 
-		// FIXME: var pageResults []P
-		var pageResults []Environment
+		var pageResults []P
 
-		// FIXME: err := client.http.Get(P{}.getEndpoint(), pageParams, &pageResults)
-		err := client.http.Get(Environment{}.getEndpoint(), pageParams, &pageResults)
+		err := client.http.Get(P{}.getEndpoint(), pageParams, &pageResults)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
closes #415

### Solution

Harness was running in go1.17 because the terraform docker image was using golang 1.17.
Switched to using a go1.18 docker image and installed terraform via `apk`.

Making this change allows me to use generics (A new feature in go1.18).