### PR TITLE
Fix env0_agent_project_assignment resource example

### DIFF
--- a/examples/resources/env0_agent_project_assignment/resource.tf
+++ b/examples/resources/env0_agent_project_assignment/resource.tf
@@ -5,7 +5,7 @@ resource "env0_project" "example" {
 
 data "env0_agents" "agents" {}
 
-resource "env0_agent_project_assignment" {
+resource "env0_agent_project_assignment" "example" {
   agent_id   = data.env0_agents.agents.0.agent_key
   project_id = env0_project.example.id
 }


### PR DESCRIPTION
The example was missing a name.

