### PR TITLE
Revert "Feat: run harness tests in parallel"

### DIFF
--- a/tests/harness.go
+++ b/tests/harness.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"runtime"
 	"strings"
-	"sync"
 )
 
 const TESTS_FOLDER = "tests/integration"
@@ -25,27 +24,16 @@ func main() {
 	log.Println(len(testNames), " tests to run")
 	buildFakeTerraformRegistry()
 	destroyMode := os.Getenv("DESTROY_MODE")
-
-	var wg sync.WaitGroup
-
 	for _, testName := range testNames {
-		wg.Add(1)
-
-		go func(testName string) {
-			if destroyMode == "DESTROY_ONLY" {
-				terraformDestory(testName)
-			} else {
-				success, err := runTest(testName, destroyMode != "NO_DESTROY")
-				if !success {
-					log.Fatalln("Halting due to test failure:", err)
-				}
+		if destroyMode == "DESTROY_ONLY" {
+			terraformDestory(testName)
+		} else {
+			success, err := runTest(testName, destroyMode != "NO_DESTROY")
+			if !success {
+				log.Fatalln("Halting due to test failure:", err)
 			}
-
-			wg.Done()
-		}(testName)
+		}
 	}
-
-	wg.Wait()
 }
 func compileProvider() error {
 	cmd := exec.Command("go", "build")


### PR DESCRIPTION
Reverts env0/terraform-provider-env0#669

we have integration tests that search for all the existing templates (022) / teams (021) and it found entities from other test while they being destroyed (deleted) which causes a race condition.