### PR TITLE
Feat: allow editing sub project parentId so it uses our new move proj…

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -27,8 +27,9 @@ type ApiClientInterface interface {
 	Projects() ([]Project, error)
 	Project(id string) (Project, error)
 	ProjectCreate(payload ProjectCreatePayload) (Project, error)
-	ProjectUpdate(id string, payload ProjectCreatePayload) (Project, error)
+	ProjectUpdate(id string, payload ProjectUpdatePayload) (Project, error)
 	ProjectDelete(id string) error
+	ProjectMove(id string, targetProjectId string) error
 	Template(id string) (Template, error)
 	Templates() ([]Template, error)
 	TemplateCreate(payload TemplateCreatePayload) (Template, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -1084,8 +1084,22 @@ func (mr *MockApiClientInterfaceMockRecorder) ProjectEnvironments(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectEnvironments", reflect.TypeOf((*MockApiClientInterface)(nil).ProjectEnvironments), arg0)
 }
 
+// ProjectMove mocks base method.
+func (m *MockApiClientInterface) ProjectMove(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProjectMove", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ProjectMove indicates an expected call of ProjectMove.
+func (mr *MockApiClientInterfaceMockRecorder) ProjectMove(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectMove", reflect.TypeOf((*MockApiClientInterface)(nil).ProjectMove), arg0, arg1)
+}
+
 // ProjectUpdate mocks base method.
-func (m *MockApiClientInterface) ProjectUpdate(arg0 string, arg1 ProjectCreatePayload) (Project, error) {
+func (m *MockApiClientInterface) ProjectUpdate(arg0 string, arg1 ProjectUpdatePayload) (Project, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectUpdate", arg0, arg1)
 	ret0, _ := ret[0].(Project)

--- a/client/project.go
+++ b/client/project.go
@@ -84,10 +84,16 @@ func (client *ApiClient) ProjectUpdate(id string, payload ProjectUpdatePayload) 
 }
 
 func (client *ApiClient) ProjectMove(id string, targetProjectId string) error {
+	// Pass nil if a subproject becomes a project.
+	var targetProjectIdPtr *string
+	if targetProjectId != "" {
+		targetProjectIdPtr = &targetProjectId
+	}
+
 	payload := struct {
-		TargetProjectId string `json:"targetProjectId"`
+		TargetProjectId *string `json:"targetProjectId"`
 	}{
-		targetProjectId,
+		targetProjectIdPtr,
 	}
 
 	return client.http.Post("/projects/"+id+"/move", payload, nil)

--- a/client/project.go
+++ b/client/project.go
@@ -20,6 +20,11 @@ type ProjectCreatePayload struct {
 	ParentProjectId string `json:"parentProjectId,omitempty"`
 }
 
+type ProjectUpdatePayload struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 func (client *ApiClient) Projects() ([]Project, error) {
 	organizationId, err := client.OrganizationId()
 	if err != nil {
@@ -68,7 +73,7 @@ func (client *ApiClient) ProjectDelete(id string) error {
 	return client.http.Delete("/projects/" + id)
 }
 
-func (client *ApiClient) ProjectUpdate(id string, payload ProjectCreatePayload) (Project, error) {
+func (client *ApiClient) ProjectUpdate(id string, payload ProjectUpdatePayload) (Project, error) {
 	var result Project
 	err := client.http.Put("/projects/"+id, payload, &result)
 
@@ -76,4 +81,14 @@ func (client *ApiClient) ProjectUpdate(id string, payload ProjectCreatePayload) 
 		return Project{}, err
 	}
 	return result, nil
+}
+
+func (client *ApiClient) ProjectMove(id string, targetProjectId string) error {
+	payload := struct {
+		TargetProjectId string `json:"targetProjectId"`
+	}{
+		targetProjectId,
+	}
+
+	return client.http.Post("/projects/"+id+"/move", payload, nil)
 }

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Project", func() {
 	Describe("ProjectUpdate", func() {
 		var mockedResponse Project
 		BeforeEach(func() {
-			payload := ProjectCreatePayload{
+			payload := ProjectUpdatePayload{
 				Name:        "newName",
 				Description: "newDesc",
 			}
@@ -147,5 +147,22 @@ var _ = Describe("Project", func() {
 		It("Should return projects", func() {
 			Expect(projects).To(Equal(mockProjects))
 		})
+	})
+
+	Describe("ProjectMove", func() {
+		targetProjectId := "targetid"
+
+		payload := struct {
+			TargetProjectId string `json:"targetProjectId"`
+		}{
+			targetProjectId,
+		}
+
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Post("/projects/"+mockProject.Id+"/move", payload, nil).Times(1)
+			apiClient.ProjectMove(mockProject.Id, targetProjectId)
+		})
+
+		It("Should send POST request with project id and target project id", func() {})
 	})
 })

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -153,9 +153,9 @@ var _ = Describe("Project", func() {
 		targetProjectId := "targetid"
 
 		payload := struct {
-			TargetProjectId string `json:"targetProjectId"`
+			TargetProjectId *string `json:"targetProjectId"`
 		}{
-			targetProjectId,
+			&targetProjectId,
 		}
 
 		BeforeEach(func() {
@@ -164,5 +164,20 @@ var _ = Describe("Project", func() {
 		})
 
 		It("Should send POST request with project id and target project id", func() {})
+	})
+
+	Describe("ProjectMove with no target project id", func() {
+		payload := struct {
+			TargetProjectId *string `json:"targetProjectId"`
+		}{
+			nil,
+		}
+
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Post("/projects/"+mockProject.Id+"/move", payload, nil).Times(1)
+			apiClient.ProjectMove(mockProject.Id, "")
+		})
+
+		It("Should send POST request with project id and nil target project id", func() {})
 	})
 })

--- a/env0/resource_project.go
+++ b/env0/resource_project.go
@@ -113,9 +113,6 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if d.HasChange("parent_project_id") {
 		parentProjectId := d.Get("parent_project_id").(string)
-		if parentProjectId == "" {
-			return diag.Errorf("could not move project: subproject cannot become a project")
-		}
 
 		if err := apiClient.ProjectMove(id, parentProjectId); err != nil {
 			return diag.Errorf("could not move project: %v", err)

--- a/env0/resource_project.go
+++ b/env0/resource_project.go
@@ -67,7 +67,6 @@ func resourceProject() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "If set, the project becomes a 'sub-project' of the parent project. See https://docs.env0.com/docs/sub-projects",
 				Optional:    true,
-				ForceNew:    true,
 			},
 		},
 	}
@@ -110,7 +109,18 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	apiClient := meta.(client.ApiClientInterface)
 
 	id := d.Id()
-	var payload client.ProjectCreatePayload
+	var payload client.ProjectUpdatePayload
+
+	if d.HasChange("parent_project_id") {
+		parentProjectId := d.Get("parent_project_id").(string)
+		if parentProjectId == "" {
+			return diag.Errorf("could not move project: subproject cannot become a project")
+		}
+
+		if err := apiClient.ProjectMove(id, parentProjectId); err != nil {
+			return diag.Errorf("could not move project: %v", err)
+		}
+	}
 
 	if err := readResourceData(&payload, d); err != nil {
 		return diag.Errorf("schema resource data deserialization failed: %v", err)

--- a/tests/integration/002_project/main.tf
+++ b/tests/integration/002_project/main.tf
@@ -22,6 +22,13 @@ resource "env0_project" "test_sub_project" {
   parent_project_id = var.second_run ? env0_project.test_project2.id : env0_project.test_project.id
 }
 
+resource "env0_project" "test_sub_project_to_project" {
+  name              = "Test-Sub-Project-To-Project-${random_string.random.result}"
+  description       = "Test Description ${var.second_run ? "after update" : ""}"
+  parent_project_id = var.second_run ? "" : env0_project.test_project.id
+}
+
+
 data "env0_project" "data_by_name" {
   name = env0_project.test_project.name
 }

--- a/tests/integration/002_project/main.tf
+++ b/tests/integration/002_project/main.tf
@@ -11,10 +11,15 @@ resource "env0_project" "test_project" {
   description = "Test Description ${var.second_run ? "after update" : ""}"
 }
 
+esource "env0_project" "test_project2" {
+  name        = "Test-Project-${random_string.random.result}2"
+  description = "Test Description2 ${var.second_run ? "after update" : ""}"
+}
+
 resource "env0_project" "test_sub_project" {
   name              = "Test-Sub-Project-${random_string.random.result}"
   description       = "Test Description ${var.second_run ? "after update" : ""}"
-  parent_project_id = env0_project.test_project.id
+  parent_project_id = var.second_run ? env0_project.test_project2.id : env0_project.test_project.id
 }
 
 data "env0_project" "data_by_name" {

--- a/tests/integration/002_project/main.tf
+++ b/tests/integration/002_project/main.tf
@@ -11,7 +11,7 @@ resource "env0_project" "test_project" {
   description = "Test Description ${var.second_run ? "after update" : ""}"
 }
 
-esource "env0_project" "test_project2" {
+resource "env0_project" "test_project2" {
   name        = "Test-Project-${random_string.random.result}2"
   description = "Test Description2 ${var.second_run ? "after update" : ""}"
 }


### PR DESCRIPTION
…ect api

### Issue & Steps to Reproduce / Feature Request
resolves #645 

### Solution

1. Added the move API call.
2. Updated the project resource schema and the update function.
3. Added unit tests for the move API call.
4. Updated acceptance tests for project resources.
5. Updated the integration tests to cover the 'move' use case.
