### PR TITLE
Feat: support Non-Admin API key creation

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -97,6 +97,8 @@ type ApiClientInterface interface {
 	Users() ([]OrganizationUser, error)
 	AssignUserToProject(projectId string, payload *AssignUserToProjectPayload) (*UserProjectAssignment, error)
 	RemoveUserFromProject(projectId string, userId string) error
+	UserProjectAssignments(projectId string) ([]UserProjectAssignment, error)
+	UpdateUserProjectAssignment(projectId string, userId string, payload *UpdateUserProjectAssignmentPayload) (*UserProjectAssignment, error)
 }
 
 func NewApiClient(client http.HttpClientInterface) ApiClientInterface {

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -1216,6 +1216,36 @@ func (mr *MockApiClientInterfaceMockRecorder) Templates() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Templates", reflect.TypeOf((*MockApiClientInterface)(nil).Templates))
 }
 
+// UpdateUserProjectAssignment mocks base method.
+func (m *MockApiClientInterface) UpdateUserProjectAssignment(arg0, arg1 string, arg2 *UpdateUserProjectAssignmentPayload) (*UserProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserProjectAssignment", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*UserProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserProjectAssignment indicates an expected call of UpdateUserProjectAssignment.
+func (mr *MockApiClientInterfaceMockRecorder) UpdateUserProjectAssignment(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserProjectAssignment", reflect.TypeOf((*MockApiClientInterface)(nil).UpdateUserProjectAssignment), arg0, arg1, arg2)
+}
+
+// UserProjectAssignments mocks base method.
+func (m *MockApiClientInterface) UserProjectAssignments(arg0 string) ([]UserProjectAssignment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserProjectAssignments", arg0)
+	ret0, _ := ret[0].([]UserProjectAssignment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UserProjectAssignments indicates an expected call of UserProjectAssignments.
+func (mr *MockApiClientInterfaceMockRecorder) UserProjectAssignments(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserProjectAssignments", reflect.TypeOf((*MockApiClientInterface)(nil).UserProjectAssignments), arg0)
+}
+
 // Users mocks base method.
 func (m *MockApiClientInterface) Users() ([]OrganizationUser, error) {
 	m.ctrl.T.Helper()

--- a/client/user_project_assignment.go
+++ b/client/user_project_assignment.go
@@ -5,20 +5,46 @@ type AssignUserToProjectPayload struct {
 	Role   Role   `json:"role"`
 }
 
+type UpdateUserProjectAssignmentPayload struct {
+	Role Role `json:"role"`
+}
+
 type UserProjectAssignment struct {
-	Id string `json:"id"`
+	UserId string `json:"userId"`
+	Role   Role   `json:"role"`
+	Id     string `json:"id"`
 }
 
 func (client *ApiClient) AssignUserToProject(projectId string, payload *AssignUserToProjectPayload) (*UserProjectAssignment, error) {
 	var result UserProjectAssignment
 
-	err := client.http.Post("/permissions/projects/"+projectId, payload, &result)
-	if err != nil {
+	if err := client.http.Post("/permissions/projects/"+projectId, payload, &result); err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
 func (client *ApiClient) RemoveUserFromProject(projectId string, userId string) error {
 	return client.http.Delete("/permissions/projects/" + projectId + "/users/" + userId)
+}
+
+func (client *ApiClient) UpdateUserProjectAssignment(projectId string, userId string, payload *UpdateUserProjectAssignmentPayload) (*UserProjectAssignment, error) {
+	var result UserProjectAssignment
+
+	if err := client.http.Put("/permissions/projects/"+projectId+"/users/"+userId, payload, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (client *ApiClient) UserProjectAssignments(projectId string) ([]UserProjectAssignment, error) {
+	var result []UserProjectAssignment
+
+	if err := client.http.Get("/permissions/projects/"+projectId, nil, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/client/user_project_assignment_test.go
+++ b/client/user_project_assignment_test.go
@@ -83,4 +83,53 @@ var _ = Describe("Agent Project Assignment", func() {
 		})
 	})
 
+	Describe("UserProjectAssignments", func() {
+
+		Describe("Successful", func() {
+			var actualResult []UserProjectAssignment
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get("/permissions/projects/"+projectId, nil, gomock.Any()).
+					Do(func(path string, request interface{}, response *[]UserProjectAssignment) {
+						*response = []UserProjectAssignment{*expectedResponse}
+					}).Times(1)
+				actualResult, err = apiClient.UserProjectAssignments(projectId)
+
+			})
+
+			It("Should send GET request with params", func() {
+				httpCall.Times(1)
+			})
+
+			It("should return the GET result", func() {
+				Expect(actualResult).To(Equal([]UserProjectAssignment{*expectedResponse}))
+			})
+
+			It("Should not return error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Describe("Failure", func() {
+			var actualResult []UserProjectAssignment
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Get("/permissions/projects/"+projectId, nil, gomock.Any()).Return(errorMock)
+				actualResult, err = apiClient.UserProjectAssignments(projectId)
+			})
+
+			It("Should fail if API call fails", func() {
+				Expect(err).To(Equal(errorMock))
+			})
+
+			It("Should not return results", func() {
+				Expect(actualResult).To(BeNil())
+			})
+		})
+	})
+
 })

--- a/client/user_project_assignment_test.go
+++ b/client/user_project_assignment_test.go
@@ -11,10 +11,15 @@ import (
 
 var _ = Describe("Agent Project Assignment", func() {
 	projectId := "projectId"
+	userId := "userId"
 
 	assignPayload := &AssignUserToProjectPayload{
-		UserId: "userId",
+		UserId: userId,
 		Role:   Admin,
+	}
+
+	updatePayload := &UpdateUserProjectAssignmentPayload{
+		Role: Admin,
 	}
 
 	expectedResponse := &UserProjectAssignment{
@@ -120,6 +125,55 @@ var _ = Describe("Agent Project Assignment", func() {
 				httpCall = mockHttpClient.EXPECT().
 					Get("/permissions/projects/"+projectId, nil, gomock.Any()).Return(errorMock)
 				actualResult, err = apiClient.UserProjectAssignments(projectId)
+			})
+
+			It("Should fail if API call fails", func() {
+				Expect(err).To(Equal(errorMock))
+			})
+
+			It("Should not return results", func() {
+				Expect(actualResult).To(BeNil())
+			})
+		})
+	})
+
+	Describe("UpdateUserProjectAssignment", func() {
+
+		Describe("Successful", func() {
+			var actualResult *UserProjectAssignment
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put("/permissions/projects/"+projectId+"/users/"+userId, updatePayload, gomock.Any()).
+					Do(func(path string, request interface{}, response *UserProjectAssignment) {
+						*response = *expectedResponse
+					}).Times(1)
+				actualResult, err = apiClient.UpdateUserProjectAssignment(projectId, userId, updatePayload)
+
+			})
+
+			It("Should send PUT request with params", func() {
+				httpCall.Times(1)
+			})
+
+			It("should return the PUT result", func() {
+				Expect(*actualResult).To(Equal(*expectedResponse))
+			})
+
+			It("Should not return error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Describe("Failure", func() {
+			var actualResult *UserProjectAssignment
+			var err error
+
+			BeforeEach(func() {
+				httpCall = mockHttpClient.EXPECT().
+					Put("/permissions/projects/"+projectId+"/users/"+userId, gomock.Any(), gomock.Any()).Return(errorMock)
+				actualResult, err = apiClient.UpdateUserProjectAssignment(projectId, userId, updatePayload)
 			})
 
 			It("Should fail if API call fails", func() {

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -104,6 +104,7 @@ func Provider(version string) plugin.ProviderFunc {
 				"env0_organization_policy":                  resourceOrganizationPolicy(),
 				"env0_agent_project_assignment":             resourceAgentProjectAssignment(),
 				"env0_user_team_assignment":                 resourceUserTeamAssignment(),
+				"env0_user_project_assignment":              resourceUserProjectAssignment(),
 			},
 		}
 

--- a/env0/resource_team_project_assignment.go
+++ b/env0/resource_team_project_assignment.go
@@ -2,7 +2,6 @@ package env0
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/env0/terraform-provider-env0/client"
@@ -31,20 +30,10 @@ func resourceTeamProjectAssignment() *schema.Resource {
 				ForceNew:    true,
 			},
 			"role": {
-				Type:        schema.TypeString,
-				Description: "the assigned role (Admin, Planner, Viewer, Deployer)",
-				Required:    true,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					role := client.Role(val.(string))
-					if role == "" ||
-						role != client.Admin &&
-							role != client.Deployer &&
-							role != client.Viewer &&
-							role != client.Planner {
-						errs = append(errs, fmt.Errorf("%v must be one of [Admin, Deployer, Viewer, Planner], got: %v", key, role))
-					}
-					return
-				},
+				Type:             schema.TypeString,
+				Description:      "the assigned role (Admin, Planner, Viewer, Deployer)",
+				Required:         true,
+				ValidateDiagFunc: ValidateRole,
 			},
 		},
 	}

--- a/env0/resource_user_project_assignment.go
+++ b/env0/resource_user_project_assignment.go
@@ -1,0 +1,116 @@
+package env0
+
+import (
+	"context"
+	"log"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceUserProjectAssignment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserProjectAssignmentCreate,
+		UpdateContext: resourceUserProjectAssignmentUpdate,
+		ReadContext:   resourceUserProjectAssignmentRead,
+		DeleteContext: resourceUserProjectAssignmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Description: `id of the user. Note: can also be an id of a "User" API key`,
+				Required:    true,
+				ForceNew:    true,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Description: "id of the project",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"role": {
+				Type:             schema.TypeString,
+				Description:      "the assigned role (Admin, Planner, Viewer, Deployer)",
+				Required:         true,
+				ValidateDiagFunc: ValidateRole,
+			},
+		},
+	}
+}
+
+func resourceUserProjectAssignmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var newAssignment client.AssignUserToProjectPayload
+	if err := readResourceData(&newAssignment, d); err != nil {
+		return diag.Errorf("schema resource data deserialization failed: %v", err)
+	}
+
+	projectId := d.Get("project_id").(string)
+
+	apiClient := meta.(client.ApiClientInterface)
+
+	assignment, err := apiClient.AssignUserToProject(projectId, &newAssignment)
+	if err != nil {
+		return diag.Errorf("could not create assignment: %v", err)
+	}
+
+	d.SetId(assignment.Id)
+
+	return nil
+}
+
+func resourceUserProjectAssignmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	apiClient := meta.(client.ApiClientInterface)
+
+	id := d.Id()
+	projectId := d.Get("project_id").(string)
+
+	assignments, err := apiClient.UserProjectAssignments(projectId)
+	if err != nil {
+		return diag.Errorf("could not get UserProjectAssignments: %v", err)
+	}
+
+	for _, assignment := range assignments {
+		if assignment.Id == id {
+			if err := writeResourceData(&assignment, d); err != nil {
+				return diag.Errorf("schema resource data serialization failed: %v", err)
+			}
+			return nil
+		}
+	}
+
+	log.Printf("[WARN] Drift Detected: Terraform will remove %s from state", d.Id())
+	d.SetId("")
+
+	return nil
+}
+
+func resourceUserProjectAssignmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	projectId := d.Get("project_id").(string)
+	userId := d.Get("user_id").(string)
+
+	var payload client.UpdateUserProjectAssignmentPayload
+	if err := readResourceData(&payload, d); err != nil {
+		return diag.Errorf("schema resource data deserialization failed: %v", err)
+	}
+
+	apiClient := meta.(client.ApiClientInterface)
+	if _, err := apiClient.UpdateUserProjectAssignment(projectId, userId, &payload); err != nil {
+		return diag.Errorf("could not update role for UserProjectAssignment: %v", err)
+	}
+
+	return nil
+}
+
+func resourceUserProjectAssignmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	projectId := d.Get("project_id").(string)
+	userId := d.Get("user_id").(string)
+
+	apiClient := meta.(client.ApiClientInterface)
+
+	if err := apiClient.RemoveUserFromProject(projectId, userId); err != nil {
+		return diag.Errorf("could not delete UserProjectAssignment: %v", err)
+	}
+
+	return nil
+}

