### PR TITLE
Feat: add support for Sub Projects to Project data and resource

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -1,21 +1,23 @@
 package client
 
 type Project struct {
-	IsArchived     bool   `json:"isArchived"`
-	OrganizationId string `json:"organizationId"`
-	UpdatedAt      string `json:"updatedAt"`
-	CreatedAt      string `json:"createdAt"`
-	Id             string `json:"id"`
-	Name           string `json:"name"`
-	CreatedBy      string `json:"createdBy"`
-	Role           string `json:"role"`
-	CreatedByUser  User   `json:"createdByUser"`
-	Description    string `json:"description"`
+	IsArchived      bool   `json:"isArchived"`
+	OrganizationId  string `json:"organizationId"`
+	UpdatedAt       string `json:"updatedAt"`
+	CreatedAt       string `json:"createdAt"`
+	Id              string `json:"id"`
+	Name            string `json:"name"`
+	CreatedBy       string `json:"createdBy"`
+	Role            string `json:"role"`
+	CreatedByUser   User   `json:"createdByUser"`
+	Description     string `json:"description"`
+	ParentProjectId string `json:"parentProjectId,omitempty" tfschema:",omitempty"`
 }
 
 type ProjectCreatePayload struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	ParentProjectId string `json:"parentProjectId,omitempty"`
 }
 
 func (client *ApiClient) Projects() ([]Project, error) {

--- a/env0/data_project.go
+++ b/env0/data_project.go
@@ -44,6 +44,11 @@ func dataProject() *schema.Resource {
 				Description: "textual description of the project",
 				Computed:    true,
 			},
+			"parent_project_id": {
+				Type:        schema.TypeString,
+				Description: "if the project is a sub-project, returns the parent of this sub-project",
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/env0/data_project_test.go
+++ b/env0/data_project_test.go
@@ -11,11 +11,12 @@ import (
 
 func TestProjectDataSource(t *testing.T) {
 	project := client.Project{
-		Id:          "id0",
-		Name:        "my-project-1",
-		CreatedBy:   "env0",
-		Role:        "role0",
-		Description: "A project's description",
+		Id:              "id0",
+		Name:            "my-project-1",
+		CreatedBy:       "env0",
+		Role:            "role0",
+		Description:     "A project's description",
+		ParentProjectId: "parent_id",
 	}
 
 	archivedProject := client.Project{
@@ -45,6 +46,7 @@ func TestProjectDataSource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "created_by", project.CreatedBy),
 						resource.TestCheckResourceAttr(accessor, "role", project.Role),
 						resource.TestCheckResourceAttr(accessor, "description", project.Description),
+						resource.TestCheckResourceAttr(accessor, "parent_project_id", project.ParentProjectId),
 					),
 				},
 			},

--- a/env0/resource_project.go
+++ b/env0/resource_project.go
@@ -63,6 +63,12 @@ func resourceProject() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
+			"parent_project_id": {
+				Type:        schema.TypeString,
+				Description: "If set, the project becomes a 'sub-project' of the parent project. See https://docs.env0.com/docs/sub-projects",
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 	}
 }

--- a/env0/resource_project_test.go
+++ b/env0/resource_project_test.go
@@ -27,50 +27,92 @@ func TestUnitProjectResource(t *testing.T) {
 		Description: "new description",
 	}
 
-	testCase := resource.TestCase{
-		Steps: []resource.TestStep{
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"name":        project.Name,
-					"description": project.Description,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "id", project.Id),
-					resource.TestCheckResourceAttr(accessor, "name", project.Name),
-					resource.TestCheckResourceAttr(accessor, "description", project.Description),
-				),
-			},
-			{
-				Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-					"name":        updatedProject.Name,
-					"description": updatedProject.Description,
-				}),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(accessor, "id", updatedProject.Id),
-					resource.TestCheckResourceAttr(accessor, "name", updatedProject.Name),
-					resource.TestCheckResourceAttr(accessor, "description", updatedProject.Description),
-				),
-			},
-		},
+	subProject := client.Project{
+		Id:              "subProjectId",
+		Description:     "sub project des",
+		Name:            "sub project nam",
+		ParentProjectId: project.Id,
 	}
 
