### PR TITLE
Fix: removing configuration from sub_environment_configuration

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -734,7 +734,7 @@ func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Di
 		for i, subEnvironment := range subEnvironments {
 			configuration := d.Get(fmt.Sprintf("sub_environment_configuration.%d.configuration", i)).([]interface{})
 			configurationChanges := getConfigurationVariablesFromSchema(configuration)
-			configurationChanges = getUpdateConfigurationVariables(configurationChanges, subEnvironment.Id, client.ScopeWorkflow, apiClient)
+			configurationChanges = getUpdateConfigurationVariables(configurationChanges, subEnvironment.Id, client.ScopeEnvironment, apiClient)
 
 			for i := range configurationChanges {
 				configurationChanges[i].Scope = client.ScopeEnvironment

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2593,7 +2593,7 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, subEnvrionmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvrionmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
 				mock.EXPECT().EnvironmentDeploy(environment.Id, deployRequest).Times(1).Return(client.EnvironmentDeployResponse{
 					Id: environment.Id,
 				}, nil),


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #873 

### Solution

Modifed scope from workflow to environment (for a sub environment). Updated test accordingly.