### PR TITLE
Fix: "Infinite" isn't a valid value for the max/default TTL Policies API

### DIFF
--- a/client/project_policy.go
+++ b/client/project_policy.go
@@ -19,8 +19,8 @@ type Policy struct {
 
 type PolicyUpdatePayload struct {
 	ProjectId                   string `json:"projectId"`
-	NumberOfEnvironments        *int   `json:"numberOfEnvironments,omitempty" tfschema:",omitempty"`
-	NumberOfEnvironmentsTotal   *int   `json:"numberOfEnvironmentsTotal,omitempty" tfschema:",omitempty"`
+	NumberOfEnvironments        int    `json:"numberOfEnvironments,omitempty"`
+	NumberOfEnvironmentsTotal   int    `json:"numberOfEnvironmentsTotal,omitempty"`
 	RequiresApprovalDefault     bool   `json:"requiresApprovalDefault"`
 	IncludeCostEstimation       bool   `json:"includeCostEstimation"`
 	SkipApplyWhenPlanIsEmpty    bool   `json:"skipApplyWhenPlanIsEmpty"`

--- a/client/project_policy.go
+++ b/client/project_policy.go
@@ -19,8 +19,8 @@ type Policy struct {
 
 type PolicyUpdatePayload struct {
 	ProjectId                   string `json:"projectId"`
-	NumberOfEnvironments        *int   `json:"numberOfEnvironments" tfschema:",omitempty"`
-	NumberOfEnvironmentsTotal   *int   `json:"numberOfEnvironmentsTotal" tfschema:",omitempty"`
+	NumberOfEnvironments        *int   `json:"numberOfEnvironments,omitempty" tfschema:",omitempty"`
+	NumberOfEnvironmentsTotal   *int   `json:"numberOfEnvironmentsTotal,omitempty" tfschema:",omitempty"`
 	RequiresApprovalDefault     bool   `json:"requiresApprovalDefault"`
 	IncludeCostEstimation       bool   `json:"includeCostEstimation"`
 	SkipApplyWhenPlanIsEmpty    bool   `json:"skipApplyWhenPlanIsEmpty"`

--- a/env0/resource_project_policy.go
+++ b/env0/resource_project_policy.go
@@ -38,13 +38,13 @@ func resourcePolicy() *schema.Resource {
 			},
 			"number_of_environments": {
 				Type:             schema.TypeInt,
-				Description:      "Max number of environments a single user can have in this project.\nSetting to `null` or omitting, removes the restriction.",
+				Description:      "Max number of environments a single user can have in this project.\nOmitting removes the restriction.",
 				Optional:         true,
 				ValidateDiagFunc: NewGreaterThanValidator(0),
 			},
 			"number_of_environments_total": {
 				Type:             schema.TypeInt,
-				Description:      "Max number of environments in this project.\nSetting to `null` or omitting, removes the restriction.",
+				Description:      "Max number of environments in this project.\nnOmitting removes the restriction.",
 				Optional:         true,
 				ValidateDiagFunc: NewGreaterThanValidator(0),
 			},
@@ -162,7 +162,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		payload.DefaultTtl = ""
 	}
 
-	if payload.MaxTtl == "Infinine" {
+	if payload.MaxTtl == "Infinite" {
 		payload.MaxTtl = ""
 	}
 

--- a/env0/resource_project_policy.go
+++ b/env0/resource_project_policy.go
@@ -44,7 +44,7 @@ func resourcePolicy() *schema.Resource {
 			},
 			"number_of_environments_total": {
 				Type:             schema.TypeInt,
-				Description:      "Max number of environments in this project.\nnOmitting removes the restriction.",
+				Description:      "Max number of environments in this project.\nOmitting removes the restriction.",
 				Optional:         true,
 				ValidateDiagFunc: NewGreaterThanValidator(0),
 			},

--- a/env0/resource_project_policy_test.go
+++ b/env0/resource_project_policy_test.go
@@ -25,7 +25,8 @@ func TestUnitPolicyResource(t *testing.T) {
 		DisableDestroyEnvironments: true,
 		SkipRedundantDeployments:   true,
 		UpdatedBy:                  "updater0",
-		DefaultTtl:                 stringPtr("6-h"),
+		MaxTtl:                     stringPtr("inherit"),
+		DefaultTtl:                 stringPtr("inherit"),
 	}
 
 	updatedPolicy := client.Policy{
@@ -48,110 +49,107 @@ func TestUnitPolicyResource(t *testing.T) {
 		RequiresApprovalDefault: true,
 	}
 
-	testCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"project_id":                    policy.ProjectId,
-					"number_of_environments":        *policy.NumberOfEnvironments,
-					"number_of_environments_total":  *policy.NumberOfEnvironmentsTotal,
-					"requires_approval_default":     policy.RequiresApprovalDefault,
-					"include_cost_estimation":       policy.IncludeCostEstimation,
-					"skip_apply_when_plan_is_empty": policy.SkipApplyWhenPlanIsEmpty,
-					"disable_destroy_environments":  policy.DisableDestroyEnvironments,
-					"skip_redundant_deployments":    policy.SkipRedundantDeployments,
-					"run_pull_request_plan_default": policy.RunPullRequestPlanDefault,
-					"continuous_deployment_default": policy.ContinuousDeploymentDefault,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "project_id", policy.ProjectId),
-					resource.TestCheckResourceAttr(accessor, "number_of_environments", strconv.Itoa(*policy.NumberOfEnvironments)),
-					resource.TestCheckResourceAttr(accessor, "number_of_environments_total", strconv.Itoa(*policy.NumberOfEnvironmentsTotal)),
-					resource.TestCheckResourceAttr(accessor, "requires_approval_default", strconv.FormatBool(policy.RequiresApprovalDefault)),
-					resource.TestCheckResourceAttr(accessor, "include_cost_estimation", strconv.FormatBool(policy.IncludeCostEstimation)),
-					resource.TestCheckResourceAttr(accessor, "skip_apply_when_plan_is_empty", strconv.FormatBool(policy.SkipApplyWhenPlanIsEmpty)),
-					resource.TestCheckResourceAttr(accessor, "disable_destroy_environments", strconv.FormatBool(policy.DisableDestroyEnvironments)),
-					resource.TestCheckResourceAttr(accessor, "skip_redundant_deployments", strconv.FormatBool(policy.SkipRedundantDeployments)),
-					resource.TestCheckResourceAttr(accessor, "run_pull_request_plan_default", strconv.FormatBool(policy.RunPullRequestPlanDefault)),
-					resource.TestCheckResourceAttr(accessor, "continuous_deployment_default", strconv.FormatBool(policy.ContinuousDeploymentDefault)),
-					resource.TestCheckResourceAttr(accessor, "max_ttl", "inherit"),
-					resource.TestCheckResourceAttr(accessor, "default_ttl", "inherit"),
-				),
+	t.Run("create and update", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"project_id":                    policy.ProjectId,
+						"number_of_environments":        *policy.NumberOfEnvironments,
+						"number_of_environments_total":  *policy.NumberOfEnvironmentsTotal,
+						"requires_approval_default":     policy.RequiresApprovalDefault,
+						"include_cost_estimation":       policy.IncludeCostEstimation,
+						"skip_apply_when_plan_is_empty": policy.SkipApplyWhenPlanIsEmpty,
+						"disable_destroy_environments":  policy.DisableDestroyEnvironments,
+						"skip_redundant_deployments":    policy.SkipRedundantDeployments,
+						"run_pull_request_plan_default": policy.RunPullRequestPlanDefault,
+						"continuous_deployment_default": policy.ContinuousDeploymentDefault,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "project_id", policy.ProjectId),
+						resource.TestCheckResourceAttr(accessor, "number_of_environments", strconv.Itoa(*policy.NumberOfEnvironments)),
+						resource.TestCheckResourceAttr(accessor, "number_of_environments_total", strconv.Itoa(*policy.NumberOfEnvironmentsTotal)),
+						resource.TestCheckResourceAttr(accessor, "requires_approval_default", strconv.FormatBool(policy.RequiresApprovalDefault)),
+						resource.TestCheckResourceAttr(accessor, "include_cost_estimation", strconv.FormatBool(policy.IncludeCostEstimation)),
+						resource.TestCheckResourceAttr(accessor, "skip_apply_when_plan_is_empty", strconv.FormatBool(policy.SkipApplyWhenPlanIsEmpty)),
+						resource.TestCheckResourceAttr(accessor, "disable_destroy_environments", strconv.FormatBool(policy.DisableDestroyEnvironments)),
+						resource.TestCheckResourceAttr(accessor, "skip_redundant_deployments", strconv.FormatBool(policy.SkipRedundantDeployments)),
+						resource.TestCheckResourceAttr(accessor, "run_pull_request_plan_default", strconv.FormatBool(policy.RunPullRequestPlanDefault)),
+						resource.TestCheckResourceAttr(accessor, "continuous_deployment_default", strconv.FormatBool(policy.ContinuousDeploymentDefault)),
+						resource.TestCheckResourceAttr(accessor, "max_ttl", "inherit"),
+						resource.TestCheckResourceAttr(accessor, "default_ttl", "inherit"),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"project_id":                    updatedPolicy.ProjectId,
+						"requires_approval_default":     updatedPolicy.RequiresApprovalDefault,
+						"include_cost_estimation":       updatedPolicy.IncludeCostEstimation,
+						"skip_apply_when_plan_is_empty": updatedPolicy.SkipApplyWhenPlanIsEmpty,
+						"disable_destroy_environments":  updatedPolicy.DisableDestroyEnvironments,
+						"skip_redundant_deployments":    updatedPolicy.SkipRedundantDeployments,
+						"max_ttl":                       "Infinite",
+						"default_ttl":                   *updatedPolicy.DefaultTtl,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "project_id", updatedPolicy.ProjectId),
+						resource.TestCheckResourceAttr(accessor, "number_of_environments", "0"),
+						resource.TestCheckResourceAttr(accessor, "number_of_environments_total", "0"),
+						resource.TestCheckResourceAttr(accessor, "requires_approval_default", strconv.FormatBool(updatedPolicy.RequiresApprovalDefault)),
+						resource.TestCheckResourceAttr(accessor, "include_cost_estimation", strconv.FormatBool(updatedPolicy.IncludeCostEstimation)),
+						resource.TestCheckResourceAttr(accessor, "skip_apply_when_plan_is_empty", strconv.FormatBool(updatedPolicy.SkipApplyWhenPlanIsEmpty)),
+						resource.TestCheckResourceAttr(accessor, "disable_destroy_environments", strconv.FormatBool(updatedPolicy.DisableDestroyEnvironments)),
+						resource.TestCheckResourceAttr(accessor, "skip_redundant_deployments", strconv.FormatBool(updatedPolicy.SkipRedundantDeployments)),
+						resource.TestCheckResourceAttr(accessor, "max_ttl", "Infinite"),
+						resource.TestCheckResourceAttr(accessor, "default_ttl", *updatedPolicy.DefaultTtl),
+					),
+				},
 			},
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"project_id":                    updatedPolicy.ProjectId,
-					"number_of_environments":        "null",
-					"number_of_environments_total":  "null",
-					"requires_approval_default":     updatedPolicy.RequiresApprovalDefault,
-					"include_cost_estimation":       updatedPolicy.IncludeCostEstimation,
-					"skip_apply_when_plan_is_empty": updatedPolicy.SkipApplyWhenPlanIsEmpty,
-					"disable_destroy_environments":  updatedPolicy.DisableDestroyEnvironments,
-					"skip_redundant_deployments":    updatedPolicy.SkipRedundantDeployments,
-					"max_ttl":                       "Infinite",
-					"default_ttl":                   *updatedPolicy.DefaultTtl,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "project_id", updatedPolicy.ProjectId),
-					resource.TestCheckNoResourceAttr(accessor, "number_of_environments"),
-					resource.TestCheckNoResourceAttr(accessor, "number_of_environments_total"),
-					resource.TestCheckResourceAttr(accessor, "requires_approval_default", strconv.FormatBool(updatedPolicy.RequiresApprovalDefault)),
-					resource.TestCheckResourceAttr(accessor, "include_cost_estimation", strconv.FormatBool(updatedPolicy.IncludeCostEstimation)),
-					resource.TestCheckResourceAttr(accessor, "skip_apply_when_plan_is_empty", strconv.FormatBool(updatedPolicy.SkipApplyWhenPlanIsEmpty)),
-					resource.TestCheckResourceAttr(accessor, "disable_destroy_environments", strconv.FormatBool(updatedPolicy.DisableDestroyEnvironments)),
-					resource.TestCheckResourceAttr(accessor, "skip_redundant_deployments", strconv.FormatBool(updatedPolicy.SkipRedundantDeployments)),
-					resource.TestCheckResourceAttr(accessor, "max_ttl", "Infinite"),
-					resource.TestCheckResourceAttr(accessor, "default_ttl", *updatedPolicy.DefaultTtl),
-				),
-			},
-		},
-	}
+		}
 
