### PR TITLE
Feat: add `prevent_auto_deploy` flag to create without deploy

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -138,7 +138,7 @@ type EnvironmentCreate struct {
 	IsRemoteBackend             *bool                  `json:"isRemoteBackend,omitempty" tfschema:"-"`
 	Type                        string                 `json:"type,omitempty"`
 	DriftDetectionRequest       *DriftDetectionRequest `json:"driftDetectionRequest,omitempty" tfschema:"-"`
-	PreventAutoDeploy           bool                   `json:"preventAutoDeploy"`
+	PreventAutoDeploy           *bool                  `json:"preventAutoDeploy,omitempty" tfschema:"-"`
 }
 
 // When converted to JSON needs to be flattened. See custom MarshalJSON below.

--- a/client/environment.go
+++ b/client/environment.go
@@ -138,7 +138,7 @@ type EnvironmentCreate struct {
 	IsRemoteBackend             *bool                  `json:"isRemoteBackend,omitempty" tfschema:"-"`
 	Type                        string                 `json:"type,omitempty"`
 	DriftDetectionRequest       *DriftDetectionRequest `json:"driftDetectionRequest,omitempty" tfschema:"-"`
-	PreventAutoDeploy           *bool                  `json:"preventAutoDeploy,omitempty" tfschema:"-"`
+	PreventAutoDeploy           bool                   `json:"preventAutoDeploy"`
 }
 
 // When converted to JSON needs to be flattened. See custom MarshalJSON below.

--- a/client/environment.go
+++ b/client/environment.go
@@ -138,6 +138,7 @@ type EnvironmentCreate struct {
 	IsRemoteBackend             *bool                  `json:"isRemoteBackend,omitempty" tfschema:"-"`
 	Type                        string                 `json:"type,omitempty"`
 	DriftDetectionRequest       *DriftDetectionRequest `json:"driftDetectionRequest,omitempty" tfschema:"-"`
+	PreventAutoDeploy           *bool                  `json:"preventAutoDeploy,omitempty" tfschema:"-"`
 }
 
 // When converted to JSON needs to be flattened. See custom MarshalJSON below.

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -251,7 +251,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"prevent_auto_deploy": {
 				Type:        schema.TypeBool,
-				Description: "prevent auto deploy",
+				Description: "use this flag to prevent auto deploy on environment creation",
 				Optional:    true,
 			},
 			"terragrunt_working_directory": {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -253,7 +253,6 @@ func resourceEnvironment() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "use this flag to prevent auto deploy on environment creation",
 				Optional:    true,
-				Default:     false,
 			},
 			"terragrunt_working_directory": {
 				Type:        schema.TypeString,
@@ -803,6 +802,11 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
 	if val, exists := d.GetOkExists("run_plan_on_pull_requests"); exists {
 		payload.PullRequestPlanDeployments = boolPtr(val.(bool))
+	}
+
+	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
+	if val, exists := d.GetOkExists("prevent_auto_deploy"); exists {
+		payload.PreventAutoDeploy = boolPtr(val.(bool))
 	}
 
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -253,6 +253,7 @@ func resourceEnvironment() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "use this flag to prevent auto deploy on environment creation",
 				Optional:    true,
+				Default:     false,
 			},
 			"terragrunt_working_directory": {
 				Type:        schema.TypeString,
@@ -802,11 +803,6 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
 	if val, exists := d.GetOkExists("run_plan_on_pull_requests"); exists {
 		payload.PullRequestPlanDeployments = boolPtr(val.(bool))
-	}
-
-	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
-	if val, exists := d.GetOkExists("prevent_auto_deploy"); exists {
-		payload.PreventAutoDeploy = boolPtr(val.(bool))
 	}
 
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -249,6 +249,11 @@ func resourceEnvironment() *schema.Resource {
 				Description: "should use remote backend",
 				Optional:    true,
 			},
+			"prevent_auto_deploy": {
+				Type:        schema.TypeBool,
+				Description: "prevent auto deploy",
+				Optional:    true,
+			},
 			"terragrunt_working_directory": {
 				Type:        schema.TypeString,
 				Description: "The working directory path to be used by a Terragrunt template. If left empty '/' is used. Note: modifying this field destroys the current environment and creates a new one",
@@ -797,6 +802,11 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
 	if val, exists := d.GetOkExists("run_plan_on_pull_requests"); exists {
 		payload.PullRequestPlanDeployments = boolPtr(val.(bool))
+	}
+
+	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817
+	if val, exists := d.GetOkExists("prevent_auto_deploy"); exists {
+		payload.PreventAutoDeploy = boolPtr(val.(bool))
 	}
 
 	//lint:ignore SA1019 reason: https://github.com/hashicorp/terraform-plugin-sdk/issues/817

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -187,7 +187,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 		t.Run("prevent auto deploy", func(t *testing.T) {
 			templateId := "template-id"
-			newTemplateId := "new-template-id"
 			truthyFruity := true
 
 			environment := client.Environment{
@@ -217,16 +216,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 							resource.TestCheckResourceAttr(accessor, "prevent_auto_deploy", "true"),
 						),
 					},
-					{
-						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-							"name":                environment.Name,
-							"project_id":          environment.ProjectId,
-							"template_id":         newTemplateId,
-							"force_destroy":       true,
-							"prevent_auto_deploy": true,
-						}),
-						ExpectError: regexp.MustCompile("template_id may not be modified, create a new environment instead"),
-					},
 				},
 			}
 
