### PR TITLE
Feat: env0_api_key resource and data source don't store apiKeyId

### DIFF
--- a/env0/data_api_key.go
+++ b/env0/data_api_key.go
@@ -25,6 +25,11 @@ func dataApiKey() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "id"},
 			},
+			"api_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the api key id",
+			},
 		},
 	}
 }

--- a/env0/data_api_key_test.go
+++ b/env0/data_api_key_test.go
@@ -39,6 +39,7 @@ func TestApiKeyDataSource(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", apiKey.Id),
 						resource.TestCheckResourceAttr(accessor, "name", apiKey.Name),
+						resource.TestCheckResourceAttr(accessor, "api_key_id", apiKey.ApiKeyId),
 					),
 				},
 			},

--- a/env0/resource_api_key.go
+++ b/env0/resource_api_key.go
@@ -46,6 +46,11 @@ func resourceApiKey() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"api_key_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "the api key id",
+			},
 		},
 	}
 }
@@ -66,13 +71,13 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("could not create api key: %v", err)
 	}
 
-	if omit, ok := d.GetOk("omit_api_key_secret"); ok && omit.(bool) {
-		d.Set("api_key_secret", "omitted")
-	} else {
-		d.Set("api_key_secret", apiKey.ApiKeySecret)
+	if err := writeResourceData(apiKey, d); err != nil {
+		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
-	d.SetId(apiKey.Id)
+	if omit, ok := d.GetOk("omit_api_key_secret"); ok && omit.(bool) {
+		d.Set("api_key_secret", "omitted")
+	}
 
 	return nil
 }

--- a/env0/resource_api_key_test.go
+++ b/env0/resource_api_key_test.go
@@ -57,6 +57,7 @@ func TestUnitApiKeyResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "name", apiKey.Name),
 						resource.TestCheckResourceAttr(accessor, "organization_role", apiKey.OrganizationRole),
 						resource.TestCheckResourceAttr(accessor, "api_key_secret", apiKey.ApiKeySecret),
+						resource.TestCheckResourceAttr(accessor, "api_key_id", apiKey.ApiKeyId),
 					),
 				},
 				{
@@ -68,6 +69,7 @@ func TestUnitApiKeyResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "name", updatedApiKey.Name),
 						resource.TestCheckResourceAttr(accessor, "organization_role", updatedApiKey.OrganizationRole),
 						resource.TestCheckResourceAttr(accessor, "api_key_secret", updatedApiKey.ApiKeySecret),
+						resource.TestCheckResourceAttr(accessor, "api_key_id", updatedApiKey.ApiKeyId),
 					),
 				},
 			},
@@ -135,6 +137,7 @@ func TestUnitApiKeyResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "name", apiKey.Name),
 						resource.TestCheckResourceAttr(accessor, "organization_role", apiKey.OrganizationRole),
 						resource.TestCheckResourceAttr(accessor, "api_key_secret", "omitted"),
+						resource.TestCheckResourceAttr(accessor, "api_key_id", apiKey.ApiKeyId),
 					),
 				},
 			},


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #581 

### Solution
1. added api_key_id to resource and data schemas.
2. updated acceptance tests.
