### PR TITLE
Feat: clarify provider documentation

### DIFF
--- a/env0/provider.go
+++ b/env0/provider.go
@@ -38,16 +38,16 @@ func Provider(version string) plugin.ProviderFunc {
 				},
 				"api_key": {
 					Type:        schema.TypeString,
-					Description: "env0 API key. This can also be set via the ENV0_API_KEY environment variable.",
+					Description: "env0 API key. Instead of this field, it can also be set via the ENV0_API_KEY environment variable.",
 					DefaultFunc: schema.EnvDefaultFunc(apiKeyEnv, nil),
-					Required:    true,
+					Optional:    true,
 					Sensitive:   true,
 				},
 				"api_secret": {
 					Type:        schema.TypeString,
-					Description: "env0 API secret. This can also be set via the ENV0_API_SECRET environment variable.",
+					Description: "env0 API secret. Instead of this field, it can also be set via the ENV0_API_SECRET environment variable.",
 					DefaultFunc: schema.EnvDefaultFunc(apiSecretEnv, nil),
-					Required:    true,
+					Optional:    true,
 					Sensitive:   true,
 				},
 				"organization_id": {
@@ -195,9 +195,19 @@ func configureProvider(version string, p *schema.Provider) schema.ConfigureConte
 				return false
 			})
 
+		apiKey, ok := d.GetOk("api_key")
+		if !ok {
+			return nil, diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Detail: `The argument "api_key" is required, but no definition was found.`}}
+		}
+
+		apiSecret, ok := d.GetOk("api_secret")
+		if !ok {
+			return nil, diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Detail: `The argument "api_secret" is required, but no definition was found.`}}
+		}
+
 		httpClient, err := http.NewHttpClient(http.HttpClientConfig{
-			ApiKey:      d.Get("api_key").(string),
-			ApiSecret:   d.Get("api_secret").(string),
+			ApiKey:      apiKey.(string),
+			ApiSecret:   apiSecret.(string),
 			ApiEndpoint: d.Get("api_endpoint").(string),
 			UserAgent:   userAgent,
 			RestClient:  restyClient,

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -74,12 +74,12 @@ func testMissingEnvVar(t *testing.T, envVars map[string]string, expectedKey stri
 		defer os.Setenv(key, "")
 	}
 
-	diags := Provider("TEST")().Validate(&terraform.ResourceConfig{})
+	diags := Provider("TEST")().Configure(context.Background(), &terraform.ResourceConfig{})
 	testExpectedProviderError(t, diags, expectedKey)
 }
 
 func testMissingConfig(t *testing.T, config map[string]interface{}, expectedKey string) {
-	diags := Provider("TEST")().Validate(terraform.NewResourceConfigRaw(config))
+	diags := Provider("TEST")().Configure(context.Background(), terraform.NewResourceConfigRaw(config))
 	testExpectedProviderError(t, diags, expectedKey)
 }
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #738 

### Solution

1. API key and API secret are now optional in the schema.
2. Will still return an error if they're not configured via schema or environment variables.
3. Minor updates to provider documentation to make it clearer.