-	runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-		mock.EXPECT().ProjectCreate(client.ProjectCreatePayload{
-			Name:        project.Name,
-			Description: project.Description,
-		}).Times(1).Return(project, nil)
-		mock.EXPECT().ProjectUpdate(updatedProject.Id, client.ProjectCreatePayload{
-			Name:        updatedProject.Name,
-			Description: updatedProject.Description,
-		}).Times(1).Return(updatedProject, nil)
+	t.Run("Test project", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":        project.Name,
+						"description": project.Description,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", project.Id),
+						resource.TestCheckResourceAttr(accessor, "name", project.Name),
+						resource.TestCheckResourceAttr(accessor, "description", project.Description),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":        updatedProject.Name,
+						"description": updatedProject.Description,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", updatedProject.Id),
+						resource.TestCheckResourceAttr(accessor, "name", updatedProject.Name),
+						resource.TestCheckResourceAttr(accessor, "description", updatedProject.Description),
+					),
+				},
+			},
+		}
 
-		gomock.InOrder(
-			mock.EXPECT().Project(gomock.Any()).Times(2).Return(project, nil),        // 1 after create, 1 before update
-			mock.EXPECT().Project(gomock.Any()).Times(1).Return(updatedProject, nil), // 1 after update
-			mock.EXPECT().ProjectEnvironments(project.Id).Times(1).Return([]client.Environment{}, nil),
-		)
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().ProjectCreate(client.ProjectCreatePayload{
+				Name:        project.Name,
+				Description: project.Description,
+			}).Times(1).Return(project, nil)
+			mock.EXPECT().ProjectUpdate(updatedProject.Id, client.ProjectCreatePayload{
+				Name:        updatedProject.Name,
+				Description: updatedProject.Description,
+			}).Times(1).Return(updatedProject, nil)
 
-		mock.EXPECT().ProjectDelete(project.Id).Times(1)
+			gomock.InOrder(
+				mock.EXPECT().Project(gomock.Any()).Times(2).Return(project, nil),        // 1 after create, 1 before update
+				mock.EXPECT().Project(gomock.Any()).Times(1).Return(updatedProject, nil), // 1 after update
+				mock.EXPECT().ProjectEnvironments(project.Id).Times(1).Return([]client.Environment{}, nil),
+			)
+
+			mock.EXPECT().ProjectDelete(project.Id).Times(1)
+		})
+	})
+
+	t.Run("Test sub-project", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":              subProject.Name,
+						"description":       subProject.Description,
+						"parent_project_id": project.Id,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", subProject.Id),
+						resource.TestCheckResourceAttr(accessor, "name", subProject.Name),
+						resource.TestCheckResourceAttr(accessor, "description", subProject.Description),
+						resource.TestCheckResourceAttr(accessor, "parent_project_id", project.Id),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().ProjectCreate(client.ProjectCreatePayload{
+					Name:            subProject.Name,
+					Description:     subProject.Description,
+					ParentProjectId: project.Id,
+				}).Times(1).Return(subProject, nil),
+				mock.EXPECT().Project(subProject.Id).Times(1).Return(subProject, nil),
+				mock.EXPECT().ProjectEnvironments(subProject.Id).Times(1).Return([]client.Environment{}, nil),
+				mock.EXPECT().ProjectDelete(subProject.Id).Times(1),
+			)
+		})
 	})
 }
 

--- a/tests/integration/002_project/main.tf
+++ b/tests/integration/002_project/main.tf
@@ -10,6 +10,13 @@ resource "env0_project" "test_project" {
   name        = "Test-Project-${random_string.random.result}"
   description = "Test Description ${var.second_run ? "after update" : ""}"
 }
+
+resource "env0_project" "test_sub_project" {
+  name              = "Test-Sub-Project-${random_string.random.result}"
+  description       = "Test Description ${var.second_run ? "after update" : ""}"
+  parent_project_id = env0_project.test_project.id
+}
+
 data "env0_project" "data_by_name" {
   name = env0_project.test_project.name
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #597 

### Solution
1. Added a new field to data and resource.
2. Updated acceptance tests.
3. Updated integration tests.
4. update go.mod and go.sum due to a security issue.
