### PR TITLE
Chore: Get teams using name filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ Afterwards, when cleanup is required, just set `DESTROY_MODE` to `DESTROY_ONLY` 
 Run from root directory:
 
 ```shell
-go test ./...
+go test -v ./...
 ```
 
 #### Running a single provider test
 
 ```shell
-export TEST_PATTERN="TestUnitConfigurationVariableResource/Create" && go test ./env0
+export TEST_PATTERN="TestUnitConfigurationVariableResource/Create" && go test -v ./env0
 ```
 
 #### How to use mocks

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -50,6 +50,7 @@ type ApiClientInterface interface {
 	RemoveCostCredentialsFromProject(projectId string, credentialId string) error
 	Team(id string) (Team, error)
 	Teams() ([]Team, error)
+	TeamsByName(name string) ([]Team, error)
 	TeamCreate(payload TeamCreatePayload) (Team, error)
 	TeamUpdate(id string, payload TeamUpdatePayload) (Team, error)
 	TeamDelete(id string) error

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -1246,6 +1246,21 @@ func (mr *MockApiClientInterfaceMockRecorder) Teams() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Teams", reflect.TypeOf((*MockApiClientInterface)(nil).Teams))
 }
 
+// TeamsByName mocks base method.
+func (m *MockApiClientInterface) TeamsByName(arg0 string) ([]Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TeamsByName", arg0)
+	ret0, _ := ret[0].([]Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TeamsByName indicates an expected call of TeamsByName.
+func (mr *MockApiClientInterfaceMockRecorder) TeamsByName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamsByName", reflect.TypeOf((*MockApiClientInterface)(nil).TeamsByName), arg0)
+}
+
 // Template mocks base method.
 func (m *MockApiClientInterface) Template(arg0 string) (Template, error) {
 	m.ctrl.T.Helper()

--- a/client/team.go
+++ b/client/team.go
@@ -69,28 +69,23 @@ func (client *ApiClient) TeamUpdate(id string, payload TeamUpdatePayload) (Team,
 	return result, nil
 }
 
-func (client *ApiClient) Teams() ([]Team, error) {
+func (client *ApiClient) GetTeams(params map[string]string) ([]Team, error) {
 	organizationId, err := client.OrganizationId()
 	if err != nil {
 		return nil, err
 	}
 	var result []Team
-	err = client.http.Get("/teams/organizations/"+organizationId, nil, &result)
+	err = client.http.Get("/teams/organizations/"+organizationId, params, &result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
+func (client *ApiClient) Teams(params map[string]string) ([]Team, error) {
+	return client.GetTeams(nil)
+}
+
 func (client *ApiClient) TeamsByName(name string) ([]Team, error) {
-	organizationId, err := client.OrganizationId()
-	if err != nil {
-		return nil, err
-	}
-	var result []Team
-	err = client.http.Get("/teams/organizations/"+organizationId, map[string]string{"name": name}, &result)
-	if err != nil {
-		return nil, err
-	}
-	return result, err
+	return client.GetTeams(map[string]string{"name": name})
 }

--- a/client/team.go
+++ b/client/team.go
@@ -82,7 +82,7 @@ func (client *ApiClient) GetTeams(params map[string]string) ([]Team, error) {
 	return result, err
 }
 
-func (client *ApiClient) Teams(params map[string]string) ([]Team, error) {
+func (client *ApiClient) Teams() ([]Team, error) {
 	return client.GetTeams(nil)
 }
 

--- a/client/team.go
+++ b/client/team.go
@@ -81,3 +81,16 @@ func (client *ApiClient) Teams() ([]Team, error) {
 	}
 	return result, err
 }
+
+func (client *ApiClient) TeamsByName(name string) ([]Team, error) {
+	organizationId, err := client.OrganizationId()
+	if err != nil {
+		return nil, err
+	}
+	var result []Team
+	err = client.http.Get("/teams/organizations/"+organizationId, map[string]string{"name": name}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}

--- a/env0/data_team_test.go
+++ b/env0/data_team_test.go
@@ -60,9 +60,9 @@ func TestTeamDataSource(t *testing.T) {
 		}
 	}
 
-	mockListTeamsCall := func(returnValue []client.Team) func(mockFunc *client.MockApiClientInterface) {
+	mockTeamsByNameCall := func(returnValue []client.Team) func(mockFunc *client.MockApiClientInterface) {
 		return func(mock *client.MockApiClientInterface) {
-			mock.EXPECT().Teams().AnyTimes().Return(returnValue, nil)
+			mock.EXPECT().TeamsByName(team.Name).AnyTimes().Return(returnValue, nil)
 		}
 	}
 
@@ -76,7 +76,7 @@ func TestTeamDataSource(t *testing.T) {
 	t.Run("By Name", func(t *testing.T) {
 		runUnitTest(t,
 			getValidTestCase(teamFieldsByName),
-			mockListTeamsCall([]client.Team{team, otherTeam}),
+			mockTeamsByNameCall([]client.Team{team, otherTeam}),
 		)
 	})
 
@@ -90,21 +90,21 @@ func TestTeamDataSource(t *testing.T) {
 	t.Run("Throw error when by name and more than one team exists", func(t *testing.T) {
 		runUnitTest(t,
 			getErrorTestCase(teamFieldsByName, "Found multiple teams for name"),
-			mockListTeamsCall([]client.Team{team, team, otherTeam}),
+			mockTeamsByNameCall([]client.Team{team, team, otherTeam}),
 		)
 	})
 
 	t.Run("Throw error when by name and no projects found at all", func(t *testing.T) {
 		runUnitTest(t,
 			getErrorTestCase(teamFieldsByName, "Could not find an env0 team with name"),
-			mockListTeamsCall([]client.Team{}),
+			mockTeamsByNameCall([]client.Team{}),
 		)
 	})
 
 	t.Run("Throw error when by name and no teams found with that name", func(t *testing.T) {
 		runUnitTest(t,
 			getErrorTestCase(teamFieldsByName, "Could not find an env0 team with name"),
-			mockListTeamsCall([]client.Team{otherTeam}),
+			mockTeamsByNameCall([]client.Team{otherTeam}),
 		)
 	})
 }

--- a/env0/resource_team.go
+++ b/env0/resource_team.go
@@ -114,9 +114,9 @@ func resourceTeamImport(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 }
 
-func getTeamByName(name interface{}, meta interface{}) (client.Team, diag.Diagnostics) {
+func getTeamByName(name string, meta interface{}) (client.Team, diag.Diagnostics) {
 	apiClient := meta.(client.ApiClientInterface)
-	teams, err := apiClient.Teams()
+	teams, err := apiClient.TeamsByName(name)
 	if err != nil {
 		return client.Team{}, diag.Errorf("Could not get teams: %v", err)
 	}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #520 

### Solution
Add `name` QS to get-teams-by-name
