### PR TITLE
Feat: module testing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout code

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: Update generated docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
       - name: Import GPG key

--- a/client/module.go
+++ b/client/module.go
@@ -6,43 +6,49 @@ type ModuleSshKey struct {
 }
 
 type Module struct {
-	ModuleName           string         `json:"moduleName"`
-	ModuleProvider       string         `json:"moduleProvider"`
-	Repository           string         `json:"repository"`
-	Description          string         `json:"description"`
-	LogoUrl              string         `json:"logoUrl"`
-	TokenId              string         `json:"tokenId"`
-	TokenName            string         `json:"tokenName"`
-	GithubInstallationId *int           `json:"githubInstallationId" tfschema:",omitempty"`
-	BitbucketClientKey   *string        `json:"bitbucketClientKey" tfschema:",omitempty"`
-	IsGitlab             bool           `json:"isGitLab"`
-	SshKeys              []ModuleSshKey `json:"sshkeys"`
-	Type                 string         `json:"type"`
-	Id                   string         `json:"id"`
-	OrganizationId       string         `json:"organizationId"`
-	Author               User           `json:"author"`
-	AuthorId             string         `json:"authorId"`
-	CreatedAt            string         `json:"createdAt"`
-	UpdatedAt            string         `json:"updatedAt"`
-	IsDeleted            bool           `json:"isDeleted"`
-	Path                 string         `json:"path"`
-	TagPrefix            string         `json:"tagPrefix"`
+	ModuleName            string         `json:"moduleName"`
+	ModuleProvider        string         `json:"moduleProvider"`
+	Repository            string         `json:"repository"`
+	Description           string         `json:"description"`
+	LogoUrl               string         `json:"logoUrl"`
+	TokenId               string         `json:"tokenId"`
+	TokenName             string         `json:"tokenName"`
+	GithubInstallationId  *int           `json:"githubInstallationId" tfschema:",omitempty"`
+	BitbucketClientKey    *string        `json:"bitbucketClientKey" tfschema:",omitempty"`
+	IsGitlab              bool           `json:"isGitLab"`
+	SshKeys               []ModuleSshKey `json:"sshkeys"`
+	Type                  string         `json:"type"`
+	Id                    string         `json:"id"`
+	OrganizationId        string         `json:"organizationId"`
+	Author                User           `json:"author"`
+	AuthorId              string         `json:"authorId"`
+	CreatedAt             string         `json:"createdAt"`
+	UpdatedAt             string         `json:"updatedAt"`
+	IsDeleted             bool           `json:"isDeleted"`
+	Path                  string         `json:"path"`
+	TagPrefix             string         `json:"tagPrefix"`
+	ModuleTestEnabled     bool           `json:"moduleTestEnabled"`
+	RunTestsOnPullRequest bool           `json:"runTestsOnPullRequest"`
+	OpentofuVersion       string         `json:"opentofuVersion"`
 }
 
 type ModuleCreatePayload struct {
-	ModuleName           string         `json:"moduleName"`
-	ModuleProvider       string         `json:"moduleProvider"`
-	Repository           string         `json:"repository"`
-	Description          string         `json:"description,omitempty"`
-	LogoUrl              string         `json:"logoUrl,omitempty"`
-	TokenId              string         `json:"tokenId,omitempty"`
-	TokenName            string         `json:"tokenName,omitempty"`
-	GithubInstallationId *int           `json:"githubInstallationId,omitempty"`
-	BitbucketClientKey   string         `json:"bitbucketClientKey,omitempty"`
-	IsGitlab             *bool          `json:"isGitLab,omitempty"`
-	SshKeys              []ModuleSshKey `json:"sshkeys,omitempty"`
-	Path                 string         `json:"path,omitempty"`
-	TagPrefix            string         `json:"tagPrefix,omitempty"`
+	ModuleName            string         `json:"moduleName"`
+	ModuleProvider        string         `json:"moduleProvider"`
+	Repository            string         `json:"repository"`
+	Description           string         `json:"description,omitempty"`
+	LogoUrl               string         `json:"logoUrl,omitempty"`
+	TokenId               string         `json:"tokenId,omitempty"`
+	TokenName             string         `json:"tokenName,omitempty"`
+	GithubInstallationId  *int           `json:"githubInstallationId,omitempty"`
+	BitbucketClientKey    string         `json:"bitbucketClientKey,omitempty"`
+	IsGitlab              *bool          `json:"isGitLab,omitempty"`
+	SshKeys               []ModuleSshKey `json:"sshkeys,omitempty"`
+	Path                  string         `json:"path,omitempty"`
+	TagPrefix             string         `json:"tagPrefix,omitempty"`
+	ModuleTestEnabled     bool           `json:"moduleTestEnabled"`
+	RunTestsOnPullRequest bool           `json:"runTestsOnPullRequest"`
+	OpentofuVersion       string         `json:"opentofuVersion,omitempty"`
 }
 
 type ModuleCreatePayloadWith struct {
@@ -52,19 +58,22 @@ type ModuleCreatePayloadWith struct {
 }
 
 type ModuleUpdatePayload struct {
-	ModuleName           string         `json:"moduleName,omitempty"`
-	ModuleProvider       string         `json:"moduleProvider,omitempty"`
-	Repository           string         `json:"repository,omitempty"`
-	Description          string         `json:"description,omitempty"`
-	LogoUrl              string         `json:"logoUrl,omitempty"`
-	TokenId              string         `json:"tokenId"`
-	TokenName            string         `json:"tokenName"`
-	GithubInstallationId *int           `json:"githubInstallationId"`
-	BitbucketClientKey   string         `json:"bitbucketClientKey"`
-	IsGitlab             bool           `json:"isGitLab"`
-	SshKeys              []ModuleSshKey `json:"sshkeys"`
-	Path                 string         `json:"path"`
-	TagPrefix            string         `json:"tagPrefix,omitempty"`
+	ModuleName            string         `json:"moduleName,omitempty"`
+	ModuleProvider        string         `json:"moduleProvider,omitempty"`
+	Repository            string         `json:"repository,omitempty"`
+	Description           string         `json:"description,omitempty"`
+	LogoUrl               string         `json:"logoUrl,omitempty"`
+	TokenId               string         `json:"tokenId"`
+	TokenName             string         `json:"tokenName"`
+	GithubInstallationId  *int           `json:"githubInstallationId"`
+	BitbucketClientKey    string         `json:"bitbucketClientKey"`
+	IsGitlab              bool           `json:"isGitLab"`
+	SshKeys               []ModuleSshKey `json:"sshkeys"`
+	Path                  string         `json:"path"`
+	TagPrefix             string         `json:"tagPrefix,omitempty"`
+	ModuleTestEnabled     bool           `json:"moduleTestEnabled"`
+	RunTestsOnPullRequest bool           `json:"runTestsOnPullRequest"`
+	OpentofuVersion       string         `json:"opentofuVersion,omitempty"`
 }
 
 func (client *ApiClient) ModuleCreate(payload ModuleCreatePayload) (*Module, error) {

--- a/env0/resource_module_test.go
+++ b/env0/resource_module_test.go
@@ -22,33 +22,39 @@ func TestUnitModuleResource(t *testing.T) {
 	}
 
 	module := client.Module{
-		ModuleName:     "name1",
-		ModuleProvider: "provider1",
-		Repository:     "repository1",
-		Description:    "description1",
-		TokenId:        "tokenid",
-		TokenName:      "tokenname",
-		IsGitlab:       false,
-		OrganizationId: "org1",
-		Author:         author,
-		AuthorId:       "author1",
-		Id:             uuid.NewString(),
-		Path:           "path1",
-		TagPrefix:      "prefix1",
+		ModuleName:            "name1",
+		ModuleProvider:        "provider1",
+		Repository:            "repository1",
+		Description:           "description1",
+		TokenId:               "tokenid",
+		TokenName:             "tokenname",
+		IsGitlab:              false,
+		OrganizationId:        "org1",
+		Author:                author,
+		AuthorId:              "author1",
+		Id:                    uuid.NewString(),
+		Path:                  "path1",
+		TagPrefix:             "prefix1",
+		ModuleTestEnabled:     true,
+		OpentofuVersion:       "1.7.0",
+		RunTestsOnPullRequest: true,
 	}
 
 	updatedModule := client.Module{
-		ModuleName:         "name2",
-		ModuleProvider:     "provider1",
-		Repository:         "repository1",
-		Description:        "description1",
-		BitbucketClientKey: stringPtr("1234"),
-		OrganizationId:     "org1",
-		Author:             author,
-		AuthorId:           "author1",
-		Id:                 module.Id,
-		Path:               "path2",
-		TagPrefix:          "prefix2",
+		ModuleName:            "name2",
+		ModuleProvider:        "provider1",
+		Repository:            "repository1",
+		Description:           "description1",
+		BitbucketClientKey:    stringPtr("1234"),
+		OrganizationId:        "org1",
+		Author:                author,
+		AuthorId:              "author1",
+		Id:                    module.Id,
+		Path:                  "path2",
+		TagPrefix:             "prefix2",
+		ModuleTestEnabled:     true,
+		OpentofuVersion:       "1.8.0",
+		RunTestsOnPullRequest: false,
 	}
 
 	t.Run("Success", func(t *testing.T) {
@@ -56,14 +62,17 @@ func TestUnitModuleResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"module_name":     module.ModuleName,
-						"module_provider": module.ModuleProvider,
-						"repository":      module.Repository,
-						"description":     module.Description,
-						"token_id":        module.TokenId,
-						"token_name":      module.TokenName,
-						"path":            module.Path,
-						"tag_prefix":      module.TagPrefix,
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", module.Id),
@@ -75,6 +84,9 @@ func TestUnitModuleResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "token_name", module.TokenName),
 						resource.TestCheckResourceAttr(accessor, "path", module.Path),
 						resource.TestCheckResourceAttr(accessor, "tag_prefix", module.TagPrefix),
+						resource.TestCheckResourceAttr(accessor, "module_test_enabled", "true"),
+						resource.TestCheckResourceAttr(accessor, "run_tests_on_pull_request", "true"),
+						resource.TestCheckResourceAttr(accessor, "opentofu_version", module.OpentofuVersion),
 					),
 				},
 				{
@@ -86,6 +98,8 @@ func TestUnitModuleResource(t *testing.T) {
 						"bitbucket_client_key": *updatedModule.BitbucketClientKey,
 						"path":                 updatedModule.Path,
 						"tag_prefix":           updatedModule.TagPrefix,
+						"module_test_enabled":  updatedModule.ModuleTestEnabled,
+						"opentofu_version":     updatedModule.OpentofuVersion,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", updatedModule.Id),
@@ -98,6 +112,9 @@ func TestUnitModuleResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "bitbucket_client_key", *updatedModule.BitbucketClientKey),
 						resource.TestCheckResourceAttr(accessor, "path", updatedModule.Path),
 						resource.TestCheckResourceAttr(accessor, "tag_prefix", updatedModule.TagPrefix),
+						resource.TestCheckResourceAttr(accessor, "module_test_enabled", "true"),
+						resource.TestCheckResourceAttr(accessor, "run_tests_on_pull_request", "false"),
+						resource.TestCheckResourceAttr(accessor, "opentofu_version", updatedModule.OpentofuVersion),
 					),
 				},
 			},
