### PR TITLE
Chore: better environment force_destroy docs

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -64,7 +64,7 @@ resource "env0_environment" "example_with_hcl_configuration" {
 - **auto_deploy_on_path_changes_only** (Boolean) redeploy only on path changes only
 - **configuration** (Block List) terraform and environment variables for the environment (see [below for nested schema](#nestedblock--configuration))
 - **deploy_on_push** (Boolean) should run terraform deploy on push events
-- **force_destroy** (Boolean) Destroy safeguard. Must be enabled before delete/destroy
+- **force_destroy** (Boolean) destroy safegurad
 - **id** (String) the environment's id
 - **revision** (String) the revision the environment is to be run against
 - **run_plan_on_pull_requests** (Boolean) should run terraform plan on pull requests creations

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -64,7 +64,7 @@ resource "env0_environment" "example_with_hcl_configuration" {
 - **auto_deploy_on_path_changes_only** (Boolean) redeploy only on path changes only
 - **configuration** (Block List) terraform and environment variables for the environment (see [below for nested schema](#nestedblock--configuration))
 - **deploy_on_push** (Boolean) should run terraform deploy on push events
-- **force_destroy** (Boolean) destroy safegurad
+- **force_destroy** (Boolean) Destroy safeguard. Must be enabled before delete/destroy
 - **id** (String) the environment's id
 - **revision** (String) the revision the environment is to be run against
 - **run_plan_on_pull_requests** (Boolean) should run terraform plan on pull requests creations

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -110,7 +110,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"force_destroy": {
 				Type:        schema.TypeBool,
-				Description: "destroy safegurad",
+				Description: "Destroy safeguard. Must be enabled before delete/destroy",
 				Optional:    true,
 			},
 			"wait_for": {
@@ -538,6 +538,7 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		if isRedeploy {
 			configurationChanges = getUpdateConfigurationVariables(configurationChanges, d.Get("id").(string), apiClient)
 		}
+		// todo debug configuration changes
 		payload.ConfigurationChanges = &configurationChanges
 	}
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -538,7 +538,6 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		if isRedeploy {
 			configurationChanges = getUpdateConfigurationVariables(configurationChanges, d.Get("id").(string), apiClient)
 		}
-		// todo debug configuration changes
 		payload.ConfigurationChanges = &configurationChanges
 	}
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[Imri](https://env0.slack.com/archives/C02HV2EBTE3/p1655381933596409) from ActiveFence was trying to destroy an environment by deleting it from the code, he didn't know he has to set `force_destroy` before, he suggested documenting that.

### Solution
Add it to the docs
