### PR TITLE
Chore: fix readme markdown

### DIFF
--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # env0 Provider
 
-The [env0][https://www.env0.com] provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer tho [this guide](https://developer.env0.com/docs/api/YXBpOjY4Njc2-env0-api#creating-an-api-key) on how to generate those credentials.
+The [env0](https://www.env0.com) provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer tho [this guide](https://developer.env0.com/docs/api/YXBpOjY4Njc2-env0-api#creating-an-api-key) on how to generate those credentials.
 
 Use the navigation to the left to read about the available resources.
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
The markdown syntax of the provider's main description text was wrong
![image](https://user-images.githubusercontent.com/20625046/193470580-181c2be8-9391-477f-b0ef-4df1d89b8494.png)


### Solution
Fix it