@@ -105,14 +122,17 @@ func TestUnitModuleResource(t *testing.T) {
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
-				ModuleName:     module.ModuleName,
-				ModuleProvider: module.ModuleProvider,
-				Repository:     module.Repository,
-				Description:    module.Description,
-				TokenId:        module.TokenId,
-				TokenName:      module.TokenName,
-				Path:           module.Path,
-				TagPrefix:      module.TagPrefix,
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
 			}).Times(1).Return(&module, nil)
 
 			mock.EXPECT().ModuleUpdate(updatedModule.Id, client.ModuleUpdatePayload{
@@ -127,6 +147,8 @@ func TestUnitModuleResource(t *testing.T) {
 				BitbucketClientKey:   *updatedModule.BitbucketClientKey,
 				Path:                 updatedModule.Path,
 				TagPrefix:            updatedModule.TagPrefix,
+				ModuleTestEnabled:    updatedModule.ModuleTestEnabled,
+				OpentofuVersion:      updatedModule.OpentofuVersion,
 			}).Times(1).Return(&updatedModule, nil)
 
 			gomock.InOrder(
@@ -207,19 +229,70 @@ func TestUnitModuleResource(t *testing.T) {
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
 	})
 
+	t.Run("Create Failure - module test not enabled - opentofu_version set", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"module_name":         module.ModuleName,
+						"module_provider":     module.ModuleProvider,
+						"repository":          module.Repository,
+						"description":         module.Description,
+						"token_id":            module.TokenId,
+						"token_name":          module.TokenName,
+						"path":                module.Path,
+						"tag_prefix":          module.TagPrefix,
+						"module_test_enabled": false,
+						"opentofu_version":    module.OpentofuVersion,
+					}),
+					ExpectError: regexp.MustCompile("'run_tests_on_pull_request' and/or 'opentofu_version' may only be set"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
+	})
+
+	t.Run("Create Failure - module test not enabled - run_tests_on_pull_request set", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       false,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+					}),
+					ExpectError: regexp.MustCompile("'run_tests_on_pull_request' and/or 'opentofu_version' may only be set"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
+	})
+
 	t.Run("Update Failure", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"module_name":     module.ModuleName,
-						"module_provider": module.ModuleProvider,
-						"repository":      module.Repository,
-						"description":     module.Description,
-						"token_id":        module.TokenId,
-						"token_name":      module.TokenName,
-						"path":            module.Path,
-						"tag_prefix":      module.TagPrefix,
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
 					}),
 				},
 				{
@@ -238,14 +311,17 @@ func TestUnitModuleResource(t *testing.T) {
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
-				ModuleName:     module.ModuleName,
-				ModuleProvider: module.ModuleProvider,
-				Repository:     module.Repository,
-				Description:    module.Description,
-				TokenId:        module.TokenId,
-				TokenName:      module.TokenName,
-				Path:           module.Path,
-				TagPrefix:      module.TagPrefix,
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
 			}).Times(1).Return(&module, nil)
 
 			mock.EXPECT().ModuleUpdate(updatedModule.Id, client.ModuleUpdatePayload{
@@ -266,19 +342,76 @@ func TestUnitModuleResource(t *testing.T) {
 		})
 	})
 
