### PR TITLE
Fix: 'endless drift' when setting template path to start with '/'

### DIFF
--- a/env0/resource_template_test.go
+++ b/env0/resource_template_test.go
@@ -1006,6 +1006,84 @@ func TestUnitTemplateResource(t *testing.T) {
 		})
 	})
 
+	// https://github.com/env0/terraform-provider-env0/issues/699
+	t.Run("path drift", func(t *testing.T) {
+		pathTemplate := client.Template{
+			Id:               "id0",
+			Name:             "template0",
+			Path:             "path/zero",
+			Repository:       "repo",
+			TerraformVersion: string(defaultVersion),
+			Type:             string(defaultType),
+		}
+
+		updatedPathTemplate := client.Template{
+			Id:               "id0",
+			Name:             "template0",
+			Path:             "path/one",
+			Repository:       "repo",
+			TerraformVersion: string(defaultVersion),
+			Type:             string(defaultType),
+		}
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":       pathTemplate.Name,
+						"path":       "/" + pathTemplate.Path,
+						"repository": pathTemplate.Repository,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceFullName, "id", pathTemplate.Id),
+						resource.TestCheckResourceAttr(resourceFullName, "name", pathTemplate.Name),
+						resource.TestCheckResourceAttr(resourceFullName, "repository", pathTemplate.Repository),
+						resource.TestCheckResourceAttr(resourceFullName, "type", pathTemplate.Type),
+						resource.TestCheckResourceAttr(resourceFullName, "terraform_version", pathTemplate.TerraformVersion),
+						resource.TestCheckResourceAttr(resourceFullName, "path", "/"+pathTemplate.Path),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"name":       updatedPathTemplate.Name,
+						"path":       "/" + updatedPathTemplate.Path,
+						"repository": updatedPathTemplate.Repository,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceFullName, "id", updatedPathTemplate.Id),
+						resource.TestCheckResourceAttr(resourceFullName, "name", updatedPathTemplate.Name),
+						resource.TestCheckResourceAttr(resourceFullName, "repository", updatedPathTemplate.Repository),
+						resource.TestCheckResourceAttr(resourceFullName, "type", updatedPathTemplate.Type),
+						resource.TestCheckResourceAttr(resourceFullName, "terraform_version", updatedPathTemplate.TerraformVersion),
+						resource.TestCheckResourceAttr(resourceFullName, "path", "/"+updatedPathTemplate.Path),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().TemplateCreate(client.TemplateCreatePayload{
+					Path:             "/" + pathTemplate.Path,
+					Name:             pathTemplate.Name,
+					Type:             pathTemplate.Type,
+					TerraformVersion: pathTemplate.TerraformVersion,
+					Repository:       pathTemplate.Repository,
+				}).Times(1).Return(pathTemplate, nil),
+				mock.EXPECT().Template(pathTemplate.Id).Times(2).Return(pathTemplate, nil),
+				mock.EXPECT().TemplateUpdate(updatedPathTemplate.Id, client.TemplateCreatePayload{
+					Path:             "/" + updatedPathTemplate.Path,
+					Name:             updatedPathTemplate.Name,
+					Type:             updatedPathTemplate.Type,
+					TerraformVersion: updatedPathTemplate.TerraformVersion,
+					Repository:       updatedPathTemplate.Repository,
+				}).Times(1).Return(updatedPathTemplate, nil),
+				mock.EXPECT().Template(pathTemplate.Id).Times(1).Return(updatedPathTemplate, nil),
+				mock.EXPECT().TemplateDelete(pathTemplate.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
 	t.Run("Invalid Terraform Version", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{

--- a/tests/integration/004_template/expected_outputs.json
+++ b/tests/integration/004_template/expected_outputs.json
@@ -3,7 +3,7 @@
     "github_template_name": "Github Test-",
     "github_template_repository": "https://github.com/env0/templates",
     "gitlab_template_repository": "https://gitlab.com/env0/gitlab-vcs-integration-tests.git",
-    "github_template_path": "second",
+    "github_template_path": "/second",
     "tg_tg_version" : "0.35.0",
     "data_github_template_type": "terraform",
     "github_variables_name": "email",

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -24,7 +24,7 @@ resource "env0_template" "github_template" {
   type                                    = "terraform"
   repository                              = data.env0_template.github_template.repository
   github_installation_id                  = data.env0_template.github_template.github_installation_id
-  path                                    = var.second_run ? "second" : "misc/null-resource"
+  path                                    = var.second_run ? "/second" : "/misc/null-resource"
   retries_on_deploy                       = 3
   retry_on_deploy_only_when_matches_regex = "abc"
   retries_on_destroy                      = 1


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #699 

### Solution

Keeping the state with "/" to avoid endless drift. Ignoring the value returned by the template if only "/" was omitted.
Added an acceptance test for this use-case and updated the integration test.
