### PR TITLE
Feat: add support to webhookSecret in notification API

### DIFF
--- a/client/notification.go
+++ b/client/notification.go
@@ -19,9 +19,10 @@ type Notification struct {
 }
 
 type NotificationCreatePayload struct {
-	Name  string           `json:"name"`
-	Type  NotificationType `json:"type"`
-	Value string           `json:"value"`
+	Name          string           `json:"name"`
+	Type          NotificationType `json:"type"`
+	Value         string           `json:"value"`
+	WebhookSecret string           `json:"webhookSecret,omitempty"`
 }
 
 type NotificationCreatePayloadWith struct {
@@ -30,9 +31,10 @@ type NotificationCreatePayloadWith struct {
 }
 
 type NotificationUpdatePayload struct {
-	Name  string           `json:"name,omitempty"`
-	Type  NotificationType `json:"type,omitempty"`
-	Value string           `json:"value,omitempty"`
+	Name          string           `json:"name,omitempty"`
+	Type          NotificationType `json:"type,omitempty"`
+	Value         string           `json:"value,omitempty"`
+	WebhookSecret **string         `json:"webhookSecret,omitempty" tfschema:"-"`
 }
 
 func (client *ApiClient) Notifications() ([]Notification, error) {

--- a/env0/resource_notification_test.go
+++ b/env0/resource_notification_test.go
@@ -51,20 +51,25 @@ func TestUnitNotificationResource(t *testing.T) {
 		CreatedByUser:  notification.CreatedByUser,
 	}
 
+	webhookSecret := "my-little-secret"
+	var nullString *string
+
 	t.Run("Success", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":  notification.Name,
-						"type":  notification.Type,
-						"value": notification.Value,
+						"name":           notification.Name,
+						"type":           notification.Type,
+						"value":          notification.Value,
+						"webhook_secret": webhookSecret,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", notification.Id),
 						resource.TestCheckResourceAttr(accessor, "name", notification.Name),
 						resource.TestCheckResourceAttr(accessor, "value", notification.Value),
 						resource.TestCheckResourceAttr(accessor, "type", string(notification.Type)),
+						resource.TestCheckResourceAttr(accessor, "webhook_secret", webhookSecret),
 					),
 				},
 				{
@@ -85,15 +90,17 @@ func TestUnitNotificationResource(t *testing.T) {
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
 			mock.EXPECT().NotificationCreate(client.NotificationCreatePayload{
-				Name:  notification.Name,
-				Type:  notification.Type,
-				Value: notification.Value,
+				Name:          notification.Name,
+				Type:          notification.Type,
+				Value:         notification.Value,
+				WebhookSecret: webhookSecret,
 			}).Times(1).Return(&notification, nil)
 
 			mock.EXPECT().NotificationUpdate(updatedNotification.Id, client.NotificationUpdatePayload{
-				Name:  updatedNotification.Name,
-				Type:  updatedNotification.Type,
-				Value: updatedNotification.Value,
+				Name:          updatedNotification.Name,
+				Type:          updatedNotification.Type,
+				Value:         updatedNotification.Value,
+				WebhookSecret: &nullString,
 			}).Times(1).Return(&updatedNotification, nil)
 
 			gomock.InOrder(

--- a/tests/integration/025_notifications/main.tf
+++ b/tests/integration/025_notifications/main.tf
@@ -11,9 +11,10 @@ locals {
 }
 
 resource "env0_notification" "test_notification_1" {
-  name  = "${local.notification_name_prefix}-1-${random_string.random.result}"
-  type  = "Slack"
-  value = "https://someurl1.com"
+  name           = "${local.notification_name_prefix}-1-${random_string.random.result}"
+  type           = "Slack"
+  value          = "https://someurl1.com"
+  webhook_secret = "my_little_secret"
 }
 
 resource "env0_notification" "test_notification_2" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #850 

### Solution

1. Added the new field to the resource.
2. Updated the acceptance tests.
3. Update the integration tests.
