### PR TITLE
Chore: make template name unique in workflow environment integration tests

### DIFF
--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -115,7 +115,7 @@ resource "env0_environment" "inactive" {
 }
 
 resource "env0_template" "workflow_template" {
-  name              = "Template for workflow environment"
+  name              = "Template for workflow environment-${random_string.random.result}"
   type              = "workflow"
   repository        = "https://github.com/env0/templates"
   path              = "misc/workflow-environment-basic"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
fixes https://github.com/env0/terraform-provider-env0/issues/612
### Solution
add the random string suffix like for other templates