@@ -242,8 +231,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 						PreventAutoDeploy: &truthyFruity,
 					}).Times(1).Return(environment, nil),
-					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
-					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -187,7 +187,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 		t.Run("prevent auto deploy", func(t *testing.T) {
 			templateId := "template-id"
-			truthyFruity := true
 
 			environment := client.Environment{
 				Id:        uuid.New().String(),
@@ -229,7 +228,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 							BlueprintId: templateId,
 						},
 
-						PreventAutoDeploy: &truthyFruity,
+						PreventAutoDeploy: true,
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -187,6 +187,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 		t.Run("prevent auto deploy", func(t *testing.T) {
 			templateId := "template-id"
+			truthyFruity := true
 
 			environment := client.Environment{
 				Id:        uuid.New().String(),
@@ -228,7 +229,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 							BlueprintId: templateId,
 						},
 
-						PreventAutoDeploy: true,
+						PreventAutoDeploy: &truthyFruity,
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -185,6 +185,72 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			})
 		})
 
+		t.Run("prevent auto deploy", func(t *testing.T) {
+			templateId := "template-id"
+			newTemplateId := "new-template-id"
+			truthyFruity := true
+
+			environment := client.Environment{
+				Id:        uuid.New().String(),
+				Name:      "name",
+				ProjectId: "project-id",
+				LatestDeploymentLog: client.DeploymentLog{
+					BlueprintId: templateId,
+				},
+			}
+
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+							"name":                environment.Name,
+							"project_id":          environment.ProjectId,
+							"template_id":         templateId,
+							"force_destroy":       true,
+							"prevent_auto_deploy": true,
+						}),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+							resource.TestCheckResourceAttr(accessor, "name", environment.Name),
+							resource.TestCheckResourceAttr(accessor, "project_id", environment.ProjectId),
+							resource.TestCheckResourceAttr(accessor, "template_id", templateId),
+							resource.TestCheckResourceAttr(accessor, "prevent_auto_deploy", "true"),
+						),
+					},
+					{
+						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+							"name":                environment.Name,
+							"project_id":          environment.ProjectId,
+							"template_id":         newTemplateId,
+							"force_destroy":       true,
+							"prevent_auto_deploy": true,
+						}),
+						ExpectError: regexp.MustCompile("template_id may not be modified, create a new environment instead"),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				gomock.InOrder(
+					mock.EXPECT().Template(environment.LatestDeploymentLog.BlueprintId).Times(1).Return(template, nil),
+					mock.EXPECT().EnvironmentCreate(client.EnvironmentCreate{
+						Name:      environment.Name,
+						ProjectId: environment.ProjectId,
+						DeployRequest: &client.DeployRequest{
+							BlueprintId: templateId,
+						},
+
+						PreventAutoDeploy: &truthyFruity,
+					}).Times(1).Return(environment, nil),
+					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
+				)
+			})
+		})
+
 		t.Run("avoid modifying template id", func(t *testing.T) {
 			templateId := "template-id"
 			newTemplateId := "new-template-id"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
we want to support the new `prevent_auto_deploy` argument of the create envirionment API.

using the property, the user can skip the deployment of the environment in env0 and only create it on resource create. updating and destroying should remain the same

### Solution

- add support for the new `prevent_auto_deploy` api

### Manual QA against dev
![image](https://github.com/env0/terraform-provider-env0/assets/103362486/2b68069d-dd88-4822-9072-27600aac6b10)