+	t.Run("Update Failure - module test not enabled", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
+					}),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+						"module_name":               updatedModule.ModuleName,
+						"module_provider":           updatedModule.ModuleProvider,
+						"repository":                updatedModule.Repository,
+						"description":               updatedModule.Description,
+						"bitbucket_client_key":      *updatedModule.BitbucketClientKey,
+						"path":                      updatedModule.Path,
+						"module_test_enabled":       false,
+						"run_tests_on_pull_request": true,
+					}),
+					ExpectError: regexp.MustCompile("'run_tests_on_pull_request' and/or 'opentofu_version' may only be set"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
+			}).Times(1).Return(&module, nil)
+
+			mock.EXPECT().Module(module.Id).Times(2).Return(&module, nil)
+			mock.EXPECT().ModuleDelete(module.Id).Times(1)
+		})
+	})
+
 	t.Run("Import By Name", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"module_name":     module.ModuleName,
-						"module_provider": module.ModuleProvider,
-						"repository":      module.Repository,
-						"description":     module.Description,
-						"token_id":        module.TokenId,
-						"token_name":      module.TokenName,
-						"path":            module.Path,
-						"tag_prefix":      module.TagPrefix,
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
 					}),
 				},
 				{
@@ -292,14 +425,17 @@ func TestUnitModuleResource(t *testing.T) {
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
-				ModuleName:     module.ModuleName,
-				ModuleProvider: module.ModuleProvider,
-				Repository:     module.Repository,
-				Description:    module.Description,
-				TokenId:        module.TokenId,
-				TokenName:      module.TokenName,
-				Path:           module.Path,
-				TagPrefix:      module.TagPrefix,
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
 			}).Times(1).Return(&module, nil)
 			mock.EXPECT().Modules().Times(1).Return([]client.Module{module}, nil)
 			mock.EXPECT().Module(module.Id).Times(2).Return(&module, nil)
