### PR TITLE
Feat: retry on 404 errors on harness testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
     runs-on: ubuntu-20.04
     container: golang:1.18-alpine3.16
     timeout-minutes: 20
-    env:
-      INTEGRATION_TESTS: 1
     steps:
       - name: Install Terraform
         run: apk add terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: ubuntu-20.04
     container: golang:1.18-alpine3.16
     timeout-minutes: 20
+    env:
+      INTEGRATION_TESTS: 1
     steps:
       - name: Install Terraform
         run: apk add terraform

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -2,6 +2,7 @@ package env0
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/env0/terraform-provider-env0/client"
@@ -128,6 +129,12 @@ func configureProvider(version string, p *schema.Provider) schema.ConfigureConte
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		restyClient := resty.New()
 
+		isIntegrationTest := false
+
+		if os.Getenv("INTEGRATION_TESTS") == "1" {
+			isIntegrationTest = true
+		}
+
 		restyClient.
 			SetRetryCount(5).
 			SetRetryWaitTime(time.Second).
@@ -139,7 +146,8 @@ func configureProvider(version string, p *schema.Provider) schema.ConfigureConte
 				}
 
 				// Retry when there's a 5xx error. Otherwise do not retry.
-				return r.StatusCode() >= 500
+				// When running integration tests 404 may occur due to "database eventual consistency".
+				return r.StatusCode() >= 500 || (isIntegrationTest && r.StatusCode() == 404)
 			})
 
 		httpClient, err := http.NewHttpClient(http.HttpClientConfig{

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -14,11 +14,10 @@ import (
 const TESTS_FOLDER = "tests/integration"
 
 func main() {
-	err := compileProvider()
-	if err != nil {
-		log.Fatalln("Couldn't compile go")
-		return
+	if err := compileProvider(); err != nil {
+		log.Fatalf("failed to compile go: %v", err)
 	}
+
 	printTerraformVersion()
 	makeSureRunningFromProjectRoot()
 	testNames := testNamesFromCommandLineArguments()
@@ -151,6 +150,8 @@ func terraformDestory(testName string) {
 func terraformCommand(testName string, arg ...string) ([]byte, error) {
 	cmd := exec.Command("terraform", arg...)
 	cmd.Dir = TESTS_FOLDER + "/" + testName
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "INTEGRATION_TESTS=1")
 	log.Println("Running terraform ", arg, " in ", testName)
 	outputBytes, err := cmd.CombinedOutput()
 	output := string(outputBytes)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #568 

### Solution

Passing an environment variable via the integration tests pipeline.
If the environment variable is set - retry on 404 as well.