### PR TITLE
Fix: lexicographical sorting of configuration items

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -320,7 +320,11 @@ func createVariable(configurationVariable *client.ConfigurationVariable) interfa
 }
 
 func setEnvironmentConfigurationSchema(d *schema.ResourceData, configurationVariables []client.ConfigurationVariable) {
-	ivariables := d.Get("configuration")
+	ivariables, ok := d.GetOk("configuration")
+	if !ok {
+		return
+	}
+
 	if ivariables == nil {
 		ivariables = make([]interface{}, 0)
 	}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Fixes #459 

### Solution
Maintains ordering of state as much as possible (vs the order returned by the API).
Added and updated acceptance tests accordingly.
