### PR TITLE
Feat: add API calls for configuration set assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ attic
 .vscode/
 .idea/
 tf
+
+# macosx
+.DS_Store

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -157,6 +157,8 @@ type ApiClientInterface interface {
 	ConfigurationSet(id string) (*ConfigurationSet, error)
 	ConfigurationSetDelete(id string) error
 	ConfigurationVariablesBySetId(setId string) ([]ConfigurationVariable, error)
+	AssignConfigurationSets(scope string, scopeId string, sets []string) error
+	UnassignConfigurationSets(scope string, scopeId string, sets []string) error
 }
 
 func NewApiClient(client http.HttpClientInterface, defaultOrganizationId string) ApiClientInterface {

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -230,6 +230,20 @@ func (mr *MockApiClientInterfaceMockRecorder) AssignCloudCredentialsToProject(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignCloudCredentialsToProject", reflect.TypeOf((*MockApiClientInterface)(nil).AssignCloudCredentialsToProject), arg0, arg1)
 }
 
+// AssignConfigurationSets mocks base method.
+func (m *MockApiClientInterface) AssignConfigurationSets(arg0, arg1 string, arg2 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssignConfigurationSets", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AssignConfigurationSets indicates an expected call of AssignConfigurationSets.
+func (mr *MockApiClientInterfaceMockRecorder) AssignConfigurationSets(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignConfigurationSets", reflect.TypeOf((*MockApiClientInterface)(nil).AssignConfigurationSets), arg0, arg1, arg2)
+}
+
 // AssignCostCredentialsToProject mocks base method.
 func (m *MockApiClientInterface) AssignCostCredentialsToProject(arg0, arg1 string) (CostCredentialProjectAssignment, error) {
 	m.ctrl.T.Helper()
@@ -2042,6 +2056,20 @@ func (m *MockApiClientInterface) Templates() ([]Template, error) {
 func (mr *MockApiClientInterfaceMockRecorder) Templates() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Templates", reflect.TypeOf((*MockApiClientInterface)(nil).Templates))
+}
+
+// UnassignConfigurationSets mocks base method.
+func (m *MockApiClientInterface) UnassignConfigurationSets(arg0, arg1 string, arg2 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnassignConfigurationSets", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnassignConfigurationSets indicates an expected call of UnassignConfigurationSets.
+func (mr *MockApiClientInterfaceMockRecorder) UnassignConfigurationSets(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignConfigurationSets", reflect.TypeOf((*MockApiClientInterface)(nil).UnassignConfigurationSets), arg0, arg1, arg2)
 }
 
 // UnsubscribeWorkflowTrigger mocks base method.

--- a/client/configuration_set_assignment.go
+++ b/client/configuration_set_assignment.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (client *ApiClient) AssignConfigurationSets(scope string, scopeId string, sets []string) error {
+	setIds := strings.Join(sets, ",")
+	url := fmt.Sprintf("/configuration-sets/assignments/%s/%s?setIds=%s", scope, scopeId, setIds)
+
+	return client.http.Post(url, nil, nil)
+}
+
+func (client *ApiClient) UnassignConfigurationSets(scope string, scopeId string, sets []string) error {
+	setIds := strings.Join(sets, ",")
+	url := fmt.Sprintf("/configuration-sets/assignments/%s/%s", scope, scopeId)
+
+	return client.http.Delete(url, map[string]string{"setIds": setIds})
+}

--- a/client/configuration_set_assignment_test.go
+++ b/client/configuration_set_assignment_test.go
@@ -1,0 +1,31 @@
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Configuration Set", func() {
+	scope := "environment"
+	scopeId := "12345"
+	setIds := []string{"1", "2", "3"}
+
+	Describe("assign configuration sets", func() {
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Post("/configuration-sets/assignments/environment/12345?setIds=1,2,3", nil, nil).Times(1)
+			apiClient.AssignConfigurationSets(scope, scopeId, setIds)
+		})
+
+		It("Should send post request", func() {})
+	})
+
+	Describe("unassign configuration sets", func() {
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Delete("/configuration-sets/assignments/environment/12345", map[string]string{
+				"setIds": "1,2,3",
+			}).Times(1)
+			apiClient.UnassignConfigurationSets(scope, scopeId, setIds)
+		})
+
+		It("Should send delete request", func() {})
+	})
+})


### PR DESCRIPTION
### Solution

Part of #829 

1. Added API calls configuration sets assignments.
2. Added unit tests.