### PR TITLE
Fix: make custom roles data test isolated

### DIFF
--- a/tests/integration/026_custom_role/main.tf
+++ b/tests/integration/026_custom_role/main.tf
@@ -45,12 +45,18 @@ resource "env0_custom_role" "custom_role2" {
   ]
 }
 
-data "env0_custom_roles" "all_roles" {}
-
-data "env0_custom_role" "roles" {
-  for_each = toset(data.env0_custom_roles.all_roles.names)
-  name     = each.value
+data "env0_custom_roles" "all_roles" {
+  depends_on = [env0_custom_role.custom_role1, env0_custom_role.custom_role2]
 }
+
+data "env0_team" "team_resource1" {
+  name = data.env0_custom_roles.all_roles.names[index(data.env0_custom_roles.all_roles.names, env0_custom_role.custom_role1.name)]
+}
+
+data "env0_team" "team_resource2" {
+  name = data.env0_custom_roles.all_roles.names[index(data.env0_custom_roles.all_roles.names, env0_custom_role.custom_role2.name)]
+}
+
 
 resource "env0_api_key" "test_api_key" {
   name = "api-key-${random_string.random.result}"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
since we run our tests in parallel other tests that create custom_role resources interfere with this test
### Solution
Isolate the test and only use resource from the same test