@@ -312,14 +448,17 @@ func TestUnitModuleResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"module_name":     module.ModuleName,
-						"module_provider": module.ModuleProvider,
-						"repository":      module.Repository,
-						"description":     module.Description,
-						"token_id":        module.TokenId,
-						"token_name":      module.TokenName,
-						"path":            module.Path,
-						"tag_prefix":      module.TagPrefix,
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
 					}),
 				},
 				{
@@ -333,14 +472,17 @@ func TestUnitModuleResource(t *testing.T) {
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
-				ModuleName:     module.ModuleName,
-				ModuleProvider: module.ModuleProvider,
-				Repository:     module.Repository,
-				Description:    module.Description,
-				TokenId:        module.TokenId,
-				TokenName:      module.TokenName,
-				Path:           module.Path,
-				TagPrefix:      module.TagPrefix,
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
 			}).Times(1).Return(&module, nil)
 			mock.EXPECT().Module(module.Id).Times(3).Return(&module, nil)
 			mock.EXPECT().ModuleDelete(module.Id).Times(1)

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -176,7 +176,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 		"opentofu_version": {
 			Type:             schema.TypeString,
 			Description:      "the Opentofu version to use (example: 0.36.5)",
-			ValidateDiagFunc: NewRegexValidator(`^(?:[0-9]\.[0-9]{1,2}\.[0-9]{1,2})|1\.6\.0-alpha$`),
+			ValidateDiagFunc: NewOpenTofuVersionValidator(),
 			Optional:         true,
 		},
 		"is_gitlab_enterprise": {

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -115,6 +115,10 @@ func NewGreaterThanValidator(greaterThan int) schema.SchemaValidateDiagFunc {
 	}
 }
 