--- a/env0/resource_user_project_assignment_test.go
+++ b/env0/resource_user_project_assignment_test.go
@@ -1,0 +1,217 @@
+package env0
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestUnitUserProjectAssignmentResource(t *testing.T) {
+	userId := "uid"
+	projectId := "pid"
+	id := "id"
+	role := client.Deployer
+	updatedRole := client.Viewer
+
+	createPayload := client.AssignUserToProjectPayload{
+		UserId: userId,
+		Role:   role,
+	}
+
+	updatePayload := client.UpdateUserProjectAssignmentPayload{
+		Role: updatedRole,
+	}
+
+	createResponse := client.UserProjectAssignment{
+		Id:     id,
+		UserId: userId,
+		Role:   role,
+	}
+
+	updateResponse := client.UserProjectAssignment{
+		Id:     id,
+		UserId: userId,
+		Role:   updatedRole,
+	}
+
+	otherResponse := client.UserProjectAssignment{
+		Id:     "id2",
+		UserId: "userId2",
+		Role:   role,
+	}
+
+	resourceType := "env0_user_project_assignment"
+	resourceName := "test"
+	accessor := resourceAccessor(resourceType, resourceName)
+
+	t.Run("Create assignment and update role", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", id),
+						resource.TestCheckResourceAttr(accessor, "user_id", userId),
+						resource.TestCheckResourceAttr(accessor, "project_id", projectId),
+						resource.TestCheckResourceAttr(accessor, "role", string(role)),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(updatedRole),
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", id),
+						resource.TestCheckResourceAttr(accessor, "user_id", userId),
+						resource.TestCheckResourceAttr(accessor, "project_id", projectId),
+						resource.TestCheckResourceAttr(accessor, "role", string(updatedRole)),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AssignUserToProject(projectId, &createPayload).Times(1).Return(&createResponse, nil),
+				mock.EXPECT().UserProjectAssignments(projectId).Times(2).Return([]client.UserProjectAssignment{otherResponse, createResponse}, nil),
+				mock.EXPECT().UpdateUserProjectAssignment(projectId, userId, &updatePayload).Times(1).Return(&updateResponse, nil),
+				mock.EXPECT().UserProjectAssignments(projectId).Times(1).Return([]client.UserProjectAssignment{otherResponse, updateResponse}, nil),
+				mock.EXPECT().RemoveUserFromProject(projectId, userId).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("Create Assignment - drift detected", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", id),
+						resource.TestCheckResourceAttr(accessor, "user_id", userId),
+						resource.TestCheckResourceAttr(accessor, "project_id", projectId),
+						resource.TestCheckResourceAttr(accessor, "role", string(role)),
+					),
+					ExpectNonEmptyPlan: true,
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", id),
+						resource.TestCheckResourceAttr(accessor, "user_id", userId),
+						resource.TestCheckResourceAttr(accessor, "project_id", projectId),
+						resource.TestCheckResourceAttr(accessor, "role", string(role)),
+					),
+					PlanOnly:           true,
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AssignUserToProject(projectId, &createPayload).Times(1).Return(&createResponse, nil),
+				mock.EXPECT().UserProjectAssignments(projectId).Times(1).Return([]client.UserProjectAssignment{otherResponse}, nil),
+			)
+		})
+	})
+
+	t.Run("Create Assignment - failed to create", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					ExpectError: regexp.MustCompile("could not create assignment: error"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AssignUserToProject(projectId, &createPayload).Times(1).Return(nil, errors.New("error")),
+			)
+		})
+	})
+
+	t.Run("Create Assignment - failed to list assignments", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					ExpectError: regexp.MustCompile("could not get UserProjectAssignments: error"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AssignUserToProject(projectId, &createPayload).Times(1).Return(&createResponse, nil),
+				mock.EXPECT().UserProjectAssignments(projectId).Times(1).Return(nil, errors.New("error")),
+				mock.EXPECT().RemoveUserFromProject(projectId, userId).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("Create Assignment and update role - failed to update role", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(role),
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", id),
+						resource.TestCheckResourceAttr(accessor, "user_id", userId),
+						resource.TestCheckResourceAttr(accessor, "project_id", projectId),
+						resource.TestCheckResourceAttr(accessor, "role", string(role)),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"user_id":    userId,
+						"project_id": projectId,
+						"role":       string(updatedRole),
+					}),
+					ExpectError: regexp.MustCompile("could not update role for UserProjectAssignment: error"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().AssignUserToProject(projectId, &createPayload).Times(1).Return(&createResponse, nil),
+				mock.EXPECT().UserProjectAssignments(projectId).Times(2).Return([]client.UserProjectAssignment{otherResponse, createResponse}, nil),
+				mock.EXPECT().UpdateUserProjectAssignment(projectId, userId, &updatePayload).Times(1).Return(nil, errors.New("error")),
+				mock.EXPECT().RemoveUserFromProject(projectId, userId).Times(1).Return(nil),
+			)
+		})
+	})
+}

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -55,6 +55,18 @@ func ValidateRetries(i interface{}, path cty.Path) diag.Diagnostics {
 	return nil
 }
 