-	runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-		// Create
-		mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
-			ProjectId:                  policy.ProjectId,
-			NumberOfEnvironments:       policy.NumberOfEnvironments,
-			NumberOfEnvironmentsTotal:  policy.NumberOfEnvironmentsTotal,
-			RequiresApprovalDefault:    policy.RequiresApprovalDefault,
-			IncludeCostEstimation:      policy.IncludeCostEstimation,
-			SkipApplyWhenPlanIsEmpty:   policy.SkipApplyWhenPlanIsEmpty,
-			DisableDestroyEnvironments: policy.DisableDestroyEnvironments,
-			SkipRedundantDeployments:   policy.SkipRedundantDeployments,
-			MaxTtl:                     "inherit",
-			DefaultTtl:                 "inherit",
-		}).Times(1).Return(policy, nil)
-
-		// Update
-		mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
-			ProjectId:                  updatedPolicy.ProjectId,
-			NumberOfEnvironments:       updatedPolicy.NumberOfEnvironments,
-			NumberOfEnvironmentsTotal:  updatedPolicy.NumberOfEnvironmentsTotal,
-			RequiresApprovalDefault:    updatedPolicy.RequiresApprovalDefault,
-			IncludeCostEstimation:      updatedPolicy.IncludeCostEstimation,
-			SkipApplyWhenPlanIsEmpty:   updatedPolicy.SkipApplyWhenPlanIsEmpty,
-			DisableDestroyEnvironments: updatedPolicy.DisableDestroyEnvironments,
-			SkipRedundantDeployments:   updatedPolicy.SkipRedundantDeployments,
-			MaxTtl:                     *updatedPolicy.MaxTtl,
-			DefaultTtl:                 *updatedPolicy.DefaultTtl,
-		}).Times(1).Return(policy, nil)
-
-		gomock.InOrder(
-			mock.EXPECT().Policy(gomock.Any()).Times(2).Return(policy, nil),        // 1 after create, 1 before update
-			mock.EXPECT().Policy(gomock.Any()).Times(1).Return(updatedPolicy, nil), // 1 after create, 1 before update
-		)
-
-		// Delete
-		mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
-			ProjectId:                  resetPolicy.ProjectId,
-			NumberOfEnvironments:       resetPolicy.NumberOfEnvironments,
-			NumberOfEnvironmentsTotal:  resetPolicy.NumberOfEnvironmentsTotal,
-			RequiresApprovalDefault:    resetPolicy.RequiresApprovalDefault,
-			IncludeCostEstimation:      resetPolicy.IncludeCostEstimation,
-			SkipApplyWhenPlanIsEmpty:   resetPolicy.SkipApplyWhenPlanIsEmpty,
-			DisableDestroyEnvironments: resetPolicy.DisableDestroyEnvironments,
-			SkipRedundantDeployments:   resetPolicy.SkipRedundantDeployments,
-		}).Times(1).Return(resetPolicy, nil)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				// Create
+				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+					ProjectId:                  policy.ProjectId,
+					NumberOfEnvironments:       policy.NumberOfEnvironments,
+					NumberOfEnvironmentsTotal:  policy.NumberOfEnvironmentsTotal,
+					RequiresApprovalDefault:    policy.RequiresApprovalDefault,
+					IncludeCostEstimation:      policy.IncludeCostEstimation,
+					SkipApplyWhenPlanIsEmpty:   policy.SkipApplyWhenPlanIsEmpty,
+					DisableDestroyEnvironments: policy.DisableDestroyEnvironments,
+					SkipRedundantDeployments:   policy.SkipRedundantDeployments,
+					MaxTtl:                     "inherit",
+					DefaultTtl:                 "inherit",
+				}).Times(1).Return(policy, nil),
+				mock.EXPECT().Policy(gomock.Any()).Times(2).Return(policy, nil), // 1 after create, 1 before update
+				// Update
+				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+					ProjectId:                  updatedPolicy.ProjectId,
+					NumberOfEnvironments:       updatedPolicy.NumberOfEnvironments,
+					NumberOfEnvironmentsTotal:  updatedPolicy.NumberOfEnvironmentsTotal,
+					RequiresApprovalDefault:    updatedPolicy.RequiresApprovalDefault,
+					IncludeCostEstimation:      updatedPolicy.IncludeCostEstimation,
+					SkipApplyWhenPlanIsEmpty:   updatedPolicy.SkipApplyWhenPlanIsEmpty,
+					DisableDestroyEnvironments: updatedPolicy.DisableDestroyEnvironments,
+					SkipRedundantDeployments:   updatedPolicy.SkipRedundantDeployments,
+					MaxTtl:                     "",
+					DefaultTtl:                 *updatedPolicy.DefaultTtl,
+				}).Times(1).Return(updatedPolicy, nil),
+				mock.EXPECT().Policy(gomock.Any()).Times(1).Return(updatedPolicy, nil), // 1 after update.
+				// Delete
+				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+					ProjectId:                  resetPolicy.ProjectId,
+					NumberOfEnvironments:       resetPolicy.NumberOfEnvironments,
+					NumberOfEnvironmentsTotal:  resetPolicy.NumberOfEnvironmentsTotal,
+					RequiresApprovalDefault:    resetPolicy.RequiresApprovalDefault,
+					IncludeCostEstimation:      resetPolicy.IncludeCostEstimation,
+					SkipApplyWhenPlanIsEmpty:   resetPolicy.SkipApplyWhenPlanIsEmpty,
+					DisableDestroyEnvironments: resetPolicy.DisableDestroyEnvironments,
+					SkipRedundantDeployments:   resetPolicy.SkipRedundantDeployments,
+				}).Times(1).Return(resetPolicy, nil),
+			)
+		})
 	})
 
 	t.Run("requires_approval_default default is true", func(t *testing.T) {

--- a/env0/resource_project_policy_test.go
+++ b/env0/resource_project_policy_test.go
@@ -112,8 +112,8 @@ func TestUnitPolicyResource(t *testing.T) {
 				// Create
 				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
 					ProjectId:                  policy.ProjectId,
-					NumberOfEnvironments:       policy.NumberOfEnvironments,
-					NumberOfEnvironmentsTotal:  policy.NumberOfEnvironmentsTotal,
+					NumberOfEnvironments:       *policy.NumberOfEnvironments,
+					NumberOfEnvironmentsTotal:  *policy.NumberOfEnvironmentsTotal,
 					RequiresApprovalDefault:    policy.RequiresApprovalDefault,
 					IncludeCostEstimation:      policy.IncludeCostEstimation,
 					SkipApplyWhenPlanIsEmpty:   policy.SkipApplyWhenPlanIsEmpty,
@@ -126,8 +126,8 @@ func TestUnitPolicyResource(t *testing.T) {
 				// Update
 				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
 					ProjectId:                  updatedPolicy.ProjectId,
-					NumberOfEnvironments:       updatedPolicy.NumberOfEnvironments,
-					NumberOfEnvironmentsTotal:  updatedPolicy.NumberOfEnvironmentsTotal,
+					NumberOfEnvironments:       0,
+					NumberOfEnvironmentsTotal:  0,
 					RequiresApprovalDefault:    updatedPolicy.RequiresApprovalDefault,
 					IncludeCostEstimation:      updatedPolicy.IncludeCostEstimation,
 					SkipApplyWhenPlanIsEmpty:   updatedPolicy.SkipApplyWhenPlanIsEmpty,
@@ -140,8 +140,8 @@ func TestUnitPolicyResource(t *testing.T) {
 				// Delete
 				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
 					ProjectId:                  resetPolicy.ProjectId,
-					NumberOfEnvironments:       resetPolicy.NumberOfEnvironments,
-					NumberOfEnvironmentsTotal:  resetPolicy.NumberOfEnvironmentsTotal,
+					NumberOfEnvironments:       0,
+					NumberOfEnvironmentsTotal:  0,
 					RequiresApprovalDefault:    resetPolicy.RequiresApprovalDefault,
 					IncludeCostEstimation:      resetPolicy.IncludeCostEstimation,
 					SkipApplyWhenPlanIsEmpty:   resetPolicy.SkipApplyWhenPlanIsEmpty,
@@ -199,8 +199,8 @@ func TestUnitPolicyResource(t *testing.T) {
 		runUnitTest(t, testCaseForDefault, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
 				ProjectId:                  policy.ProjectId,
-				NumberOfEnvironments:       policy.NumberOfEnvironments,
-				NumberOfEnvironmentsTotal:  policy.NumberOfEnvironmentsTotal,
+				NumberOfEnvironments:       *policy.NumberOfEnvironments,
+				NumberOfEnvironmentsTotal:  *policy.NumberOfEnvironmentsTotal,
 				RequiresApprovalDefault:    true,
 				IncludeCostEstimation:      policy.IncludeCostEstimation,
 				SkipApplyWhenPlanIsEmpty:   policy.SkipApplyWhenPlanIsEmpty,
@@ -214,8 +214,8 @@ func TestUnitPolicyResource(t *testing.T) {
 
 			mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
 				ProjectId:                  resetPolicy.ProjectId,
-				NumberOfEnvironments:       resetPolicy.NumberOfEnvironments,
-				NumberOfEnvironmentsTotal:  resetPolicy.NumberOfEnvironmentsTotal,
+				NumberOfEnvironments:       0,
+				NumberOfEnvironmentsTotal:  0,
 				RequiresApprovalDefault:    resetPolicy.RequiresApprovalDefault,
 				IncludeCostEstimation:      resetPolicy.IncludeCostEstimation,
 				SkipApplyWhenPlanIsEmpty:   resetPolicy.SkipApplyWhenPlanIsEmpty,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #549 

### Solution
The acceptance test was crashing, and therefore it never ran successfully (and was hiding the bug).
Once I fixed the test I saw a couple of problems. I fixed them.
This should now work as expected.