### PR TITLE
Fix: Revert PR495

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -15,7 +15,6 @@ type HttpClientInterface interface {
 }
 
 type HttpClient struct {
-	jwtToken  string
 	ApiKey    string
 	ApiSecret string
 	Endpoint  string
@@ -30,32 +29,18 @@ type HttpClientConfig struct {
 	RestClient  *resty.Client
 }
 
-func getJWTToken(httpClient *HttpClient) (*resty.Response, error) {
-	req := httpClient.client.R().SetBasicAuth(httpClient.ApiKey, httpClient.ApiSecret)
-	response, err := req.SetQueryParams(map[string]string{"encoded": "true"}).Get("auth/token")
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
 func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 	httpClient := &HttpClient{
 		ApiKey:    config.ApiKey,
 		ApiSecret: config.ApiSecret,
 		client:    config.RestClient.SetBaseURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}
-	response, err := getJWTToken(httpClient)
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient.jwtToken = string(response.Body())
+	
 	return httpClient, nil
 }
 
 func (client *HttpClient) request() *resty.Request {
-	return client.client.R().SetAuthToken(client.jwtToken)
+	return client.client.R().SetBasicAuth(client.ApiKey, client.ApiSecret)
 }
 
 func (client *HttpClient) httpResult(response *resty.Response, err error) error {

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -35,7 +35,7 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 		ApiSecret: config.ApiSecret,
 		client:    config.RestClient.SetBaseURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
 	}
-	
+
 	return httpClient, nil
 }
 

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -39,7 +39,7 @@ var httpclient *httpModule.HttpClient
 var _ = BeforeSuite(func() {
 	// mock all HTTP requests
 	restClient := resty.New()
-		config := httpModule.HttpClientConfig{
+	config := httpModule.HttpClientConfig{
 		ApiKey:      ApiKey,
 		ApiSecret:   ApiSecret,
 		ApiEndpoint: BaseUrl,

--- a/client/http/client_test.go
+++ b/client/http/client_test.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 const BaseUrl = "https://fake.env0.com"
 const ApiKey = "MY_USER"
 const ApiSecret = "MY_PASS"
-const ExpectedJWTAuth = "Bearer \"mockedJwtToken\""
+const ExpectedBasicAuth = "Basic TVlfVVNFUjpNWV9QQVNT"
 const UserAgent = "super-cool-ua"
 const ErrorStatusCode = 500
 const ErrorMessage = "Very bad!"
@@ -39,9 +39,7 @@ var httpclient *httpModule.HttpClient
 var _ = BeforeSuite(func() {
 	// mock all HTTP requests
 	restClient := resty.New()
-	httpmock.ActivateNonDefault(restClient.GetClient())
-	httpmock.RegisterResponder("GET", BaseUrl+"/auth/token", httpmock.NewStringResponder(200, `"mockedJwtToken"`))
-	config := httpModule.HttpClientConfig{
+		config := httpModule.HttpClientConfig{
 		ApiKey:      ApiKey,
 		ApiSecret:   ApiSecret,
 		ApiEndpoint: BaseUrl,
@@ -49,6 +47,7 @@ var _ = BeforeSuite(func() {
 		RestClient:  restClient,
 	}
 	httpclient, _ = httpModule.NewHttpClient(config)
+	httpmock.ActivateNonDefault(restClient.GetClient())
 })
 
 var _ = BeforeEach(func() {
@@ -83,7 +82,7 @@ var _ = Describe("Http Client", func() {
 	AssertAuth := func() {
 		authorization := httpRequest.Header["Authorization"]
 		Expect(len(authorization)).To(Equal(1), "Should have authorization header")
-		Expect(authorization[0]).To(Equal(ExpectedJWTAuth), "Should have correct Basic Auth")
+		Expect(authorization[0]).To(Equal(ExpectedBasicAuth), "Should have correct Basic Auth")
 	}
 
 	AssertNoError := func(err error) {


### PR DESCRIPTION
### Issue
#495 introduced a fix which used an endpoint to obtain a JWT by api key to avoid 429/401.  
We've since added proper caching on api key based authorizations and will no longer need to force clients to obtain the token first.  

### Solution
Revert #495 