+func NewOpenTofuVersionValidator() schema.SchemaValidateDiagFunc {
+	return NewRegexValidator(`^(?:[0-9]\.[0-9]{1,2}\.[0-9]{1,2})|1\.6\.0-alpha$`)
+}
+
 func ValidateTtl(i interface{}, path cty.Path) diag.Diagnostics {
 	ttl := i.(string)
 

--- a/tests/integration/018_module/main.tf
+++ b/tests/integration/018_module/main.tf
@@ -28,5 +28,5 @@ resource "env0_module" "test_module_with_test_enabled" {
   tag_prefix                = var.second_run ? "t2" : "t1"
   module_test_enabled       = var.second_run ? false : true
   run_tests_on_pull_request = var.second_run ? false : true
-  opentofu_version          = var.second_run ? "" : "1.6.0"
+  opentofu_version          = var.second_run ? null : "1.6.0"
 }

--- a/tests/integration/018_module/main.tf
+++ b/tests/integration/018_module/main.tf
@@ -16,3 +16,17 @@ resource "env0_module" "test_module" {
   path                   = var.second_run ? "/cool1" : "/cool2"
   tag_prefix             = var.second_run ? "t2" : "t1"
 }
+
+resource "env0_module" "test_module_with_test_enabled" {
+  module_name               = "test-module-${random_string.random.result}_1"
+  module_provider           = "testprovider1"
+  token_id                  = var.second_run ? null : "37689e5a-5298-4555-b71e-92b80f736222"
+  token_name                = var.second_run ? null : "johns_token"
+  repository                = "https://gitlab.com/moooo/moooo-docs-aws-functions.git"
+  github_installation_id    = var.second_run ? 32112 : null
+  path                      = var.second_run ? "/cool1" : "/cool2"
+  tag_prefix                = var.second_run ? "t2" : "t1"
+  module_test_enabled       = var.second_run ? true : false
+  run_tests_on_pull_request = var.second_run ? true : false
+  opentofu_version          = var.second_run ? "" : "1.6.0"
+}

--- a/tests/integration/018_module/main.tf
+++ b/tests/integration/018_module/main.tf
@@ -26,7 +26,7 @@ resource "env0_module" "test_module_with_test_enabled" {
   github_installation_id    = var.second_run ? 32112 : null
   path                      = var.second_run ? "/cool1" : "/cool2"
   tag_prefix                = var.second_run ? "t2" : "t1"
-  module_test_enabled       = var.second_run ? true : false
-  run_tests_on_pull_request = var.second_run ? true : false
+  module_test_enabled       = var.second_run ? false : true
+  run_tests_on_pull_request = var.second_run ? false : true
   opentofu_version          = var.second_run ? "" : "1.6.0"
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #788 

### Solution

1. Added the new fields to the API structs.
2. Added the new fields to the schema.
3. Added a condition to fail module test is disabled but opentofu or run_tests_on pull are enalbed.
4. Updated integration tests.
5. Updated acceptance tests.
