### PR TITLE
Fix: organizationId() hides the errors

### DIFF
--- a/client/notification_test.go
+++ b/client/notification_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 import (
+	"errors"
+
 	. "github.com/env0/terraform-provider-env0/client"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/jinzhu/copier"
@@ -83,6 +85,25 @@ var _ = Describe("Notification Client", func() {
 
 			It("Should return created notification", func() {
 				Expect(*createdNotification).To(Equal(mockNotification))
+			})
+		})
+
+		Describe("Failure - Multiple Organizations", func() {
+			var err error
+
+			BeforeEach(func() {
+				organizationsResult := []Organization{{}, {}}
+				mockHttpClient.EXPECT().
+					Get("/organizations", nil, gomock.Any()).
+					Do(func(path string, request interface{}, response *[]Organization) {
+						*response = organizationsResult
+					})
+				_, err = apiClient.NotificationCreate(NotificationCreatePayload{})
+
+			})
+
+			It("Should return error", func() {
+				Expect(err).To(BeEquivalentTo(errors.New("server responded with too many organizations")))
 			})
 		})
 	})

--- a/client/notification_test.go
+++ b/client/notification_test.go
@@ -88,6 +88,10 @@ var _ = Describe("Notification Client", func() {
 			})
 		})
 
+		// NotificationCreate calls "organizationId()""
+		// The test was "randomly" added here to test organizationId failure (when there are multiple organizations).
+		// Ideally should be tested in organization. Unfortunatly, organizationId is private and cannot be tested directly.
+		// (test package name varies from package name).
 		Describe("Failure - Multiple Organizations", func() {
 			var err error
 

--- a/client/organization.go
+++ b/client/organization.go
@@ -46,7 +46,7 @@ func (client *ApiClient) organizationId() (string, error) {
 	}
 	organization, err := client.Organization()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	client.cachedOrganizationId = organization.Id
 	return client.cachedOrganizationId, nil


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #448 

### Solution
1. organizationId now returns error on failure.
2. Added a test that verified the use-case.
