### PR TITLE
Fix: unable to unset auto_deploy_by_custom_glob property of environme…

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -129,7 +129,7 @@ type EnvironmentCreate struct {
 	ContinuousDeployment        *bool                  `json:"continuousDeployment,omitempty" tfschema:"-"`
 	PullRequestPlanDeployments  *bool                  `json:"pullRequestPlanDeployments,omitempty" tfschema:"-"`
 	AutoDeployOnPathChangesOnly *bool                  `json:"autoDeployOnPathChangesOnly,omitempty" tfchema:"-"`
-	AutoDeployByCustomGlob      string                 `json:"autoDeployByCustomGlob,omitempty"`
+	AutoDeployByCustomGlob      string                 `json:"autoDeployByCustomGlob"`
 	ConfigurationChanges        *ConfigurationChanges  `json:"configurationChanges,omitempty" tfschema:"-"`
 	TTL                         *TTL                   `json:"ttl,omitempty" tfschema:"-"`
 	TerragruntWorkingDirectory  string                 `json:"terragruntWorkingDirectory,omitempty"`


### PR DESCRIPTION
…nt resource back to empty string or null

### Issue & Steps to Reproduce / Feature Request
fixes #719 

### Solution

Explicitly passing `autoDeployByCustomGlob: ""` when not set.
