### PR TITLE
Fix - 401 errors from auth0 sue to cache misses when using user/pass

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -3,8 +3,6 @@ package http
 //go:generate mockgen -destination=client_mock.go -package=http . HttpClientInterface
 
 import (
-	"fmt"
-
 	"github.com/go-resty/resty/v2"
 )
 
@@ -38,11 +36,14 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 		ApiSecret: config.ApiSecret,
 		client:    config.RestClient.SetHostURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}
+	var res string
 	req := httpClient.client.R().SetBasicAuth(httpClient.ApiKey, httpClient.ApiSecret)
+	response, err := req.SetQueryParams(map[string]string{"encoded": "true"}).SetResult(&res).Get("auth/token")
+	if err != nil {
+		return nil, err
+	}
 
-	req.SetQueryParams(nil).SetResult(httpClient.jwtToken).Get("auth/token?encoded=true")
-	fmt.Println("***", httpClient.jwtToken)
-
+	httpClient.jwtToken = string(response.Body())
 	return httpClient, nil
 }
 

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -51,7 +51,6 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 	return httpClient, err
 }
 
-
 func (client *HttpClient) request() *resty.Request {
 	return client.client.R().SetAuthToken(client.jwtToken)
 }

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -17,7 +17,7 @@ type HttpClientInterface interface {
 }
 
 type HttpClient struct {
-	jwtToken    string
+	jwtToken  string
 	ApiKey    string
 	ApiSecret string
 	Endpoint  string
@@ -41,7 +41,7 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 	req := httpClient.client.R().SetBasicAuth(httpClient.ApiKey, httpClient.ApiSecret)
 
 	req.SetQueryParams(nil).SetResult(httpClient.jwtToken).Get("auth/token?encoded=true")
-	fmt.Println("***", httpClient.jwtToken);
+	fmt.Println("***", httpClient.jwtToken)
 
 	return httpClient, nil
 }

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -36,9 +36,8 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 		ApiSecret: config.ApiSecret,
 		client:    config.RestClient.SetHostURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}
-	var res string
 	req := httpClient.client.R().SetBasicAuth(httpClient.ApiKey, httpClient.ApiSecret)
-	response, err := req.SetQueryParams(map[string]string{"encoded": "true"}).SetResult(&res).Get("auth/token")
+	response, err := req.SetQueryParams(map[string]string{"encoded": "true"}).Get("auth/token")
 	if err != nil {
 		return nil, err
 	}

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -46,9 +46,12 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 		client:    config.RestClient.SetHostURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}
 	response, err := getJWTToken(httpClient)
+	if err != nil {
+		return nil, err
+	}
 
 	httpClient.jwtToken = string(response.Body())
-	return httpClient, err
+	return httpClient, nil
 }
 
 func (client *HttpClient) request() *resty.Request {

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -3,6 +3,8 @@ package http
 //go:generate mockgen -destination=client_mock.go -package=http . HttpClientInterface
 
 import (
+	"fmt"
+
 	"github.com/go-resty/resty/v2"
 )
 
@@ -38,7 +40,8 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 	}
 	req := httpClient.client.R().SetBasicAuth(httpClient.ApiKey, httpClient.ApiSecret)
 
-	req.SetQueryParams(nil).SetResult(&httpClient.jwtToken).Get("auth/token?encoded=true")
+	req.SetQueryParams(nil).SetResult(httpClient.jwtToken).Get("auth/token?encoded=true")
+	fmt.Println("***", httpClient.jwtToken);
 
 	return httpClient, nil
 }

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 const BaseUrl = "https://fake.env0.com"
 const ApiKey = "MY_USER"
 const ApiSecret = "MY_PASS"
-const ExpectedBasicAuth = "Bearer \"mockedJwtToken\""
+const ExpectedJWTAuth = "Bearer \"mockedJwtToken\""
 const UserAgent = "super-cool-ua"
 const ErrorStatusCode = 500
 const ErrorMessage = "Very bad!"
@@ -83,7 +83,7 @@ var _ = Describe("Http Client", func() {
 	AssertAuth := func() {
 		authorization := httpRequest.Header["Authorization"]
 		Expect(len(authorization)).To(Equal(1), "Should have authorization header")
-		Expect(authorization[0]).To(Equal(ExpectedBasicAuth), "Should have correct Basic Auth")
+		Expect(authorization[0]).To(Equal(ExpectedJWTAuth), "Should have correct Basic Auth")
 	}
 
 	AssertNoError := func(err error) {

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 const BaseUrl = "https://fake.env0.com"
 const ApiKey = "MY_USER"
 const ApiSecret = "MY_PASS"
-const ExpectedBasicAuth = "Basic TVlfVVNFUjpNWV9QQVNT"
+const ExpectedBasicAuth = "Bearer mockedJwtToken"
 const UserAgent = "super-cool-ua"
 const ErrorStatusCode = 500
 const ErrorMessage = "Very bad!"
@@ -39,7 +39,8 @@ var httpclient *httpModule.HttpClient
 var _ = BeforeSuite(func() {
 	// mock all HTTP requests
 	restClient := resty.New()
-
+	httpmock.ActivateNonDefault(restClient.GetClient())
+	httpmock.RegisterResponder("GET", BaseUrl+"/auth/token", httpmock.NewStringResponder(200, `mockedJwtToken`))
 	config := httpModule.HttpClientConfig{
 		ApiKey:      ApiKey,
 		ApiSecret:   ApiSecret,
@@ -48,7 +49,6 @@ var _ = BeforeSuite(func() {
 		RestClient:  restClient,
 	}
 	httpclient, _ = httpModule.NewHttpClient(config)
-	httpmock.ActivateNonDefault(restClient.GetClient())
 })
 
 var _ = BeforeEach(func() {

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 const BaseUrl = "https://fake.env0.com"
 const ApiKey = "MY_USER"
 const ApiSecret = "MY_PASS"
-const ExpectedBasicAuth = "Bearer mockedJwtToken"
+const ExpectedBasicAuth = "Bearer \"mockedJwtToken\""
 const UserAgent = "super-cool-ua"
 const ErrorStatusCode = 500
 const ErrorMessage = "Very bad!"
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 	// mock all HTTP requests
 	restClient := resty.New()
 	httpmock.ActivateNonDefault(restClient.GetClient())
-	httpmock.RegisterResponder("GET", BaseUrl+"/auth/token", httpmock.NewStringResponder(200, `mockedJwtToken`))
+	httpmock.RegisterResponder("GET", BaseUrl+"/auth/token", httpmock.NewStringResponder(200, `"mockedJwtToken"`))
 	config := httpModule.HttpClientConfig{
 		ApiKey:      ApiKey,
 		ApiSecret:   ApiSecret,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
We're seeing an elevated rate of throttling errors  in the `tf_provder` tests as we do not benefit from cache when using user/password.

### Solution
Use user/password once to obtain JWT and use that on following API calls.

