### PR TITLE
Chore: Use random names for all "team"s in harness tests

### DIFF
--- a/tests/integration/009_team/expected_outputs.json
+++ b/tests/integration/009_team/expected_outputs.json
@@ -1,4 +1,4 @@
 {
-  "team_resource_name": "second description",
-  "team_data_name": "second description"
+  "team_resource_description": "second description",
+  "team_data_description": "second description"
 }

--- a/tests/integration/009_team/expected_outputs.json
+++ b/tests/integration/009_team/expected_outputs.json
@@ -1,4 +1,4 @@
 {
-  "team_resource_name": "Test-Team",
-  "team_data_name": "Test-Team"
+  "team_resource_name": "second description",
+  "team_data_name": "second description"
 }

--- a/tests/integration/009_team/main.tf
+++ b/tests/integration/009_team/main.tf
@@ -1,5 +1,13 @@
+provider "random" {}
+
+resource "random_string" "random" {
+  length    = 8
+  special   = false
+  min_lower = 8
+}
+
 resource "env0_team" "team_resource" {
-  name        = "Test-Team"
+  name        = "Test-Team-009-${random_string.random.result}"
   description = var.second_run ? "second description" : "first description"
 }
 
@@ -8,10 +16,10 @@ data "env0_team" "team_data" {
   depends_on = [env0_team.team_resource]
 }
 
-output "team_resource_name" {
-  value = env0_team.team_resource.name
+output "team_resource_description" {
+  value = env0_team.team_resource.description
 }
 
-output "team_data_name" {
-  value = data.env0_team.team_data.name
+output "team_data_description" {
+  value = data.env0_team.team_data.description
 }

--- a/tests/integration/010_team_project_assignment/main.tf
+++ b/tests/integration/010_team_project_assignment/main.tf
@@ -1,10 +1,18 @@
+provider "random" {}
+
+resource "random_string" "random" {
+  length    = 8
+  special   = false
+  min_lower = 8
+}
+
 resource "env0_project" "test_project" {
   name        = "Test-Project"
   description = "Test Description ${var.second_run ? "after update" : ""}"
 }
 
 resource "env0_team" "team_resource" {
-  name        = "Test-Team"
+  name        = "Test-Team-010-${random_string.random.result}"
   description = var.second_run ? "second description" : "first description"
 }
 

--- a/tests/integration/020_api_key/main.tf
+++ b/tests/integration/020_api_key/main.tf
@@ -16,7 +16,7 @@ resource "env0_api_key" "test_user_api_key" {
 }
 
 resource "env0_team" "team_resource" {
-  name        = "team-with-api-key"
+  name        = "team-with-api-key-020-${random_string.random.result}"
   description = "description"
 }
 

--- a/tests/integration/021_teams/expected_outputs.json
+++ b/tests/integration/021_teams/expected_outputs.json
@@ -1,4 +1,4 @@
 {
-    "team1_name": "team1",
-    "team2_name": "team2"
+    "team1_name": "team 1 description",
+    "team2_name": "team 2 description"
 }

--- a/tests/integration/021_teams/expected_outputs.json
+++ b/tests/integration/021_teams/expected_outputs.json
@@ -1,4 +1,4 @@
 {
-    "team1_name": "team 1 description",
-    "team2_name": "team 2 description"
+    "team1_description": "team 1 description",
+    "team2_description": "team 2 description"
 }

--- a/tests/integration/021_teams/main.tf
+++ b/tests/integration/021_teams/main.tf
@@ -1,9 +1,19 @@
+provider "random" {}
+
+resource "random_string" "random" {
+  length    = 8
+  special   = false
+  min_lower = 8
+}
+
 resource "env0_team" "team_resource1" {
-  name = "team1"
+  name = "team1-021-${random_string.random.result}"
+  description = "team 1 description"
 }
 
 resource "env0_team" "team_resource2" {
-  name = "team2"
+  name = "team2-021-${random_string.random.result}"
+  description = "team 2 description"
 }
 
 data "env0_teams" "all_teams" {}
@@ -13,10 +23,10 @@ data "env0_team" "teams" {
   name     = each.value
 }
 
-output "team1_name" {
-  value = var.second_run ? data.env0_team.teams["team1"].name : ""
+output "team1_description" {
+  value = var.second_run ? data.env0_team.teams[env0_team.team_resource1.name].description : ""
 }
 
-output "team2_name" {
-  value = var.second_run ? data.env0_team.teams["team2"].name : ""
+output "team2_description" {
+  value = var.second_run ? data.env0_team.teams[env0_team.team_resource2.name].description : ""
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Right now some harness tests are using a static name for `env0_team` resource. That means that if any harness test fails, and the team still exists, running the same test on the same organization will fail.

### Solution
Let's make sure all harness' team resources are using a unique team name
