### PR TITLE
Fix: integration test 025 is not isolated

### DIFF
--- a/tests/integration/025_notifications/expected_outputs.json
+++ b/tests/integration/025_notifications/expected_outputs.json
@@ -1,1 +1,3 @@
-{}
+{
+  "notification_1_from_all_notifications": "integration-test-025-notification-1-"
+}

--- a/tests/integration/025_notifications/main.tf
+++ b/tests/integration/025_notifications/main.tf
@@ -6,14 +6,18 @@ resource "random_string" "random" {
   min_lower = 20
 }
 
+locals {
+  notification_name_prefix = "integration-test-025-notification"
+}
+
 resource "env0_notification" "test_notification_1" {
-  name  = "notification123-${random_string.random.result}-1"
+  name  = "${local.notification_name_prefix}-1-${random_string.random.result}"
   type  = "Slack"
   value = "https://someurl1.com"
 }
 
 resource "env0_notification" "test_notification_2" {
-  name  = "notification123-${random_string.random.result}-2"
+  name  = "${local.notification_name_prefix}-2-${random_string.random.result}"
   type  = "Teams"
   value = "https://someurl2.com"
 }
@@ -23,9 +27,22 @@ data "env0_notifications" "all_notifications" {
 }
 
 data "env0_notification" "test_notification_1" {
-  name = data.env0_notifications.all_notifications.names[index(data.env0_notifications.all_notifications.names, env0_notification.test_notification_1.name)]
+  depends_on = [env0_notification.test_notification_1]
+  name       = "${local.notification_name_prefix}-1-${random_string.random.result}"
 }
 
 data "env0_notification" "test_notification_2" {
-  name = data.env0_notifications.all_notifications.names[index(data.env0_notifications.all_notifications.names, env0_notification.test_notification_2.name)]
+  depends_on = [env0_notification.test_notification_2]
+  name       = "${local.notification_name_prefix}-2-${random_string.random.result}"
+}
+
+output "notification_1_from_all_notifications" {
+  value = replace(
+    data.env0_notifications.all_notifications.names[
+      index(data.env0_notifications.all_notifications.names,
+      env0_notification.test_notification_1.name)
+    ]
+    , random_string.random.result
+    , ""
+  )
 }

--- a/tests/integration/025_notifications/main.tf
+++ b/tests/integration/025_notifications/main.tf
@@ -18,9 +18,14 @@ resource "env0_notification" "test_notification_2" {
   value = "https://someurl2.com"
 }
 
-data "env0_notifications" "all_notifications" {}
+data "env0_notifications" "all_notifications" {
+  depends_on = [env0_notification.test_notification_1, env0_notification.test_notification_2]
+}
 
-data "env0_notification" "notification" {
-  for_each = toset(data.env0_notifications.all_notifications.names)
-  name     = each.value
+data "env0_notification" "test_notification_1" {
+  name = data.env0_notifications.all_notifications.names[index(data.env0_notifications.all_notifications.names, env0_notification.test_notification_1.name)]
+}
+
+data "env0_notification" "test_notification_2" {
+  name = data.env0_notifications.all_notifications.names[index(data.env0_notifications.all_notifications.names, env0_notification.test_notification_2.name)]
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)

test `025_notifications` uses `all_notifications`, and it fetches data from other tests, such as `017_notification`, that may become unavailable during test 025's run.

### Solution

make the test rely solely on its own data

### QA done

ran the test locally to make sure it works on its own. deliberately failing it is much harder, didn't happen sporadically (that we caught) until a few days prior to the PR