### PR TITLE
Fix: TF module name uniqueness in integration tests

### DIFF
--- a/tests/integration/018_module/main.tf
+++ b/tests/integration/018_module/main.tf
@@ -1,5 +1,13 @@
+provider "random" {}
+
+resource "random_string" "random" {
+  length    = 8
+  special   = false
+  min_lower = 8
+}
+
 resource "env0_module" "test_module" {
-  module_name            = "test-module234"
+  module_name            = "test-module-${random_string.random.result}"
   module_provider        = "testprovider1"
   token_id               = var.second_run ? null : "37689e5a-5298-4555-b71e-92b80f736222"
   token_name             = var.second_run ? null : "johns_token"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Integration tests might fail due to having a non-random env0 module resource name

### Solution
Randomize it
