### PR TITLE
Fix: destroy already destroyed workflow environment fails with error

### DIFF
--- a/client/http/errors.go
+++ b/client/http/errors.go
@@ -13,3 +13,7 @@ func (e *FailedResponseError) Error() string {
 func (e *FailedResponseError) NotFound() bool {
 	return e.res.StatusCode() == 404
 }
+
+func (e *FailedResponseError) BadRequest() bool {
+	return e.res.StatusCode() == 400
+}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #704 

### Solution

1. On 400 error, prints a warning, but does not fail the destroy.
2. Updated acceptance tests to cover this use case.
