### PR TITLE
Chore: add a description note for resource custom_flow name field

### DIFF
--- a/env0/resource_custom_flow.go
+++ b/env0/resource_custom_flow.go
@@ -28,7 +28,7 @@ func resourceCustomFlow() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "name for the custom flow",
+				Description: "name for the custom flow. note: for the UI to render the custom-flow please use `project-<project.id>`",
 				Required:    true,
 			},
 			"repository": {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
UI does not render custom flow when a custom name is given. 
The custom flow must match the following format:  `project-<project.id>`

### Solution
Include a note in the terraform provider resource name field
