### PR TITLE
Fix: project's parent_project_id does not work

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -49,8 +49,15 @@ func (client *ApiClient) ProjectCreate(payload ProjectCreatePayload) (Project, e
 		return Project{}, err
 	}
 
-	request := map[string]interface{}{"name": payload.Name, "organizationId": organizationId, "description": payload.Description}
-	err = client.http.Post("/projects", request, &result)
+	payloadWith := struct {
+		ProjectCreatePayload
+		OrganizationId string `json:"organizationId"`
+	}{
+		payload,
+		organizationId,
+	}
+
+	err = client.http.Post("/projects", payloadWith, &result)
 	if err != nil {
 		return Project{}, err
 	}

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -9,6 +9,7 @@ import (
 
 const projectName = "project_test"
 const projectDescription = "project description"
+const parentProjectId = "parent_project_id"
 
 var _ = Describe("Project", func() {
 	var project Project
@@ -23,20 +24,28 @@ var _ = Describe("Project", func() {
 		BeforeEach(func() {
 			mockOrganizationIdCall(organizationId)
 
-			httpCall = mockHttpClient.EXPECT().
-				Post("/projects", map[string]interface{}{
-					"name":           projectName,
-					"organizationId": organizationId,
-					"description":    projectDescription,
+			payload := struct {
+				ProjectCreatePayload
+				OrganizationId string `json:"organizationId"`
+			}{
+				ProjectCreatePayload{
+					Name:            projectName,
+					Description:     projectDescription,
+					ParentProjectId: parentProjectId,
 				},
-					gomock.Any()).
+				organizationId,
+			}
+
+			httpCall = mockHttpClient.EXPECT().
+				Post("/projects", payload, gomock.Any()).
 				Do(func(path string, request interface{}, response *Project) {
 					*response = mockProject
 				})
 
 			project, _ = apiClient.ProjectCreate(ProjectCreatePayload{
-				Name:        projectName,
-				Description: projectDescription,
+				Name:            projectName,
+				Description:     projectDescription,
+				ParentProjectId: parentProjectId,
 			})
 		})
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #617 

### Solution
1. Modified create project to pass payload instead of a custom map.
2. Updated HTTP client tests for create project.
3. Tested manually.
