### PR TITLE
Feat: Add Support for K8s Credentials - kubeconfig

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -150,6 +150,7 @@ type ApiClientInterface interface {
 	TeamRoleAssignmentCreateOrUpdate(payload *TeamRoleAssignmentCreateOrUpdatePayload) (*TeamRoleAssignmentPayload, error)
 	TeamRoleAssignmentDelete(payload *TeamRoleAssignmentDeletePayload) error
 	TeamRoleAssignments(payload *TeamRoleAssignmentListPayload) ([]TeamRoleAssignmentPayload, error)
+	KubernetesCredentialsCreate(payload *KubernetesCredentialsCreatePayload) (*Credentials, error)
 }
 
 func NewApiClient(client http.HttpClientInterface, defaultOrganizationId string) ApiClientInterface {

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -939,6 +939,21 @@ func (mr *MockApiClientInterfaceMockRecorder) GpgKeys() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GpgKeys", reflect.TypeOf((*MockApiClientInterface)(nil).GpgKeys))
 }
 
+// KubernetesCredentialsCreate mocks base method.
+func (m *MockApiClientInterface) KubernetesCredentialsCreate(arg0 *KubernetesCredentialsCreatePayload) (*Credentials, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KubernetesCredentialsCreate", arg0)
+	ret0, _ := ret[0].(*Credentials)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KubernetesCredentialsCreate indicates an expected call of KubernetesCredentialsCreate.
+func (mr *MockApiClientInterfaceMockRecorder) KubernetesCredentialsCreate(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KubernetesCredentialsCreate", reflect.TypeOf((*MockApiClientInterface)(nil).KubernetesCredentialsCreate), arg0)
+}
+
 // Module mocks base method.
 func (m *MockApiClientInterface) Module(arg0 string) (*Module, error) {
 	m.ctrl.T.Helper()

--- a/client/kubernetes_credentials.go
+++ b/client/kubernetes_credentials.go
@@ -1,0 +1,65 @@
+package client
+
+type KubernetesCrednetialsType string
+
+const (
+	KubeconfigCredentialsType KubernetesCrednetialsType = "K8S_KUBECONFIG_FILE"
+	AwsEksCredentialsType     KubernetesCrednetialsType = "K8S_EKS_AUTH"
+	AzureAksCredentialsType   KubernetesCrednetialsType = "K8S_AZURE_AKS_AUTH"
+	GcpGkeCredentialsType     KubernetesCrednetialsType = "K8S_GCP_GKE_AUTH"
+)
+
+type KubernetesCredentialsCreatePayload struct {
+	Name  string                    `json:"name"`
+	Type  KubernetesCrednetialsType `json:"type"`
+	Value interface{}               `json:"value"`
+}
+
+// K8S_KUBECONFIG_FILE
+type KubeconfigFileValue struct {
+	KubeConfig string `json:"kubeConfig"`
+}
+
+// K8S_EKS_AUTH
+type AwsEksValue struct {
+	ClusterName   string `json:"clusterName"`
+	ClusterRegion string `json:"clusterRegion"`
+}
+
+// K8S_AZURE_AKS_AUTH
+type AzureAksValue struct {
+	ClusterName   string `json:"clusterName"`
+	ResourceGroup string `json:"resourceGroup"`
+}
+
+// K8S_GCP_GKE_AUTH
+type GcpGkeValue struct {
+	ClusterName   string `json:"clusterName"`
+	ComputeRegion string `json:"computeRegion"`
+}
+
+func (client *ApiClient) KubernetesCredentialsCreate(payload *KubernetesCredentialsCreatePayload) (*Credentials, error) {
+	organizationId, err := client.OrganizationId()
+	if err != nil {
+		return nil, err
+	}
+
+	payloadWithOrganizatioId := &struct {
+		OrganizationId string      `json:"organizationId"`
+		Name           string      `json:"name"`
+		Type           string      `json:"type"`
+		Value          interface{} `json:"value"`
+	}{
+		OrganizationId: organizationId,
+		Name:           payload.Name,
+		Type:           string(payload.Type),
+		Value:          payload.Value,
+	}
+
+	var result Credentials
+	if err := client.http.Post("/credentials", payloadWithOrganizatioId, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/client/kubernetes_credentials_test.go
+++ b/client/kubernetes_credentials_test.go
@@ -1,0 +1,65 @@
+package client_test
+
+import (
+	. "github.com/env0/terraform-provider-env0/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Kubernetes Credentials", func() {
+	var credentials *Credentials
+
+	Describe("KubernetesCredentialsCreate", func() {
+		value := AzureAksValue{
+			ClusterName:   "cc11",
+			ResourceGroup: "rg11",
+		}
+
+		createPayload := KubernetesCredentialsCreatePayload{
+			Name:  "n1",
+			Type:  "K8S_AZURE_AKS_AUTH",
+			Value: &value,
+		}
+
+		createPayloadWithOrganizationId := struct {
+			OrganizationId string      `json:"organizationId"`
+			Name           string      `json:"name"`
+			Type           string      `json:"type"`
+			Value          interface{} `json:"value"`
+		}{
+			OrganizationId: organizationId,
+			Name:           createPayload.Name,
+			Type:           string(createPayload.Type),
+			Value:          createPayload.Value,
+		}
+
+		mockCredentials := Credentials{
+			Id: "id111",
+		}
+
+		BeforeEach(func() {
+			mockOrganizationIdCall(organizationId)
+
+			httpCall = mockHttpClient.EXPECT().
+				Post("/credentials", &createPayloadWithOrganizationId, gomock.Any()).
+				Do(func(path string, request interface{}, response *Credentials) {
+					*response = mockCredentials
+				})
+
+			credentials, _ = apiClient.KubernetesCredentialsCreate(&createPayload)
+		})
+
+		It("Should get organization id", func() {
+			organizationIdCall.Times(1)
+		})
+
+		It("Should send POST request with params", func() {
+			httpCall.Times(1)
+		})
+
+		It("Should return key", func() {
+			Expect(credentials).To(Equal(&mockCredentials))
+		})
+	})
+})

--- a/env0/credentials.go
+++ b/env0/credentials.go
@@ -25,6 +25,10 @@ const (
 	GCP_OIDC_TYPE   CloudType = "gcp_oidc"
 	GCP_COST_TYPE   CloudType = "google_cost"
 	VAULT_OIDC_TYPE CloudType = "vault_oidc"
+	KUBECONFIG_TYPE CloudType = "kubeconfig"
+	AWS_EKS_TYPE    CloudType = "aws_eks"
+	AZURE_AKS_TYPE  CloudType = "azure_aks"
+	GCP_GKE_TYPE    CloudType = "gcp_gke"
 )
 
 var credentialsTypeToPrefixList map[CloudType][]string = map[CloudType][]string{
@@ -38,6 +42,10 @@ var credentialsTypeToPrefixList map[CloudType][]string = map[CloudType][]string{
 	GCP_COST_TYPE:   {string(client.GoogleCostCredentialsType)},
 	GCP_OIDC_TYPE:   {string(client.GcpOidcCredentialsType)},
 	VAULT_OIDC_TYPE: {string(client.VaultOidcCredentialsType)},
+	KUBECONFIG_TYPE: {string(client.KubeconfigCredentialsType)},
+	AWS_EKS_TYPE:    {string(client.AwsEksCredentialsType)},
+	AZURE_AKS_TYPE:  {string(client.AzureAksCredentialsType)},
+	GCP_GKE_TYPE:    {string(client.GcpGkeCredentialsType)},
 }
 
 func getCredentialsByName(name string, prefixList []string, meta interface{}) (client.Credentials, error) {

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -148,6 +148,7 @@ func Provider(version string) plugin.ProviderFunc {
 				"env0_approval_policy_assignment":           resourceApprovalPolicyAssignment(),
 				"env0_project_budget":                       resourceProjectBudget(),
 				"env0_environment_discovery_configuration":  resourceEnvironmentDiscoveryConfiguration(),
+				"env0_kubeconfig_credentials":               resourceKubeconfigCredentials(),
 			},
 		}
 

--- a/env0/resource_kubeconfig_credentials.go
+++ b/env0/resource_kubeconfig_credentials.go
@@ -1,0 +1,58 @@
+package env0
+
+import (
+	"context"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceKubeconfigCredentials() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKubeconfigCredentialsCreate,
+		ReadContext:   resourceCredentialsRead(KUBECONFIG_TYPE),
+		DeleteContext: resourceCredentialsDelete,
+
+		Importer: &schema.ResourceImporter{StateContext: resourceCredentialsImport(KUBECONFIG_TYPE)},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "name for the credentials",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"kube_config": {
+				Type:        schema.TypeString,
+				Description: "A valid kubeconfig file content",
+				Required:    true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceKubeconfigCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	value := client.KubeconfigFileValue{}
+	if err := readResourceData(&value, d); err != nil {
+		return diag.Errorf("schema resource data deserialization failed: %v", err)
+	}
+
+	apiClient := meta.(client.ApiClientInterface)
+
+	request := client.KubernetesCredentialsCreatePayload{
+		Name:  d.Get("name").(string),
+		Value: value,
+		Type:  client.KubeconfigCredentialsType,
+	}
+
+	credentials, err := apiClient.KubernetesCredentialsCreate(&request)
+	if err != nil {
+		return diag.Errorf("could not create credentials: %v", err)
+	}
+
+	d.SetId(credentials.Id)
+
+	return nil
+}

--- a/env0/resource_kubeconfig_credentials_test.go
+++ b/env0/resource_kubeconfig_credentials_test.go
@@ -1,0 +1,231 @@
+package env0
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/env0/terraform-provider-env0/client/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUnitKubeconfigCredentialsResource(t *testing.T) {
+	resourceType := "env0_kubeconfig_credentials"
+	resourceName := "test"
+	resourceNameImport := resourceType + "." + resourceName
+	accessor := resourceAccessor(resourceType, resourceName)
+
+	credentialsResource := map[string]interface{}{
+		"name":        "test",
+		"kube_config": "file content...",
+	}
+
+	updatedCredentialsResource := map[string]interface{}{
+		"name":        "test",
+		"kube_config": "new file content...",
+	}
+
+	createPayload := client.KubernetesCredentialsCreatePayload{
+		Name: credentialsResource["name"].(string),
+		Value: client.KubeconfigFileValue{
+			KubeConfig: credentialsResource["kube_config"].(string),
+		},
+		Type: client.KubeconfigCredentialsType,
+	}
+
+	updatePayload := client.KubernetesCredentialsCreatePayload{
+		Name: updatedCredentialsResource["name"].(string),
+		Value: client.KubeconfigFileValue{
+			KubeConfig: updatedCredentialsResource["kube_config"].(string),
+		},
+		Type: client.KubeconfigCredentialsType,
+	}
+
+	returnValues := client.Credentials{
+		Id:             "f595c4b6-0a24-4c22-89f7-7030045de30f",
+		Name:           "test",
+		OrganizationId: "id",
+		Type:           string(client.KubeconfigCredentialsType),
+	}
+
+	otherTypeReturnValues := client.Credentials{
+		Id:             "f595c4b6-0a24-4c22-89f7-7030045de30a",
+		Name:           "test",
+		OrganizationId: "id",
+		Type:           "AWS_....",
+	}
+
+	updateReturnValues := client.Credentials{
+		Id:             "dsdsdsd-0a24-4c22-89f7-7030045de30f",
+		Name:           returnValues.Name,
+		OrganizationId: "id",
+		Type:           string(client.KubeconfigCredentialsType),
+	}
+
+	testCaseForCreateAndUpdate := resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, credentialsResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accessor, "name", credentialsResource["name"].(string)),
+					resource.TestCheckResourceAttr(accessor, "kube_config", credentialsResource["kube_config"].(string)),
+					resource.TestCheckResourceAttr(accessor, "id", returnValues.Id),
+				),
+			},
+			{
+				Config: resourceConfigCreate(resourceType, resourceName, updatedCredentialsResource),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(accessor, "name", updatedCredentialsResource["name"].(string)),
+					resource.TestCheckResourceAttr(accessor, "kube_config", updatedCredentialsResource["kube_config"].(string)),
+					resource.TestCheckResourceAttr(accessor, "id", updateReturnValues.Id),
+				),
+			},
+		},
+	}
+
+	t.Run("create and update", func(t *testing.T) {
+		runUnitTest(t, testCaseForCreateAndUpdate, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(2).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+				mock.EXPECT().KubernetesCredentialsCreate(&updatePayload).Times(1).Return(&updateReturnValues, nil),
+				mock.EXPECT().CloudCredentials(updateReturnValues.Id).Times(1).Return(updateReturnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(updateReturnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("drift", func(t *testing.T) {
+		stepConfig := resourceConfigCreate(resourceType, resourceName, credentialsResource)
+
+		createTestCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: stepConfig,
+				},
+				{
+					Config: stepConfig,
+				},
+			},
+		}
+
+		runUnitTest(t, createTestCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, http.NewMockFailedResponseError(404)),
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("import by name", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, credentialsResource),
+				},
+				{
+					ResourceName:            resourceNameImport,
+					ImportState:             true,
+					ImportStateId:           credentialsResource["name"].(string),
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"kube_config"},
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsList().Times(1).Return([]client.Credentials{otherTypeReturnValues, returnValues}, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("import by id", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, credentialsResource),
+				},
+				{
+					ResourceName:            resourceNameImport,
+					ImportState:             true,
+					ImportStateId:           returnValues.Id,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"kube_config"},
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(3).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("import by id not found", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, credentialsResource),
+				},
+				{
+					ResourceName:      resourceNameImport,
+					ImportState:       true,
+					ImportStateId:     otherTypeReturnValues.Id,
+					ImportStateVerify: true,
+					ExpectError:       regexp.MustCompile("credentials not found"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentials(otherTypeReturnValues.Id).Times(1).Return(client.Credentials{}, &client.NotFoundError{}),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+
+	t.Run("import by name not found", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, credentialsResource),
+				},
+				{
+					ResourceName:      resourceNameImport,
+					ImportState:       true,
+					ImportStateId:     credentialsResource["name"].(string),
+					ImportStateVerify: true,
+					ExpectError:       regexp.MustCompile(fmt.Sprintf("credentials with name %v not found", credentialsResource["name"].(string))),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().KubernetesCredentialsCreate(&createPayload).Times(1).Return(&returnValues, nil),
+				mock.EXPECT().CloudCredentials(returnValues.Id).Times(1).Return(returnValues, nil),
+				mock.EXPECT().CloudCredentialsList().Times(1).Return([]client.Credentials{otherTypeReturnValues}, nil),
+				mock.EXPECT().CloudCredentialsDelete(returnValues.Id).Times(1).Return(nil),
+			)
+		})
+	})
+}


### PR DESCRIPTION
part 1 of of #837. Adding support for kubeconfig (1 out of 4).

### Solution

1. Added a new API for creating kubernetes credential types.
2. Added some enums, constants and structs for the new types.
3. Added a test for the new API.
4. Added a new resource for kube config.
5. Added tests for the new resource.
6. Added a kube config use-case to the integration tests.