### PR TITLE
Fix: changing terragrunt_working_directory for an environment should …

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -251,7 +251,8 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"terragrunt_working_directory": {
 				Type:        schema.TypeString,
-				Description: "The working directory path to be used by a Terragrunt template. If left empty '/' is used.",
+				Description: "The working directory path to be used by a Terragrunt template. If left empty '/' is used. Note: modifying this field destroys the current environment and creates a new one",
+				ForceNew:    true,
 				Optional:    true,
 			},
 			"vcs_commands_alias": {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -658,7 +658,7 @@ func shouldDeploy(d *schema.ResourceData) bool {
 }
 
 func shouldUpdate(d *schema.ResourceData) bool {
-	return d.HasChanges("name", "approve_plan_automatically", "deploy_on_push", "run_plan_on_pull_requests", "auto_deploy_by_custom_glob", "auto_deploy_on_path_changes_only", "terragrunt_working_directory", "vcs_commands_alias", "is_remote_backend", "is_inactive", "is_remote_apply_enabled")
+	return d.HasChanges("name", "approve_plan_automatically", "deploy_on_push", "run_plan_on_pull_requests", "auto_deploy_by_custom_glob", "auto_deploy_on_path_changes_only", "vcs_commands_alias", "is_remote_backend", "is_inactive", "is_remote_apply_enabled")
 }
 
 func shouldUpdateTTL(d *schema.ResourceData) bool {

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -55,7 +55,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			BlueprintRevision: "revision",
 			Output:            []byte(`{"a": "b"}`),
 		},
-		TerragruntWorkingDirectory: "/terragrunt/directory2/",
+		TerragruntWorkingDirectory: "/terragrunt/directory/",
 		VcsCommandsAlias:           "alias2",
 		IsRemoteBackend:            &isRemoteBackendTrue,
 		IsArchived:                 boolPtr(true),


### PR DESCRIPTION
…force replacement instead of update in place

### Issue & Steps to Reproduce / Feature Request
fixes #792 

### Solution

1. Added forcenew to the terragrunt_working_directory field.
2. Updated tests (avoid changing terragrunt directory).