### PR TITLE
Chore: Update configuration.environmentId docs

### DIFF
--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -62,7 +62,7 @@ func resourceConfigurationVariable() *schema.Resource {
 			},
 			"environment_id": {
 				Type:          schema.TypeString,
-				Description:   "create the variable under this environment, not globally",
+				Description:   "create the variable under this environment, not globally. Make sure to 'ignore changes' on environment.configuration to prevent drifts",
 				Optional:      true,
 				ConflictsWith: []string{"template_id", "project_id", "is_required", "is_read_only"},
 				ForceNew:      true,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves : #347 

Since Zip doesn't use `environment.configuration` but only `configuration` with environment scope, a solution for using both is irrelevant.

There was a misunderstanding regarding their usage but eventually, we decided to update the docs by describing that using `configuration.environment_id` requires `ignoring changes` of `environment.configuration`

The issue with allowing both is that `configuration` requires an environment, so at the first run, the environment will be deployed without configuration variables. From the 2nd deployment, there will be a drift because the configuration resource metadata will be retrieved by the API of the environment.

In other words, those are 2 ways to manage the same resource so only one way should be picked. ( preferably the `environment.configuration` to prevent the first usage issue )
### Solution
Add ignore changes requirement in `configuration.environment_id` description
