### PR TITLE
Feat: environment resource does not support new templateless creation

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -201,7 +201,6 @@ func setEnvironmentSchema(d *schema.ResourceData, environment client.Environment
 	}
 
 	if environment.LatestDeploymentLog != (client.DeploymentLog{}) {
-		d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
 		d.Set("revision", environment.LatestDeploymentLog.BlueprintRevision)
 	}
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -201,6 +201,7 @@ func setEnvironmentSchema(d *schema.ResourceData, environment client.Environment
 	}
 
 	if environment.LatestDeploymentLog != (client.DeploymentLog{}) {
+		d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
 		d.Set("revision", environment.LatestDeploymentLog.BlueprintRevision)
 	}
 

--- a/env0/utils_test.go
+++ b/env0/utils_test.go
@@ -246,6 +246,30 @@ func TestReadByPointerNilCustomResourceData(t *testing.T) {
 	assert.Equal(t, params.Description, "description")
 }
 
+func TestReadResourceDataEx(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceEnvironment().Schema, map[string]interface{}{
+		"name":       "name",
+		"project_id": "poroject_id",
+		"template": []interface{}{map[string]interface{}{
+			"type":                 "terraform",
+			"is_gitlab_enterprise": true,
+			"ssh_keys": []interface{}{
+				map[string]interface{}{"id": "id1", "name": "name1"},
+			},
+		}},
+	})
+
+	var payload client.TemplateCreatePayload
+	assert.Nil(t, readResourceDataEx("template.0", &payload, d))
+	assert.Equal(t, "terraform", string(payload.Type))
+	assert.Equal(t, client.TemplateSshKey{
+		Id:   "id1",
+		Name: "name1",
+	}, payload.SshKeys[0])
+	assert.True(t, payload.IsGitlabEnterprise)
+	assert.False(t, payload.IsGithubEnterprise)
+}
+
 func TestWriteResourceDataSliceVariablesAgents(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, dataAgents().Schema, map[string]interface{}{})
 


### PR DESCRIPTION
### Solution
Part of the effort to support template-less environment #374.
Added readResouceDataEx to support a prefix use-case which is required for the effort.
Added a unit test.
