### PR TITLE
Fix: resource 'env0_environment_scheduling' does not pass destroy_cro…

### DIFF
--- a/env0/resource_environment_scheduling.go
+++ b/env0/resource_environment_scheduling.go
@@ -69,6 +69,14 @@ func resourceEnvironmentSchedulingCreateOrUpdate(ctx context.Context, d *schema.
 		return diag.Errorf("schema resource data deserialization failed: %v", err)
 	}
 
+	if payload.Deploy != nil && !payload.Deploy.Enabled {
+		payload.Deploy = nil
+	}
+
+	if payload.Destroy != nil && !payload.Destroy.Enabled {
+		payload.Destroy = nil
+	}
+
 	if _, err := apiClient.EnvironmentSchedulingUpdate(environmentId, payload); err != nil {
 		return diag.Errorf("could not create or update environment scheduling: %v", err)
 	}

--- a/tests/integration/014_environment_scheduling/main.tf
+++ b/tests/integration/014_environment_scheduling/main.tf
@@ -34,5 +34,5 @@ resource "env0_environment" "environment" {
 resource "env0_environment_scheduling" "scheduling" {
   environment_id = env0_environment.environment.id
   deploy_cron    = "5 * * * *"
-  destroy_cron   = "10 * * * *"
+  destroy_cron   = var.second_run ? null : "10 * * * *"
 }


### PR DESCRIPTION
…n=null on updates

fixes #841 

### Solution

1. Passing null instead of a "disabled" cron.
2. Updated an integration test.