### PR TITLE
Fix: Workflow environment creation integration test

### DIFF
--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -154,28 +154,30 @@ resource "env0_environment" "workflow-environment" {
   approve_plan_automatically = true
 
   sub_environment_configuration {
-    alias    = "rootService1"
-    revision = "master"
+    alias     = "rootService1"
+    revision  = "master"
+    workspace = "rootService1"
     configuration {
-      name  = "sub_env1_var1"
-      value = "hello"
+      name    = "sub_env1_var1"
+      value   = "hello"
     }
     configuration {
-      name  = "sub_env1_var2"
-      value = "world"
+      name    = "sub_env1_var2"
+      value   = "world"
     }
   }
 
   sub_environment_configuration {
-    alias    = "rootService2"
-    revision = "master"
+    alias     = "rootService2"
+    revision  = "master"
+    workspace = "rootService2"
     configuration {
-      name  = "sub_env2_var1"
-      value = "hello"
+      name    = "sub_env2_var1"
+      value   = "hello"
     }
     configuration {
-      name  = var.second_run ? "sub_env2_var3" : "sub_env2_var2"
-      value = var.second_run ? "world2" : "world"
+      name    = var.second_run ? "sub_env2_var3" : "sub_env2_var2"
+      value   = var.second_run ? "world2" : "world"
     }
   }
 }

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -156,7 +156,6 @@ resource "env0_environment" "workflow-environment" {
   sub_environment_configuration {
     alias     = "rootService1"
     revision  = "master"
-    workspace = "rootService1"
     configuration {
       name    = "sub_env1_var1"
       value   = "hello"

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -127,7 +127,7 @@ resource "env0_template" "workflow_template" {
   name              = "Template for workflow environment-${random_string.random.result}"
   type              = "workflow"
   repository        = "https://github.com/env0/templates"
-  path              = "misc/workflow-environment-basic"
+  path              = "misc/single-environment-workflow"
   terraform_version = "1.1.5"
 }
 

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -166,18 +166,4 @@ resource "env0_environment" "workflow-environment" {
       value   = "world"
     }
   }
-
-  sub_environment_configuration {
-    alias     = "rootService2"
-    revision  = "master"
-    workspace = "rootService2"
-    configuration {
-      name    = "sub_env2_var1"
-      value   = "hello"
-    }
-    configuration {
-      name    = var.second_run ? "sub_env2_var3" : "sub_env2_var2"
-      value   = var.second_run ? "world2" : "world"
-    }
-  }
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We want to prevent creating sub environments with the same workspace name and template name but since we can't explicitly set workspace name in the sub environment resource

### Solution
have a workflow template with a single environment
