### PR TITLE
Fix: cannot create env0_user_team_assignment: validation error

### DIFF
--- a/env0/resource_user_team_assignment.go
+++ b/env0/resource_user_team_assignment.go
@@ -33,6 +33,7 @@ func (a *UserTeamAssignment) GetId() string {
 }
 
 func GetUserTeamAssignmentFromId(id string) (*UserTeamAssignment, error) {
+	// lastSplit is used to avoid issues where the user_id has underscores in it.
 	splitUserTeam := lastSplit(id, "_")
 	if len(splitUserTeam) != 2 {
 		return nil, fmt.Errorf("the id %v is invalid must be <user_id>_<team_id>", id)

--- a/env0/resource_user_team_assignment.go
+++ b/env0/resource_user_team_assignment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 
 	"github.com/env0/terraform-provider-env0/client"
@@ -34,7 +33,7 @@ func (a *UserTeamAssignment) GetId() string {
 }
 
 func GetUserTeamAssignmentFromId(id string) (*UserTeamAssignment, error) {
-	splitUserTeam := strings.Split(id, "_")
+	splitUserTeam := lastSplit(id, "_")
 	if len(splitUserTeam) != 2 {
 		return nil, fmt.Errorf("the id %v is invalid must be <user_id>_<team_id>", id)
 	}

--- a/env0/resource_user_team_assignment_test.go
+++ b/env0/resource_user_team_assignment_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUnitUserTeamAssignmentResource(t *testing.T) {
-	userId := "uid"
+	userId := "ui_d"
 	teamId := "tid"
 
 	GenerateTeam := func(teamId string, userIds []string) client.Team {

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -489,3 +489,12 @@ func ttlToDuration(ttl *string) (time.Duration, error) {
 
 	return time.ParseDuration(fmt.Sprintf("%dh", hours))
 }
+
+func lastSplit(s string, sep string) []string {
+	lastIndex := strings.LastIndex(s, sep)
+	if lastIndex == -1 {
+		return nil
+	}
+
+	return []string{s[:lastIndex], s[lastIndex+1:]}
+}

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -493,7 +493,7 @@ func ttlToDuration(ttl *string) (time.Duration, error) {
 func lastSplit(s string, sep string) []string {
 	lastIndex := strings.LastIndex(s, sep)
 	if lastIndex == -1 {
-		return nil
+		return []string{s}
 	}
 
 	return []string{s[:lastIndex], s[lastIndex+1:]}

--- a/env0/utils_test.go
+++ b/env0/utils_test.go
@@ -465,6 +465,5 @@ func TestLastSplit(t *testing.T) {
 	assert.Equal(t, []string{"a__", "b"}, lastSplit("a___b", "_"))
 	assert.Equal(t, []string{"a_", ""}, lastSplit("a__", "_"))
 
-	var nilString []string
-	assert.Equal(t, nilString, lastSplit("abc", "_"))
+	assert.Equal(t, []string{"abc"}, lastSplit("abc", "_"))
 }

--- a/env0/utils_test.go
+++ b/env0/utils_test.go
@@ -459,3 +459,12 @@ func TestTTLToDuration(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestLastSplit(t *testing.T) {
+	assert.Equal(t, []string{"a", "b"}, lastSplit("a_b", "_"))
+	assert.Equal(t, []string{"a__", "b"}, lastSplit("a___b", "_"))
+	assert.Equal(t, []string{"a_", ""}, lastSplit("a__", "_"))
+
+	var nilString []string
+	assert.Equal(t, nilString, lastSplit("abc", "_"))
+}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #681 

### Solution

Some user ids have an "_". Original solution assumed it's not possible.

1. created a custom split called lastSplit: split by the last underscore.
2. use lastSplit instead of using strings.Split().
3. Updated the acceptance tests to cover this use-case.
4. Added unit tests for lastSplit.