### PR TITLE
Fix: acceptance tests pass when test crashes

### DIFF
--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func runUnitTest(t *testing.T, testCase resource.TestCase, mockFunc func(mockFunc *client.MockApiClientInterface)) {
+	t.Helper()
+
 	os.Setenv("TF_ACC", "1")
 	os.Setenv("ENV0_API_KEY", "value")
 	os.Setenv("ENV0_API_SECRET", "value")
@@ -29,7 +31,6 @@ func runUnitTest(t *testing.T, testCase resource.TestCase, mockFunc func(mockFun
 
 	testReporter := utils.TestReporter{T: t}
 	ctrl := gomock.NewController(&testReporter)
-	defer ctrl.Finish()
 
 	apiClientMock := client.NewMockApiClientInterface(ctrl)
 	mockFunc(apiClientMock)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #552 

### Solution

There's an issue with gomock. It "recovers" from the exception but doesn't check if there was an exception.
I think it's happening because Finish() is called multiple times.

Starting from go 1.14 if the function cleanUp is available, it will call finish from the cleanup function (which testReporter implements).
Now finish is called once and a fatal is properly thrown.

It's not entirely clear why the code is implemented this way, and why would we ever want to ignore a panic. This probably a bug in gomock.

gomock code
```
func (ctrl *Controller) finish(cleanup bool, panicErr interface{}) {
	ctrl.T.Helper()

	ctrl.mu.Lock()
	defer ctrl.mu.Unlock()

	if ctrl.finished {
		if _, ok := isCleanuper(ctrl.T); !ok {
			ctrl.T.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
		}
		return
	}
	ctrl.finished = true

	// Short-circuit, pass through the panic.
	if panicErr != nil {
		panic(panicErr)
	}

	// Check that all remaining expected calls are satisfied.
	failures := ctrl.expectedCalls.Failures()
	for _, call := range failures {
		ctrl.T.Errorf("missing call(s) to %v", call)
	}
	if len(failures) != 0 {
		if !cleanup {
			ctrl.T.Fatalf("aborting test due to missing call(s)")
			return
		}
		ctrl.T.Errorf("aborting test due to missing call(s)")
	}
}
```
