### PR TITLE
Fix: env0_git_token recreating in every tf apply

### DIFF
--- a/client/git_token.go
+++ b/client/git_token.go
@@ -3,7 +3,7 @@ package client
 type GitToken struct {
 	Id             string `json:"id"`
 	Name           string `json:"name"`
-	Value          string `json:"value"`
+	Value          string `json:"value" tfschema:"-"`
 	OrganizationId string `json:"organizationId"`
 }
 

--- a/env0/resource_git_token_test.go
+++ b/env0/resource_git_token_test.go
@@ -108,10 +108,11 @@ func TestUnitGitTokenResource(t *testing.T) {
 					}),
 				},
 				{
-					ResourceName:      resourceNameImport,
-					ImportState:       true,
-					ImportStateId:     gitToken.Name,
-					ImportStateVerify: true,
+					ResourceName:            resourceNameImport,
+					ImportState:             true,
+					ImportStateId:           gitToken.Name,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"value"},
 				},
 			},
 		}
@@ -137,10 +138,11 @@ func TestUnitGitTokenResource(t *testing.T) {
 					}),
 				},
 				{
-					ResourceName:      resourceNameImport,
-					ImportState:       true,
-					ImportStateId:     gitToken.Id,
-					ImportStateVerify: true,
+					ResourceName:            resourceNameImport,
+					ImportState:             true,
+					ImportStateId:           gitToken.Id,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"value"},
 				},
 			},
 		}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #707 

### Solution

1. "value" returns *****. Therefore, it causes a drift.
2. It is now ignored (except for creation).