### PR TITLE
Feat: refactoring for adding run-all support

### DIFF
--- a/client/template_test.go
+++ b/client/template_test.go
@@ -220,59 +220,6 @@ var _ = Describe("Templates Client", func() {
 		})
 	})
 
-	Describe("Terragrunt version errors", func() {
-		var err error
-
-		Describe("type is tg and no tg version supplied", func() {
-			It("Should fail on create", func() {
-				createTemplatePayload := TemplateCreatePayload{}
-				copier.Copy(&createTemplatePayload, &mockTemplate)
-
-				createTemplatePayload.Type = "terragrunt"
-
-				_, err = apiClient.TemplateCreate(createTemplatePayload)
-
-				Expect(err).To(Not(BeNil()))
-			})
-
-			It("Should fail on update", func() {
-				createTemplatePayload := TemplateCreatePayload{}
-				copier.Copy(&createTemplatePayload, &mockTemplate)
-
-				createTemplatePayload.Type = "terragrunt"
-
-				_, err = apiClient.TemplateUpdate(mockTemplate.Id, createTemplatePayload)
-
-				Expect(err).To(Not(BeNil()))
-			})
-		})
-
-		Describe("type is NOT tg and tg version IS supplied", func() {
-			It("Should fail on create", func() {
-				createTemplatePayload := TemplateCreatePayload{}
-				copier.Copy(&createTemplatePayload, &mockTemplate)
-
-				createTemplatePayload.Type = "terraform"
-				createTemplatePayload.TerragruntVersion = "0.29.0"
-
-				_, err = apiClient.TemplateCreate(createTemplatePayload)
-
-				Expect(err).To(Not(BeNil()))
-			})
-
-			It("Should fail on update", func() {
-				createTemplatePayload := TemplateCreatePayload{}
-				copier.Copy(&createTemplatePayload, &mockTemplate)
-
-				createTemplatePayload.Type = "terragrunt"
-
-				_, err = apiClient.TemplateUpdate(mockTemplate.Id, createTemplatePayload)
-
-				Expect(err).To(Not(BeNil()))
-			})
-		})
-	})
-
 	Describe("VariablesFromRepository", func() {
 		var returnedVariables []ConfigurationVariable
 		var err error

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -51,14 +51,8 @@ func templateCreatePayloadFromParameters(d *schema.ResourceData) (client.Templat
 	templateCreatePayloadRetryOnHelper(d, "deploy", &payload.Retry.OnDeploy)
 	templateCreatePayloadRetryOnHelper(d, "destroy", &payload.Retry.OnDestroy)
 
-	if payload.Type == "cloudformation" {
-		if len(payload.FileName) == 0 {
-			return payload, diag.Errorf("file_name is required with cloudformation template type")
-		}
-	} else {
-		if len(payload.FileName) > 0 {
-			return payload, diag.Errorf("file_name cannot be set when template type is: %s", payload.Type)
-		}
+	if err := payload.Validate(); err != nil {
+		return payload, diag.Errorf(err.Error())
 	}
 
 	return payload, nil


### PR DESCRIPTION
### Solution

Some refactoring I wanted to do before working on #438.
(Instead of having one large PR).

Schema validation was moved to the correct place, instead of doing it before the API call.
Updated tests accordingly.