### PR TITLE
Chore: Document how to disallow remote state access

### DIFF
--- a/docs/resources/environment_state_access.md
+++ b/docs/resources/environment_state_access.md
@@ -42,7 +42,8 @@ resource "env0_environment_state_access" "example_entire_organization" {
 ### Optional
 
 - `accessible_from_entire_organization` (Boolean) when this parameter is 'false', allowed_project_ids should be provided. Defaults to 'false'
-- `allowed_project_ids` (List of String) list of allowed project_ids. Used when 'accessible_from_entire_organization' is 'false'
+- `allowed_project_ids` (List of String) list of allowed project_ids. Used when 'accessible_from_entire_organization' is 'false'. To disallow remote state access for env0 backend, fill the allowed_project_id list with string "none". Skipping allowed_project_ids or setting to [] yields a 400 error. (e.g. ```accessible_from_entire_organization = false
+  allowed_project_ids = ["none"]```)
 
 ### Read-Only
 


### PR DESCRIPTION
From customer:

> │ Error: could not create a remote state access configation: 400 Bad Request: /body must have required property 'allowedProjectIds', /body/accessibleFromEntireOrganization must be equal to constant, /body must match a schema in anyOf
seems silly, but the only way i found to disallow remote state access for env0 backend with terraform is to fill the allowed project id list with an string like "none":
resource "env0_environment_state_access" "disallow" {
  accessible_from_entire_organization = false
  allowed_project_ids = ["none"]
skipping allowed_project_ids or setting to [] yields the given error