+func ValidateRole(i interface{}, path cty.Path) diag.Diagnostics {
+	role := client.Role(i.(string))
+	if role == "" ||
+		role != client.Admin &&
+			role != client.Deployer &&
+			role != client.Viewer &&
+			role != client.Planner {
+		return diag.Errorf("must be one of [Admin, Deployer, Viewer, Planner], got: %v", role)
+	}
+	return nil
+}
+
 func NewRegexValidator(r string) schema.SchemaValidateDiagFunc {
 	cr := regexp.MustCompile(r)
 

--- a/examples/resources/env0_api_key/resource.tf
+++ b/examples/resources/env0_api_key/resource.tf
@@ -1,3 +1,22 @@
-resource "env0_api_key" "api_key_sample" {
-  name = "sample-name"
+resource "env0_api_key" "api_key_example" {
+  name = "api-key-example"
+}
+
+resource "env0_project" "project_resource" {
+  name = "project-resource"
+}
+
+resource "env0_user_project_assignment" "api_key_project_assignment_example" {
+  user_id    = env0_api_key.api_key_example.id
+  project_id = env0_project.project_resource.id
+  role       = "Viewer"
+}
+
+resource "env0_team" "team_resource" {
+  name = "team-resource"
+}
+
+resource "env0_user_team_assignment" "api_key_team_assignment_example" {
+  user_id = env0_api_key.api_key_example.id
+  team_id = env0_team.team_resource.id
 }

--- a/examples/resources/env0_user_project_assignment/resource.tf
+++ b/examples/resources/env0_user_project_assignment/resource.tf
@@ -1,0 +1,13 @@
+data "env0_user" "user_example" {
+  email = "example@email.com"
+}
+
+resource "env0_project" "project_example" {
+  name = "project-example"
+}
+
+resource "env0_user_project_assignment" "project_assignment_example" {
+  user_id    = data.env0_user.user_example.id
+  project_id = env0_project.project_example.id
+  role       = "Viewer"
+}

--- a/tests/integration/020_api_key/main.tf
+++ b/tests/integration/020_api_key/main.tf
@@ -25,6 +25,17 @@ resource "env0_user_team_assignment" "api_key_team_assignment" {
   team_id = env0_team.team_resource.id
 }
 
+resource "env0_project" "project_resource" {
+  name        = "Test-Project-API-${random_string.random.result}"
+  description = "Test Description"
+}
+
+resource "env0_user_project_assignment" "api_key_project_assignment" {
+  user_id    = env0_api_key.test_user_api_key.id
+  project_id = env0_project.project_resource.id
+  role       = var.second_run ? "Viewer" : "Planner"
+}
+
 data "env0_api_key" "test_api_key1" {
   name       = env0_api_key.test_api_key.name
   depends_on = [env0_api_key.test_api_key]


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
closes #405

### Solution
1. Added additional API calls for user-project-assignment.
3. Implemented the user-project-assignment resource.
4. Added acceptance tests for the resource.
5. Added integration tests for api-key-project-assignment (same as user-project-assignment).
6. Added examples.
