### PR TITLE
Fix: when updating without_template_settings terraform force environm…

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -345,6 +345,9 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 			EnvironmentCreate: environmentPayload,
 			TemplateCreate:    templatePayload,
 		}
+		// Note: the blueprint id field of the environment is returned only during creation of a template without envrionment.
+		// Afterward, it will be omitted from future response.
+		// setEnvironmentSchema() (several lines below) sets the blueprint id in the resource (under "without_template_settings.0.id").
 		environment, err = apiClient.EnvironmentCreateWithoutTemplate(payload)
 	}
 	if err != nil {

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -1191,8 +1191,10 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 		WorkspaceName:              "workspace-name",
 		TerragruntWorkingDirectory: "/terragrunt/directory/",
 		VcsCommandsAlias:           "alias",
-		BlueprintId:                "id-template-0",
 	}
+
+	environmentWithBluePrint := environment
+	environmentWithBluePrint.BlueprintId = "id-template-0"
 
 	template := client.Template{
 		Id:          "id-template-0",
@@ -1366,6 +1368,7 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "without_template_settings.0.retry_on_destroy_only_when_matches_regex", template.Retry.OnDestroy.ErrorRegex),
 					),
 				},
+
 				// Update the template.
 				{
 					Config: createEnvironmentResourceConfig(environment, updatedTemplate),
@@ -1414,25 +1417,44 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 		}
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-			// Step1
-			mock.EXPECT().EnvironmentCreateWithoutTemplate(createPayload).Times(1).Return(environment, nil)
-			mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil)
-			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil)
-			mock.EXPECT().Template(environment.BlueprintId).Times(1).Return(template, nil)
 
-			// Step2
-			mock.EXPECT().Environment(environment.Id).Times(2).Return(environment, nil)
-			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(2).Return(client.ConfigurationChanges{}, nil)
-			mock.EXPECT().Template(environment.BlueprintId).Times(1).Return(template, nil)
-			mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil)
-			mock.EXPECT().TemplateUpdate(environment.BlueprintId, templateUpdatePayload).Times(1).Return(updatedTemplate, nil)
-			mock.EXPECT().Template(environment.BlueprintId).Times(1).Return(updatedTemplate, nil)
+			gomock.InOrder(
+				// Step1
+				// Create
+				mock.EXPECT().EnvironmentCreateWithoutTemplate(createPayload).Times(1).Return(environmentWithBluePrint, nil),
 
-			// Step3
-			mock.EXPECT().Environment(environment.Id).Times(2).Return(environment, nil)
-			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(2).Return(client.ConfigurationChanges{}, nil)
-			mock.EXPECT().Template(environment.BlueprintId).Times(2).Return(updatedTemplate, nil)
-			mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
+				// Read
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
+
+				// Step2
+				// Read
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
+
+				// Update
+				mock.EXPECT().TemplateUpdate(template.Id, templateUpdatePayload).Times(1).Return(updatedTemplate, nil),
+
+				// Read
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
+
+				// Step3
+				// Read
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
+
+				// Read
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
+
+				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
+			)
 		})
 	})
 

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -64,6 +64,11 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 	}
 
 	templateSchema := map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeString,
+			Description: "id of the template",
+			Computed:    true,
+		},
 		"description": {
 			Type:        schema.TypeString,
 			Description: "description for the template",
@@ -197,12 +202,6 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 	}
 
 	if prefix == "" {
-		templateSchema["id"] = &schema.Schema{
-			Type:        schema.TypeString,
-			Description: "id of the template",
-			Computed:    true,
-		}
-
 		templateSchema["name"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Description: "name to give the template",


### PR DESCRIPTION
…ent re-creation

### Issue & Steps to Reproduce / Feature Request
fixes #507 

### Solution
One of the issues I observed is that the BluePrint id field of the environment is returned only during creation.
Afterward, it will be omitted.

We need to keep the template id in the schema and use it instead.

I noticed other consistency issues as well and resolved them.

Updated the acceptance test.