### PR TITLE
Fix: make cloud_credentials data test isolated

### DIFF
--- a/env0/data_cloud_credentials.go
+++ b/env0/data_cloud_credentials.go
@@ -29,7 +29,7 @@ func dataCloudCredentials() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"names": {
 				Type:        schema.TypeList,
-				Description: "list of all cloud credentials (by name), optionaly filtered by credential_type",
+				Description: "list of all cloud credentials (by name), optionally filtered by credential_type",
 				Computed:    true,
 				Elem: &schema.Schema{
 					Type:        schema.TypeString,

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -21,7 +21,7 @@ resource "env0_gcp_credentials" "gcp_cred" {
 }
 
 data "env0_cloud_credentials" "all_aws_credentials" {
-  depends_on = [env0_aws_credentials.aws_cred1, aws_cred2,env0_gcp_credentials.gcp_cred]
+  depends_on = [env0_aws_credentials.aws_cred1, env0_aws_credentials.aws_cred2, env0_gcp_credentials.gcp_cred]
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -24,14 +24,19 @@ data "env0_cloud_credentials" "all_aws_credentials" {
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 
-data "env0_aws_credentials" "aws_credentials1" {
-  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
-}
+//data "env0_aws_credentials" "aws_credentials1" {
+//  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
+//}
+//
+//data "env0_aws_credentials" "aws_credentials2" {
+//  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
+//}
+//
+//output "credentials_name" {
+//  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials1.name, random_string.random.result, "") : ""
+//}
 
-data "env0_aws_credentials" "aws_credentials2" {
-  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
-}
-
-output "credentials_name" {
-  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials1.name, random_string.random.result, "") : ""
+output "credentials_names" {
+  for_each = toset(data.env0_cloud_credentials.all_aws_credentials.names)
+  value = each.value
 }

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -37,6 +37,6 @@ data "env0_cloud_credentials" "all_aws_credentials" {
 //}
 
 output "credentials_names" {
-  for_each = toset(data.env0_cloud_credentials.all_aws_credentials.names)
+  for_each = data.env0_cloud_credentials.all_aws_credentials.names
   value = each.value
 }

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -33,5 +33,5 @@ data "env0_aws_credentials" "aws_credentials2" {
 }
 
 output "credentials_name" {
-  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials["Test Role arn1 ${random_string.random.result}"].name, random_string.random.result, "") : ""
+  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials1.name, random_string.random.result, "") : ""
 }

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -20,16 +20,16 @@ resource "env0_gcp_credentials" "gcp_cred" {
   project_id          = "your_project_id"
 }
 
-data "env0_cloud_credentials" "aws_credentials" {
+data "env0_cloud_credentials" "all_aws_credentials" {
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 
 data "env0_aws_credentials" "aws_credentials1" {
-  name     = data.env0_cloud_credentials.aws_credentials.names[index(data.env0_cloud_credentials.aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
+  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
 }
 
 data "env0_aws_credentials" "aws_credentials2" {
-  name     = data.env0_cloud_credentials.aws_credentials.names[index(data.env0_cloud_credentials.aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
+  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
 }
 
 output "credentials_name" {

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -24,18 +24,14 @@ data "env0_cloud_credentials" "all_aws_credentials" {
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 
-//data "env0_aws_credentials" "aws_credentials1" {
-//  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
-//}
-//
-//data "env0_aws_credentials" "aws_credentials2" {
-//  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
-//}
-//
-//output "credentials_name" {
-//  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials1.name, random_string.random.result, "") : ""
-//}
+data "env0_aws_credentials" "aws_credentials1" {
+  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
+}
 
-output "credentials_names" {
-  value = data.env0_cloud_credentials.all_aws_credentials.names[*]
+data "env0_aws_credentials" "aws_credentials2" {
+  name     = data.env0_cloud_credentials.all_aws_credentials.names[index(data.env0_cloud_credentials.all_aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
+}
+
+output "credentials_name" {
+  value = var.second_run ? replace(data.env0_aws_credentials.aws_credentials1.name, random_string.random.result, "") : ""
 }

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -21,6 +21,7 @@ resource "env0_gcp_credentials" "gcp_cred" {
 }
 
 data "env0_cloud_credentials" "all_aws_credentials" {
+  depends_on = [env0_aws_credentials.aws_cred1, aws_cred2,env0_gcp_credentials.gcp_cred]
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -4,12 +4,17 @@ resource "random_string" "random" {
   min_lower = 8
 }
 
-resource "env0_aws_credentials" "cred1" {
+resource "env0_aws_credentials" "aws_cred1" {
   name = "Test Role arn1 ${random_string.random.result}"
   arn  = "Role ARN1"
 }
 
-resource "env0_gcp_credentials" "cred2" {
+resource "env0_aws_credentials" "aws_cred2" {
+  name = "Test Role arn2 ${random_string.random.result}"
+  arn  = "Role ARN2"
+}
+
+resource "env0_gcp_credentials" "gcp_cred" {
   name                = "name ${random_string.random.result}"
   service_account_key = "your_account_key"
   project_id          = "your_project_id"
@@ -19,9 +24,12 @@ data "env0_cloud_credentials" "aws_credentials" {
   credential_type = "AWS_ASSUMED_ROLE_FOR_DEPLOYMENT"
 }
 
-data "env0_aws_credentials" "aws_credentials" {
-  for_each = toset(data.env0_cloud_credentials.aws_credentials.names)
-  name     = each.value
+data "env0_aws_credentials" "aws_credentials1" {
+  name     = data.env0_cloud_credentials.aws_credentials.names[index(data.env0_cloud_credentials.aws_credentials.names, env0_aws_credentials.aws_cred1.name)]
+}
+
+data "env0_aws_credentials" "aws_credentials2" {
+  name     = data.env0_cloud_credentials.aws_credentials.names[index(data.env0_cloud_credentials.aws_credentials.names, env0_aws_credentials.aws_cred2.name)]
 }
 
 output "credentials_name" {

--- a/tests/integration/024_cloud_credentials/main.tf
+++ b/tests/integration/024_cloud_credentials/main.tf
@@ -37,6 +37,5 @@ data "env0_cloud_credentials" "all_aws_credentials" {
 //}
 
 output "credentials_names" {
-  for_each = data.env0_cloud_credentials.all_aws_credentials.names
-  value = each.value
+  value = data.env0_cloud_credentials.all_aws_credentials.names[*]
 }


### PR DESCRIPTION
Issue & Steps to Reproduce / Feature Request
since we run our tests in parallel other tests that create `env0_aws_credentials` resources interfere with this test

Solution
Isolate the test and only use resources from the same test