### PR TITLE
Feat: env0_environment with project_id property

### DIFF
--- a/env0/data_environment.go
+++ b/env0/data_environment.go
@@ -36,6 +36,7 @@ func dataEnvironment() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "project id of the environment",
 				Computed:    true,
+				Optional:    true,
 			},
 			"approve_plan_automatically": {
 				Type:        schema.TypeBool,
@@ -105,6 +106,8 @@ func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 	var err diag.Diagnostics
 	var environment client.Environment
 
+	projectId := d.Get("project_id").(string)
+
 	id, ok := d.GetOk("id")
 	if ok {
 		environment, err = getEnvironmentById(id.(string), meta)
@@ -112,9 +115,9 @@ func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 			return err
 		}
 	} else {
-		name := d.Get("name")
+		name := d.Get("name").(string)
 		excludeArchived := d.Get("exclude_archived")
-		environment, err = getEnvironmentByName(name.(string), meta, excludeArchived.(bool))
+		environment, err = getEnvironmentByName(meta, name, projectId, excludeArchived.(bool))
 		if err != nil {
 			return err
 		}

--- a/env0/data_environment_test.go
+++ b/env0/data_environment_test.go
@@ -40,6 +40,12 @@ func TestEnvironmentDataSource(t *testing.T) {
 		Name: "other-name",
 	}
 
+	environmentWithSameName := client.Environment{
+		Id:        "other-id",
+		Name:      environment.Name,
+		ProjectId: "other-project-id",
+	}
+
 	archivedEnvironment := client.Environment{
 		Id:         "id-archived",
 		Name:       environment.Name,
@@ -48,6 +54,7 @@ func TestEnvironmentDataSource(t *testing.T) {
 
 	environmentFieldsByName := map[string]interface{}{"name": environment.Name}
 	environmentFieldsByNameWithExclude := map[string]interface{}{"name": environment.Name, "exclude_archived": "true"}
+	environmentFieldByNameWithProjectId := map[string]interface{}{"name": environment.Name, "project_id": environment.ProjectId}
 	environmentFieldsById := map[string]interface{}{"id": environment.Id}
 
 	resourceType := "env0_environment"
@@ -127,6 +134,13 @@ func TestEnvironmentDataSource(t *testing.T) {
 		runUnitTest(t,
 			getValidTestCase(environmentFieldsByNameWithExclude),
 			mockListEnvironmentsCall([]client.Environment{environment, archivedEnvironment, otherEnvironment}, &template),
+		)
+	})
+
+	t.Run("By Name with Different Project Id", func(t *testing.T) {
+		runUnitTest(t,
+			getValidTestCase(environmentFieldByNameWithProjectId),
+			mockListEnvironmentsCall([]client.Environment{environment, environmentWithSameName, otherEnvironment}, &template),
 		)
 	})
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -1058,7 +1058,7 @@ func getConfigurationVariableFromSchema(variable map[string]interface{}) client.
 	return configurationVariable
 }
 
-func getEnvironmentByName(name interface{}, meta interface{}, excludeArchived bool) (client.Environment, diag.Diagnostics) {
+func getEnvironmentByName(meta interface{}, name string, projectId string, excludeArchived bool) (client.Environment, diag.Diagnostics) {
 	apiClient := meta.(client.ApiClientInterface)
 	environments, err := apiClient.Environments()
 	if err != nil {
@@ -1068,6 +1068,10 @@ func getEnvironmentByName(name interface{}, meta interface{}, excludeArchived bo
 	var environmentsByName []client.Environment
 	for _, candidate := range environments {
 		if excludeArchived && candidate.IsArchived != nil && *candidate.IsArchived {
+			continue
+		}
+
+		if projectId != "" && candidate.ProjectId != projectId {
 			continue
 		}
 
@@ -1107,7 +1111,7 @@ func resourceEnvironmentImport(ctx context.Context, d *schema.ResourceData, meta
 	} else {
 		tflog.Info(ctx, "Resolving environment by name", map[string]interface{}{"name": id})
 
-		environment, getErr = getEnvironmentByName(id, meta, false)
+		environment, getErr = getEnvironmentByName(meta, id, "", false)
 	}
 	apiClient := meta.(client.ApiClientInterface)
 	d.SetId(environment.Id)


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #737 

### Solution

1. Updated the schema to make project_id optional and not just computed.
2. Added an acceptance test for the new use-case. (Failed before adding code, passed updating code).
3. Updated code to filter out if project_id is set.
