### PR TITLE
Fix: readResourceData does not work for bool or *bool fields

### DIFF
--- a/client/module.go
+++ b/client/module.go
@@ -13,8 +13,8 @@ type Module struct {
 	LogoUrl              string         `json:"logoUrl"`
 	TokenId              string         `json:"tokenId"`
 	TokenName            string         `json:"tokenName"`
-	GithubInstallationId *int           `json:"githubInstallationId"`
-	BitbucketClientKey   *string        `json:"bitbucketClientKey"`
+	GithubInstallationId *int           `json:"githubInstallationId" tfschema:",omitempty"`
+	BitbucketClientKey   *string        `json:"bitbucketClientKey" tfschema:",omitempty"`
 	IsGitlab             bool           `json:"isGitLab"`
 	SshKeys              []ModuleSshKey `json:"sshkeys"`
 	Type                 string         `json:"type"`

--- a/env0/resource_organization_policy_test.go
+++ b/env0/resource_organization_policy_test.go
@@ -82,12 +82,16 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 					MaxTtl:                              organization.MaxTtl,
 					DefaultTtl:                          organization.DefaultTtl,
 					DoNotConsiderMergeCommitsForPrPlans: &organization.DoNotConsiderMergeCommitsForPrPlans,
+					DoNotReportSkippedStatusChecks:      boolPtr(false),
+					EnableOidc:                          boolPtr(false),
 				}).Times(1).Return(&organization, nil),
 				mock.EXPECT().Organization().Times(2).Return(organization, nil),
 				mock.EXPECT().OrganizationPolicyUpdate(client.OrganizationPolicyUpdatePayload{
-					DefaultTtl:                     organizationUpdated.DefaultTtl,
-					DoNotReportSkippedStatusChecks: &organizationUpdated.DoNotReportSkippedStatusChecks,
-					EnableOidc:                     &organizationUpdated.EnableOidc,
+					DefaultTtl:                          organizationUpdated.DefaultTtl,
+					DoNotReportSkippedStatusChecks:      &organizationUpdated.DoNotReportSkippedStatusChecks,
+					EnableOidc:                          &organizationUpdated.EnableOidc,
+					DoNotConsiderMergeCommitsForPrPlans: boolPtr(false),
+					MaxTtl:                              stringPtr(""),
 				}).Times(1).Return(&organizationUpdated, nil),
 				mock.EXPECT().Organization().Times(1).Return(organizationUpdated, nil),
 				mock.EXPECT().OrganizationPolicyUpdate(client.OrganizationPolicyUpdatePayload{}).Times(1).Return(&defaultOrganization, nil),
@@ -130,6 +134,8 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 				MaxTtl:                              organization.MaxTtl,
 				DefaultTtl:                          organization.DefaultTtl,
 				DoNotConsiderMergeCommitsForPrPlans: &organization.DoNotConsiderMergeCommitsForPrPlans,
+				DoNotReportSkippedStatusChecks:      boolPtr(false),
+				EnableOidc:                          boolPtr(false),
 			}).Times(1).Return(nil, errors.New("error"))
 		})
 	})


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #504 

### Solution

Added some special handling for "zero" values.
More details in the comments.
