### PR TITLE
Chore: remove deprecation of environment_id attribute of config var resource

### DIFF
--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -66,7 +66,6 @@ func resourceConfigurationVariable() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"template_id", "project_id", "is_required", "is_read_only"},
 				ForceNew:      true,
-				Deprecated:    "use \"configuration\" field in the environment resource instead. for more details check https://registry.terraform.io/providers/env0/env0/latest/docs/resources/environment#nested-schema-for-configuration",
 			},
 			"type": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We initially decided to deprecate the `environment_id` attribute of `env0_configuration_variable` resource to make the provider aligned with our UI workflow but ended up thinking we can still expose this ability via the provider, but only add some disclaimer and how it should be used alongside `env0_environment.configuration` attribute

### Solution
Remove the unwanted deprecation message
