### PR TITLE
Feat: support removal_strategy on destroy environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -70,6 +70,7 @@ type ApiClientInterface interface {
 	EnvironmentCreate(payload EnvironmentCreate) (Environment, error)
 	EnvironmentCreateWithoutTemplate(payload EnvironmentCreateWithoutTemplate) (Environment, error)
 	EnvironmentDestroy(id string) (Environment, error)
+	EnvironmentMarkAsArchived(id string) error
 	EnvironmentUpdate(id string, payload EnvironmentUpdate) (Environment, error)
 	EnvironmentDeploy(id string, payload DeployRequest) (EnvironmentDeployResponse, error)
 	EnvironmentUpdateTTL(id string, payload TTL) (Environment, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -704,6 +704,20 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDriftDetection(arg0 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDriftDetection", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDriftDetection), arg0)
 }
 
+// EnvironmentMarkAsArchived mocks base method.
+func (m *MockApiClientInterface) EnvironmentMarkAsArchived(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentMarkAsArchived", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnvironmentMarkAsArchived indicates an expected call of EnvironmentMarkAsArchived.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentMarkAsArchived(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentMarkAsArchived", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentMarkAsArchived), arg0)
+}
+
 // EnvironmentScheduling mocks base method.
 func (m *MockApiClientInterface) EnvironmentScheduling(arg0 string) (EnvironmentScheduling, error) {
 	m.ctrl.T.Helper()

--- a/client/environment.go
+++ b/client/environment.go
@@ -270,6 +270,14 @@ func (client *ApiClient) EnvironmentUpdate(id string, payload EnvironmentUpdate)
 	return result, nil
 }
 
+func (client *ApiClient) EnvironmentMarkAsArchived(id string) error {
+	payload := struct {
+		IsArchived bool `json:"isArchived"`
+	}{true}
+
+	return client.http.Put("/environments/"+id, &payload, nil)
+}
+
 func (client *ApiClient) EnvironmentUpdateTTL(id string, payload TTL) (Environment, error) {
 	var result Environment
 	err := client.http.Put("/environments/"+id+"/ttl", payload, &result)

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -277,6 +277,26 @@ var _ = Describe("Environment Client", func() {
 		})
 	})
 
+	Describe("EnvironmentMarkAsArchived", func() {
+		payload := struct {
+			IsArchived bool `json:"isArchived"`
+		}{true}
+
+		var err error
+
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Put("/environments/"+mockEnvironment.Id, &payload, nil).Return(nil).Times(1)
+			err = apiClient.EnvironmentMarkAsArchived(mockEnvironment.Id)
+		})
+
+		It("Should send an archive put request", func() {})
+
+		It("Should not return error", func() {
+			Expect(err).To(BeNil())
+		})
+
+	})
+
 	Describe("EnvironmentUpdate", func() {
 		Describe("Success", func() {
 			var updatedEnvironment Environment

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -226,3 +226,11 @@ resource "env0_environment" "workflow-environment" {
     }
   }
 }
+
+resource "env0_environment" "mark_as_archived" {
+  depends_on       = [env0_template_project_assignment.assignment]
+  name             = "environment-mark-as-archived-${random_string.random.result}"
+  project_id       = env0_project.test_project.id
+  template_id      = env0_template.template.id
+  removal_strategy = "mark_as_archived"
+}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #806 

### Solution

1. Added 'removal_strategy' to the schema (defaults to: 'destroy') and required functionality.
2. Added a PUT API call that marks the environment as isArchived 'true'.
3. Added unit test for the new API call.
4. Added an acceptance test.
5. Added an integration.
