### PR TITLE
Fix: tf apply fails when switching from v1.2.4 to v1.2.5

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -241,10 +241,10 @@ func setEnvironmentSchema(d *schema.ResourceData, environment client.Environment
 			d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
 			d.Set("revision", environment.LatestDeploymentLog.BlueprintRevision)
 		}
-	} else if environment.BlueprintId != "" {
+	} else if environment.LatestDeploymentLog.BlueprintId != "" {
 		settings := d.Get("without_template_settings").([]interface{})
 		elem := settings[0].(map[string]interface{})
-		elem["id"] = environment.BlueprintId
+		elem["id"] = environment.LatestDeploymentLog.BlueprintId
 		d.Set("without_template_settings", settings)
 	}
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -241,10 +241,16 @@ func setEnvironmentSchema(d *schema.ResourceData, environment client.Environment
 			d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
 			d.Set("revision", environment.LatestDeploymentLog.BlueprintRevision)
 		}
-	} else if environment.LatestDeploymentLog.BlueprintId != "" {
+	} else if environment.BlueprintId != "" || environment.LatestDeploymentLog.BlueprintId != "" {
 		settings := d.Get("without_template_settings").([]interface{})
 		elem := settings[0].(map[string]interface{})
-		elem["id"] = environment.LatestDeploymentLog.BlueprintId
+
+		if environment.BlueprintId != "" {
+			elem["id"] = environment.BlueprintId
+		} else {
+			elem["id"] = environment.LatestDeploymentLog.BlueprintId
+		}
+
 		d.Set("without_template_settings", settings)
 	}
 

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -1191,6 +1191,9 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 		WorkspaceName:              "workspace-name",
 		TerragruntWorkingDirectory: "/terragrunt/directory/",
 		VcsCommandsAlias:           "alias",
+		LatestDeploymentLog:         client.DeploymentLog{
+			BlueprintId: "id-template-0",
+		},
 	}
 
 	environmentWithBluePrint := environment

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -1191,7 +1191,7 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 		WorkspaceName:              "workspace-name",
 		TerragruntWorkingDirectory: "/terragrunt/directory/",
 		VcsCommandsAlias:           "alias",
-		LatestDeploymentLog:         client.DeploymentLog{
+		LatestDeploymentLog: client.DeploymentLog{
 			BlueprintId: "id-template-0",
 		},
 	}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
#### steps to reproduce:
1. create the following configuration:
```tf
terraform {
  required_providers {
    env0 = {
      source  = "env0/env0"
      version = "1.2.4"
    }
  }
}

resource "env0_environment" "aws-development-vault-elb-coralogix-s3-lambda" {
  name                       = "aws-development-vault-elb-coralogix-s3-lambda"
  project_id                 = "2e8094c9-8771-475e-83a0-23ce1999479e"
  approve_plan_automatically = true
  workspace                  = "aws-development-vault-elb-coralogix-s3-lambda"
  force_destroy              = true


  without_template_settings {
    repository        = "https://github.com/env0/templates"
    path              = "misc/null-resource"
    type              = "terraform"
    terraform_version = "1.2.9"
  }
}
```
2. do `tf init` and `tf apply`
3. change the `env0` version in the configuration to `1.2.5`
4. `tf apply` again
5. you get:
```
Error: could not get template: 400 Bad Request: You may specify exactly one of the parameters ["organizationId","projectId"]

```
### Solution
the source for this error is because we created "bad" environment resource in `v1.2.4` that does not contain `BlueprintId` when fetching them, only when creating. 
To solve this, we extract the `BlueprintId` from `environment.LatestDeploymentLog`

