### PR TITLE
Fix: CD and PR plan settings on environment are not applied correctly

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -82,8 +82,8 @@ type Environment struct {
 	ProjectId                   string        `json:"projectId"`
 	WorkspaceName               string        `json:"workspaceName,omitempty"`
 	RequiresApproval            *bool         `json:"requiresApproval,omitempty" tfschema:"-"`
-	ContinuousDeployment        *bool         `json:"continuousDeployment,omitempty" tfschema:"deploy_on_push"`
-	PullRequestPlanDeployments  *bool         `json:"pullRequestPlanDeployments,omitempty" tfschema:"run_plan_on_pull_requests"`
+	ContinuousDeployment        *bool         `json:"continuousDeployment,omitempty" tfschema:"deploy_on_push,omitempty"`
+	PullRequestPlanDeployments  *bool         `json:"pullRequestPlanDeployments,omitempty" tfschema:"run_plan_on_pull_requests,omitempty"`
 	AutoDeployOnPathChangesOnly *bool         `json:"autoDeployOnPathChangesOnly,omitempty" tfschema:",omitempty"`
 	AutoDeployByCustomGlob      string        `json:"autoDeployByCustomGlob,omitempty"`
 	Status                      string        `json:"status"`

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -428,7 +428,8 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	}
 
 	continuousDeployment := d.Get("deploy_on_push").(bool)
-	if d.HasChange("deploy_on_push") {
+	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
+	if _, exists := d.GetOkExists("deploy_on_push"); exists {
 		payload.ContinuousDeployment = &continuousDeployment
 	}
 
@@ -438,7 +439,8 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	}
 
 	pullRequestPlanDeployments := d.Get("run_plan_on_pull_requests").(bool)
-	if d.HasChange("run_plan_on_pull_requests") {
+	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
+	if _, exists := d.GetOkExists("run_plan_on_pull_requests"); exists {
 		payload.PullRequestPlanDeployments = &pullRequestPlanDeployments
 	}
 
@@ -494,6 +496,7 @@ func getUpdatePayload(d *schema.ResourceData) (client.EnvironmentUpdate, diag.Di
 	if d.HasChange("deploy_on_push") {
 		payload.ContinuousDeployment = &continuousDeployment
 	}
+
 	pullRequestPlanDeployments := d.Get("run_plan_on_pull_requests").(bool)
 	if d.HasChange("run_plan_on_pull_requests") {
 		payload.PullRequestPlanDeployments = &pullRequestPlanDeployments


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #471 

### Solution

Using GetOkExist.
Updarted unit tests.

The bug was that HasChange behaves the same for field not set and false.
The only way around it is to use GetOkExist. The supports: true, false, and unset. (All 3 modes are required).
