### PR TITLE
Feat: add variable set support for environment schema

### DIFF
--- a/client/configuration_set_assignment.go
+++ b/client/configuration_set_assignment.go
@@ -22,7 +22,7 @@ func (client *ApiClient) UnassignConfigurationSets(scope string, scopeId string,
 func (client *ApiClient) ConfigurationSetsAssignments(scope string, scopeId string) ([]ConfigurationSet, error) {
 	var result []ConfigurationSet
 
-	url := fmt.Sprintf("/configuration-sets/assignments/%s/%s", scope, scopeId)
+	url := fmt.Sprintf("/configuration-sets/assignments/%s/%s", strings.ToLower(scope), scopeId)
 
 	if err := client.http.Get(url, nil, &result); err != nil {
 		return nil, err

--- a/client/environment.go
+++ b/client/environment.go
@@ -65,14 +65,15 @@ type SubEnvironment struct {
 }
 
 type DeployRequest struct {
-	BlueprintId          string                    `json:"blueprintId,omitempty"`
-	BlueprintRevision    string                    `json:"blueprintRevision,omitempty"`
-	BlueprintRepository  string                    `json:"blueprintRepository,omitempty"`
-	ConfigurationChanges *ConfigurationChanges     `json:"configurationChanges,omitempty"`
-	TTL                  *TTL                      `json:"ttl,omitempty"`
-	EnvName              string                    `json:"envName,omitempty"`
-	UserRequiresApproval *bool                     `json:"userRequiresApproval,omitempty"`
-	SubEnvironments      map[string]SubEnvironment `json:"subEnvironments,omitempty"`
+	BlueprintId             string                    `json:"blueprintId,omitempty"`
+	BlueprintRevision       string                    `json:"blueprintRevision,omitempty"`
+	BlueprintRepository     string                    `json:"blueprintRepository,omitempty"`
+	ConfigurationChanges    *ConfigurationChanges     `json:"configurationChanges,omitempty"`
+	TTL                     *TTL                      `json:"ttl,omitempty"`
+	EnvName                 string                    `json:"envName,omitempty"`
+	UserRequiresApproval    *bool                     `json:"userRequiresApproval,omitempty"`
+	SubEnvironments         map[string]SubEnvironment `json:"subEnvironments,omitempty"`
+	ConfigurationSetChanges *ConfigurationSetChanges  `json:"configurationSetChanges,omitempty" tfschema:"-"`
 }
 
 type WorkflowSubEnvironment struct {
@@ -97,6 +98,11 @@ type DeploymentLog struct {
 type DriftDetectionRequest struct {
 	Enabled bool   `json:"enabled"`
 	Cron    string `json:"cron"`
+}
+
+type ConfigurationSetChanges struct {
+	Assign   []string `json:"assign,omitempty"`
+	Unassign []string `json:"unassign,omitempty"`
 }
 
 type Environment struct {
@@ -124,24 +130,25 @@ type Environment struct {
 }
 
 type EnvironmentCreate struct {
-	Name                        string                 `json:"name"`
-	ProjectId                   string                 `json:"projectId"`
-	DeployRequest               *DeployRequest         `json:"deployRequest" tfschema:"-"`
-	WorkspaceName               string                 `json:"workspaceName,omitempty" tfschema:"workspace"`
-	RequiresApproval            *bool                  `json:"requiresApproval,omitempty" tfschema:"-"`
-	ContinuousDeployment        *bool                  `json:"continuousDeployment,omitempty" tfschema:"-"`
-	PullRequestPlanDeployments  *bool                  `json:"pullRequestPlanDeployments,omitempty" tfschema:"-"`
-	AutoDeployOnPathChangesOnly *bool                  `json:"autoDeployOnPathChangesOnly,omitempty" tfchema:"-"`
-	AutoDeployByCustomGlob      string                 `json:"autoDeployByCustomGlob"`
-	ConfigurationChanges        *ConfigurationChanges  `json:"configurationChanges,omitempty" tfschema:"-"`
-	TTL                         *TTL                   `json:"ttl,omitempty" tfschema:"-"`
-	TerragruntWorkingDirectory  string                 `json:"terragruntWorkingDirectory,omitempty"`
-	VcsCommandsAlias            string                 `json:"vcsCommandsAlias"`
-	IsRemoteBackend             *bool                  `json:"isRemoteBackend,omitempty" tfschema:"-"`
-	Type                        string                 `json:"type,omitempty"`
-	DriftDetectionRequest       *DriftDetectionRequest `json:"driftDetectionRequest,omitempty" tfschema:"-"`
-	PreventAutoDeploy           *bool                  `json:"preventAutoDeploy,omitempty" tfschema:"-"`
-	K8sNamespace                string                 `json:"k8s_namespace,omitempty"`
+	Name                        string                   `json:"name"`
+	ProjectId                   string                   `json:"projectId"`
+	DeployRequest               *DeployRequest           `json:"deployRequest" tfschema:"-"`
+	WorkspaceName               string                   `json:"workspaceName,omitempty" tfschema:"workspace"`
+	RequiresApproval            *bool                    `json:"requiresApproval,omitempty" tfschema:"-"`
+	ContinuousDeployment        *bool                    `json:"continuousDeployment,omitempty" tfschema:"-"`
+	PullRequestPlanDeployments  *bool                    `json:"pullRequestPlanDeployments,omitempty" tfschema:"-"`
+	AutoDeployOnPathChangesOnly *bool                    `json:"autoDeployOnPathChangesOnly,omitempty" tfchema:"-"`
+	AutoDeployByCustomGlob      string                   `json:"autoDeployByCustomGlob"`
+	ConfigurationChanges        *ConfigurationChanges    `json:"configurationChanges,omitempty" tfschema:"-"`
+	TTL                         *TTL                     `json:"ttl,omitempty" tfschema:"-"`
+	TerragruntWorkingDirectory  string                   `json:"terragruntWorkingDirectory,omitempty"`
+	VcsCommandsAlias            string                   `json:"vcsCommandsAlias"`
+	IsRemoteBackend             *bool                    `json:"isRemoteBackend,omitempty" tfschema:"-"`
+	Type                        string                   `json:"type,omitempty"`
+	DriftDetectionRequest       *DriftDetectionRequest   `json:"driftDetectionRequest,omitempty" tfschema:"-"`
+	PreventAutoDeploy           *bool                    `json:"preventAutoDeploy,omitempty" tfschema:"-"`
+	K8sNamespace                string                   `json:"k8s_namespace,omitempty"`
+	ConfigurationSetChanges     *ConfigurationSetChanges `json:"configurationSetChanges,omitempty" tfschema:"-"`
 }
 
 // When converted to JSON needs to be flattened. See custom MarshalJSON below.

--- a/env0/data_environment.go
+++ b/env0/data_environment.go
@@ -123,7 +123,7 @@ func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	setEnvironmentSchema(ctx, d, environment, client.ConfigurationChanges{})
+	setEnvironmentSchema(ctx, d, environment, client.ConfigurationChanges{}, nil)
 
 	templateId := environment.LatestDeploymentLog.BlueprintId
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -616,12 +616,7 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func getEnvironmentVariableSetIdsFromApi(d *schema.ResourceData, apiClient client.ApiClientInterface) ([]string, error) {
-	scope := "ENVIRONMENT"
-	if _, ok := d.GetOk("sub_environment_configuration"); ok {
-		scope = "WORKFLOW"
-	}
-
-	environmentVariableSets, err := apiClient.ConfigurationSetsAssignments(scope, d.Id())
+	environmentVariableSets, err := apiClient.ConfigurationSetsAssignments("ENVIRONMENT", d.Id())
 	if err != nil {
 		return nil, err
 	}

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -368,7 +368,7 @@ func resourceEnvironment() *schema.Resource {
 	}
 }
 
-func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, configurationVariables client.ConfigurationChanges, VariableSetsIds []string) error {
+func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, configurationVariables client.ConfigurationChanges, variableSetsIds []string) error {
 	if err := writeResourceData(&environment, d); err != nil {
 		return fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
@@ -426,8 +426,10 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 
 	setEnvironmentConfigurationSchema(ctx, d, configurationVariables)
 
-	if err := d.Set("variable_sets", VariableSetsIds); err != nil {
-		return fmt.Errorf("failed to set variable_sets value: %w", err)
+	if d.Get("variable_sets") != nil {
+		if err := d.Set("variable_sets", variableSetsIds); err != nil {
+			return fmt.Errorf("failed to set variable_sets value: %w", err)
+		}
 	}
 
 	return nil

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -1069,6 +1069,10 @@ func getEnvironmentConfigurationSetChanges(d *schema.ResourceData, apiClient cli
 		}
 	}
 
+	if assignVariableSets == nil && unassignVariableSets == nil {
+		return nil, nil
+	}
+
 	return &client.ConfigurationSetChanges{
 		Assign:   assignVariableSets,
 		Unassign: unassignVariableSets,

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -348,6 +348,15 @@ func resourceEnvironment() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"variable_sets": {
+				Type:        schema.TypeList,
+				Description: "a list of variable set to assign to this environment",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					Description: "variable set id",
+				},
+			},
 		},
 		CustomizeDiff: customdiff.ValidateChange("template_id", func(ctx context.Context, oldValue, newValue, meta interface{}) error {
 			if oldValue != "" && oldValue != newValue {
@@ -359,7 +368,7 @@ func resourceEnvironment() *schema.Resource {
 	}
 }
 
-func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, configurationVariables client.ConfigurationChanges) error {
+func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, configurationVariables client.ConfigurationChanges, VariableSetsIds []string) error {
 	if err := writeResourceData(&environment, d); err != nil {
 		return fmt.Errorf("schema resource data serialization failed: %v", err)
 	}
@@ -416,6 +425,10 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 	}
 
 	setEnvironmentConfigurationSchema(ctx, d, configurationVariables)
+
+	if err := d.Set("variable_sets", VariableSetsIds); err != nil {
+		return fmt.Errorf("failed to set variable_sets value: %w", err)
+	}
 
 	return nil
 }
@@ -590,9 +603,33 @@ func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta
 		d.Set("auto_deploy_on_path_changes_only", *environment.AutoDeployOnPathChangesOnly)
 	}
 
-	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables)
+	var environmentVariableSetIds []string
+	if environmentPayload.ConfigurationSetChanges != nil {
+		environmentVariableSetIds = environmentPayload.ConfigurationSetChanges.Assign
+	}
+
+	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables, environmentVariableSetIds)
 
 	return nil
+}
+
+func getEnvironmentVariableSetIdsFromApi(d *schema.ResourceData, apiClient client.ApiClientInterface) ([]string, error) {
+	scope := "ENVIRONMENT"
+	if _, ok := d.GetOk("sub_environment_configuration"); ok {
+		scope = "WORKFLOW"
+	}
+
+	environmentVariableSets, err := apiClient.ConfigurationSetsAssignments(scope, d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	var environmentVariableSetIds []string
+	for _, variableSet := range environmentVariableSets {
+		environmentVariableSetIds = append(environmentVariableSetIds, variableSet.Id)
+	}
+
+	return environmentVariableSetIds, nil
 }
 
 func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -613,7 +650,12 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("could not get environment configuration variables: %v", err)
 	}
 
-	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables)
+	environmentVariableSetIds, err := getEnvironmentVariableSetIdsFromApi(d, apiClient)
+	if err != nil {
+		return diag.Errorf("could not get environment variable sets: %v", err)
+	}
+
+	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables, environmentVariableSetIds)
 
 	if isTemplateless(d) {
 		// envrionment with no template.
@@ -672,7 +714,7 @@ func shouldUpdateTemplate(d *schema.ResourceData) bool {
 }
 
 func shouldDeploy(d *schema.ResourceData) bool {
-	return d.HasChanges("revision", "configuration", "sub_environment_configuration")
+	return d.HasChanges("revision", "configuration", "sub_environment_configuration", "variable_sets")
 }
 
 func shouldUpdate(d *schema.ResourceData) bool {
@@ -721,7 +763,10 @@ func updateDriftDetection(d *schema.ResourceData, apiClient client.ApiClientInte
 }
 
 func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Diagnostics {
-	deployPayload := getDeployPayload(d, apiClient, true)
+	deployPayload, err := getDeployPayload(d, apiClient, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	subEnvironments, err := getSubEnvironments(d)
 	if err != nil {
@@ -734,7 +779,10 @@ func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Di
 		for i, subEnvironment := range subEnvironments {
 			configuration := d.Get(fmt.Sprintf("sub_environment_configuration.%d.configuration", i)).([]interface{})
 			configurationChanges := getConfigurationVariablesFromSchema(configuration)
-			configurationChanges = getUpdateConfigurationVariables(configurationChanges, subEnvironment.Id, client.ScopeEnvironment, apiClient)
+			configurationChanges, err = getUpdateConfigurationVariables(configurationChanges, subEnvironment.Id, client.ScopeEnvironment, apiClient)
+			if err != nil {
+				return diag.FromErr(err)
+			}
 
 			for i := range configurationChanges {
 				configurationChanges[i].Scope = client.ScopeEnvironment
@@ -778,6 +826,18 @@ func updateTTL(d *schema.ResourceData, apiClient client.ApiClientInterface) diag
 		return diag.Errorf("could not update the environment's ttl: %v", err)
 	}
 	return nil
+}
+
+func getEnvironmentVariableSetIdsFromSchema(d *schema.ResourceData) []string {
+	var variableSets []string
+
+	if ivariableSets, ok := d.GetOk("variable_sets"); ok {
+		for _, ivariableSet := range ivariableSets.([]interface{}) {
+			variableSets = append(variableSets, ivariableSet.(string))
+		}
+	}
+
+	return variableSets
 }
 
 func resourceEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -868,7 +928,17 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		}
 	}
 
-	deployPayload := getDeployPayload(d, apiClient, false)
+	variableSets := getEnvironmentVariableSetIdsFromSchema(d)
+	if len(variableSets) > 0 {
+		payload.ConfigurationSetChanges = &client.ConfigurationSetChanges{
+			Assign: variableSets,
+		}
+	}
+
+	deployPayload, err := getDeployPayload(d, apiClient, false)
+	if err != nil {
+		return client.EnvironmentCreate{}, diag.FromErr(err)
+	}
 
 	subEnvironments, err := getSubEnvironments(d)
 	if err != nil {
@@ -957,8 +1027,55 @@ func getUpdatePayload(d *schema.ResourceData) (client.EnvironmentUpdate, diag.Di
 	return payload, nil
 }
 
-func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterface, isRedeploy bool) client.DeployRequest {
+func getEnvironmentConfigurationSetChanges(d *schema.ResourceData, apiClient client.ApiClientInterface) (*client.ConfigurationSetChanges, error) {
+	variableSetsFromSchema := getEnvironmentVariableSetIdsFromSchema(d)
+	variableSetFromApi, err := getEnvironmentVariableSetIdsFromApi(d, apiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	var assignVariableSets []string
+	var unassignVariableSets []string
+
+	for _, sv := range variableSetsFromSchema {
+		found := false
+
+		for _, av := range variableSetFromApi {
+			if sv == av {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			assignVariableSets = append(assignVariableSets, sv)
+		}
+	}
+
+	for _, av := range variableSetFromApi {
+		found := false
+
+		for _, sv := range variableSetsFromSchema {
+			if sv == av {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			unassignVariableSets = append(unassignVariableSets, av)
+		}
+	}
+
+	return &client.ConfigurationSetChanges{
+		Assign:   assignVariableSets,
+		Unassign: unassignVariableSets,
+	}, nil
+}
+
+func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterface, isRedeploy bool) (client.DeployRequest, error) {
 	payload := client.DeployRequest{}
+	var err error
 
 	if isTemplateless(d) {
 		templateId, ok := d.GetOk("without_template_settings.0.id")
@@ -973,14 +1090,24 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		payload.BlueprintRevision = revision.(string)
 	}
 
-	if configuration, ok := d.GetOk("configuration"); ok && isRedeploy {
-		configurationChanges := getConfigurationVariablesFromSchema(configuration.([]interface{}))
-		scope := client.ScopeEnvironment
-		if _, ok := d.GetOk("sub_environment_configuration"); ok {
-			scope = client.ScopeWorkflow
+	if isRedeploy {
+		if configuration, ok := d.GetOk("configuration"); ok && isRedeploy {
+			configurationChanges := getConfigurationVariablesFromSchema(configuration.([]interface{}))
+			scope := client.ScopeEnvironment
+			if _, ok := d.GetOk("sub_environment_configuration"); ok {
+				scope = client.ScopeWorkflow
+			}
+			configurationChanges, err = getUpdateConfigurationVariables(configurationChanges, d.Get("id").(string), scope, apiClient)
+			if err != nil {
+				return client.DeployRequest{}, err
+			}
+			payload.ConfigurationChanges = &configurationChanges
 		}
-		configurationChanges = getUpdateConfigurationVariables(configurationChanges, d.Get("id").(string), scope, apiClient)
-		payload.ConfigurationChanges = &configurationChanges
+
+		payload.ConfigurationSetChanges, err = getEnvironmentConfigurationSetChanges(d, apiClient)
+		if err != nil {
+			return client.DeployRequest{}, err
+		}
 	}
 
 	if userRequiresApproval, ok := d.GetOk("requires_approval"); ok {
@@ -988,7 +1115,7 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		payload.UserRequiresApproval = &userRequiresApproval
 	}
 
-	return payload
+	return payload, nil
 }
 
 func getTTl(date string) client.TTL {
@@ -1004,15 +1131,15 @@ func getTTl(date string) client.TTL {
 	}
 }
 
-func getUpdateConfigurationVariables(configurationChanges client.ConfigurationChanges, environmentId string, scope client.Scope, apiClient client.ApiClientInterface) client.ConfigurationChanges {
+func getUpdateConfigurationVariables(configurationChanges client.ConfigurationChanges, environmentId string, scope client.Scope, apiClient client.ApiClientInterface) (client.ConfigurationChanges, error) {
 	existVariables, err := apiClient.ConfigurationVariablesByScope(scope, environmentId)
 	if err != nil {
-		diag.Errorf("could not get environment configuration variables: %v", err)
+		return client.ConfigurationChanges{}, fmt.Errorf("could not get environment configuration variables: %w", err)
 	}
 	configurationChanges = linkToExistConfigurationVariables(configurationChanges, existVariables)
 	configurationChanges = deleteUnusedConfigurationVariables(configurationChanges, existVariables)
 
-	return configurationChanges
+	return configurationChanges, nil
 }
 
 func getConfigurationVariablesFromSchema(configuration []interface{}) client.ConfigurationChanges {
@@ -1188,6 +1315,11 @@ func resourceEnvironmentImporter(ctx context.Context, d *schema.ResourceData, me
 		return nil, fmt.Errorf("could not get environment configuration variables: %v", err)
 	}
 
+	environmentVariableSetIds, err := getEnvironmentVariableSetIdsFromApi(d, apiClient)
+	if err != nil {
+		return nil, fmt.Errorf("could not get environment variable sets: %v", err)
+	}
+
 	d.Set("deployment_id", environment.LatestDeploymentLogId)
 
 	if environment.IsSingleUseBlueprint {
@@ -1206,7 +1338,7 @@ func resourceEnvironmentImporter(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables)
+	setEnvironmentSchema(ctx, d, environment, environmentConfigurationVariables, environmentVariableSetIds)
 
 	if environment.IsRemoteBackend != nil {
 		d.Set("is_remote_backend", *environment.IsRemoteBackend)

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2746,17 +2746,18 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(environmentCreatePayload).Times(1).Return(environment, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvrionmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
 				mock.EXPECT().EnvironmentDeploy(environment.Id, deployRequest).Times(1).Return(client.EnvironmentDeployResponse{
 					Id: environment.Id,
 				}, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 			)
 		})

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -183,6 +183,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					IsArchived:                 updatedEnvironment.IsArchived,
 				}).Times(1).Return(updatedEnvironment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", updatedEnvironment.Id).Times(3).Return(nil, nil)
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil),        // 1 after create, 1 before update
 					mock.EXPECT().Environment(gomock.Any()).Times(1).Return(updatedEnvironment, nil), // 1 after update
@@ -240,6 +241,128 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
+				)
+			})
+		})
+
+		t.Run("environment with variable set ids", func(t *testing.T) {
+			templateId := "template-id"
+
+			environment := client.Environment{
+				Id:        uuid.New().String(),
+				Name:      "name",
+				ProjectId: "project-id",
+				LatestDeploymentLog: client.DeploymentLog{
+					BlueprintId: templateId,
+				},
+			}
+
+			configurationSets := []client.ConfigurationSet{
+				{
+					Id: "id1",
+				},
+				{
+					Id: "id2",
+				},
+			}
+
+			updatedConfigurationSets := []client.ConfigurationSet{
+				{
+					Id: "id3",
+				},
+				{
+					Id: "id2",
+				},
+			}
+
+			environmentCreate := client.EnvironmentCreate{
+				Name:      environment.Name,
+				ProjectId: environment.ProjectId,
+				DeployRequest: &client.DeployRequest{
+					BlueprintId: environment.LatestDeploymentLog.BlueprintId,
+				},
+				ConfigurationSetChanges: &client.ConfigurationSetChanges{
+					Assign: []string{
+						configurationSets[0].Id,
+						configurationSets[1].Id,
+					},
+				},
+			}
+
+			environmentDeployRequest := client.DeployRequest{
+				BlueprintId: environment.LatestDeploymentLog.BlueprintId,
+				ConfigurationSetChanges: &client.ConfigurationSetChanges{
+					Assign:   []string{updatedConfigurationSets[0].Id},
+					Unassign: []string{configurationSets[0].Id},
+				},
+			}
+
+			environmentDeployResponse := client.EnvironmentDeployResponse{
+				Id: "12345",
+			}
+
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+							"name":          environment.Name,
+							"project_id":    environment.ProjectId,
+							"template_id":   templateId,
+							"force_destroy": true,
+							"variable_sets": environmentCreate.ConfigurationSetChanges.Assign,
+						}),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+							resource.TestCheckResourceAttr(accessor, "name", environment.Name),
+							resource.TestCheckResourceAttr(accessor, "project_id", environment.ProjectId),
+							resource.TestCheckResourceAttr(accessor, "template_id", templateId),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.0", configurationSets[0].Id),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.1", configurationSets[1].Id),
+						),
+					},
+					{
+						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+							"name":          environment.Name,
+							"project_id":    environment.ProjectId,
+							"template_id":   templateId,
+							"force_destroy": true,
+							"variable_sets": []string{updatedConfigurationSets[0].Id, updatedConfigurationSets[1].Id},
+						}),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+							resource.TestCheckResourceAttr(accessor, "name", environment.Name),
+							resource.TestCheckResourceAttr(accessor, "project_id", environment.ProjectId),
+							resource.TestCheckResourceAttr(accessor, "template_id", templateId),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.0", updatedConfigurationSets[0].Id),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.1", updatedConfigurationSets[1].Id),
+							resource.TestCheckResourceAttr(accessor, "deployment_id", environmentDeployResponse.Id),
+						),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				gomock.InOrder(
+					mock.EXPECT().Template(environment.LatestDeploymentLog.BlueprintId).Times(1).Return(template, nil),
+					mock.EXPECT().EnvironmentCreate(environmentCreate).Times(1).Return(environment, nil),
+
+					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(configurationSets, nil),
+
+					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(configurationSets, nil),
+
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(configurationSets, nil),
+					mock.EXPECT().EnvironmentDeploy(environment.Id, environmentDeployRequest).Times(1).Return(environmentDeployResponse, nil),
+
+					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(updatedConfigurationSets, nil),
+
 					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 				)
 			})
@@ -300,8 +423,10 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 				)
 			})
@@ -402,8 +527,10 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().EnvironmentUpdate(updatedEnvironment.Id, client.EnvironmentUpdate{
 						Name:                 updatedEnvironment.Name,
 						IsRemoteBackend:      updatedEnvironment.IsRemoteBackend,
@@ -412,8 +539,10 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					}).Times(1).Return(updatedEnvironment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(updatedEnvironment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(updatedEnvironment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 				)
 			})
@@ -462,6 +591,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					}).Times(1).Return(environment, nil),
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 					mock.EXPECT().EnvironmentMarkAsArchived(environment.Id).Times(1).Return(nil),
 				)
 			})
@@ -501,6 +631,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().Environment(environment.Id).Times(3).Return(environment, nil)
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(3).Return(nil, nil)
 			})
 		})
 
@@ -576,6 +707,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				}).Times(1).Return(updatedEnvironment, nil)
 				mock.EXPECT().EnvironmentStopDriftDetection(environment.Id).Times(1).Return(nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(3).Return(nil, nil)
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil),        // 1 after create, 1 before update
 					mock.EXPECT().Environment(gomock.Any()).Times(1).Return(updatedEnvironment, nil), // 1 after update
@@ -657,6 +789,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				}).Times(1).Return(updatedEnvironment, nil)
 				mock.EXPECT().EnvironmentUpdateDriftDetection(environment.Id, client.EnvironmentSchedulingExpression{Cron: updatedDriftDetectionCron, Enabled: true}).Times(1).Return(client.EnvironmentSchedulingExpression{}, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(3).Return(nil, nil)
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil),        // 1 after create, 1 before update
 					mock.EXPECT().Environment(gomock.Any()).Times(1).Return(updatedEnvironment, nil), // 1 after update
@@ -840,6 +973,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 				varTrue := true
 				configurationVariables.ToDelete = &varTrue
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(4).Return(nil, nil)
 				gomock.InOrder(
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{configurationVariables}, nil), // read after create -> on update
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(1).Return(redeployConfigurationVariables, nil),                      // read after create -> on update -> read after update
@@ -932,6 +1066,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
 
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariables}, nil) // read after create -> on update -> read after update
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil)
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil)
 
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
@@ -1069,6 +1204,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			}
 
 			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(4).Return(nil, nil)
 				gomock.InOrder(
 					mock.EXPECT().Template(environment.LatestDeploymentLog.BlueprintId).Times(1).Return(template, nil),
 					mock.EXPECT().EnvironmentCreate(environmentCreate).Times(1).Return(environment, nil),
@@ -1149,6 +1285,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
 
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariables}, nil) // read after create -> on update -> read after update
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil)
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil)
 
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
@@ -1230,6 +1367,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
 
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable2, configurationVariable1}, nil) // read after create -> on update -> read after update
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil)
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil)
 
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
@@ -1342,6 +1480,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().EnvironmentDeploy(environment.Id, gomock.Any()).Times(1).Return(client.EnvironmentDeployResponse{
 					Id: "deployment-id",
 				}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(4).Return(nil, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(2).Return(client.ConfigurationChanges{}, nil) // read after create -> on update -> read after update
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil), // 1 after create, 1 before update
@@ -1421,6 +1560,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					Value: updatedEnvironment.LifespanEndAt,
 				}).Times(1).Return(environment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{}, nil) // read after create -> on update -> read after update
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", updatedEnvironment.Id).Times(3).Return(nil, nil)
 
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil),        // 1 after create, 1 before update
@@ -1492,6 +1632,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					Value: "",
 				}).Times(1).Return(environment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, updatedEnvironment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", updatedEnvironment.Id).Times(3).Return(nil, nil)
 
 				gomock.InOrder(
 					mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil),        // 1 after create, 1 before update
@@ -1601,6 +1742,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					mock.EXPECT().Environment(gomock.Any()).Times(1).Return(environmentAfterUpdate, nil), // 1 after update
 				)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(3).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", updatedEnvironment.Id).Times(3).Return(nil, nil)
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 			})
 		})
@@ -1668,6 +1810,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().Template(environment.LatestDeploymentLog.BlueprintId).Times(1).Return(template, nil)
 				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(5).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", updatedEnvironment.Id).Times(5).Return(nil, nil)
 				mock.EXPECT().Environment(gomock.Any()).Times(5).Return(environment, nil)
 				mock.EXPECT().EnvironmentDestroy(gomock.Any()).Times(1)
 
@@ -1731,6 +1874,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
 				mock.EXPECT().Environment(gomock.Any()).Times(1).Return(environment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(gomock.Any(), gomock.Any()).Times(1).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", gomock.Any()).Times(1).Return(nil, nil)
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 			})
 		})
@@ -1832,6 +1976,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 					K8sNamespace:               environment.K8sNamespace,
 				}).Times(1).Return(environment, nil)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(2).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(2).Return(nil, nil)
 				mock.EXPECT().EnvironmentUpdate(updatedEnvironment.Id, client.EnvironmentUpdate{
 					Name:                       updatedEnvironment.Name,
 					AutoDeployByCustomGlob:     autoDeployByCustomGlobDefault,
@@ -1888,6 +2033,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil) // 1 after create, 1 before update
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(2).Return(client.ConfigurationChanges{}, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(2).Return(nil, nil)
 			})
 
 		})
@@ -1942,6 +2088,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				BlueprintRevision: updatedEnvironment.LatestDeploymentLog.BlueprintRevision,
 			}).Times(1).Return(client.EnvironmentDeployResponse{}, errors.New("error"))
 			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil)
+			mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil)
 			mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil)
 			mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(environment, http.NewMockFailedResponseError(400))
 		})
@@ -2234,12 +2381,14 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
 
 				// Step2
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
 
 				// Update
@@ -2248,17 +2397,20 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
 
 				// Step3
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
 
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(updatedTemplate, nil),
 
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
@@ -2292,16 +2444,19 @@ func TestUnitEnvironmentWithoutTemplateResource(t *testing.T) {
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
 
 				// Import
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
 
 				// Read
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Template(template.Id).Times(1).Return(template, nil),
 
 				// Destroy
@@ -2591,14 +2746,17 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 				mock.EXPECT().EnvironmentCreate(environmentCreatePayload).Times(1).Return(environment, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvrionmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
 				mock.EXPECT().EnvironmentDeploy(environment.Id, deployRequest).Times(1).Return(client.EnvironmentDeployResponse{
 					Id: environment.Id,
 				}, nil),
 				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("WORKFLOW", environment.Id).Times(1).Return(nil, nil),
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 			)
 		})

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2033,7 +2033,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 				mock.EXPECT().Environment(gomock.Any()).Times(2).Return(environment, nil) // 1 after create, 1 before update
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
 				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(2).Return(client.ConfigurationChanges{}, nil)
-				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(2).Return(nil, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(3).Return(nil, nil)
 			})
 
 		})

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -211,6 +211,21 @@ resource "env0_template_project_assignment" "assignment_workflow" {
   project_id  = env0_project.test_project.id
 }
 
+
+resource "env0_variable_set" "variable_set" {
+  name        = "variable-set-project-${random_string.random.result}"
+  description = "description123"
+  scope       = "project"
+  scope_id    = env0_project.test_project.id
+
+  variable {
+    name   = "n1"
+    value  = "v1"
+    type   = "terraform"
+    format = "text"
+  }
+}
+
 resource "env0_environment" "workflow-environment" {
   depends_on                 = [env0_template_project_assignment.assignment_workflow, env0_template_project_assignment.assignment_sub_environment_null_template]
   force_destroy              = true
@@ -223,6 +238,8 @@ resource "env0_environment" "workflow-environment" {
     name  = "n1"
     value = "v1"
   }
+
+  variable_sets = [env0_variable_set.variable_set.id]
 
   sub_environment_configuration {
     alias    = "rootService1"

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -212,7 +212,7 @@ resource "env0_template_project_assignment" "assignment_workflow" {
 }
 
 
-resource "env0_variable_set" "variable_set" {
+resource "env0_variable_set" "variable_set1" {
   name        = "variable-set-project-${random_string.random.result}"
   description = "description123"
   scope       = "project"
@@ -221,6 +221,20 @@ resource "env0_variable_set" "variable_set" {
   variable {
     name   = "n1"
     value  = "v1"
+    type   = "terraform"
+    format = "text"
+  }
+}
+
+resource "env0_variable_set" "variable_set2" {
+  name        = "variable-set-project2-${random_string.random.result}"
+  description = "description123"
+  scope       = "project"
+  scope_id    = env0_project.test_project.id
+
+  variable {
+    name   = "n2"
+    value  = "v2"
     type   = "terraform"
     format = "text"
   }
@@ -239,7 +253,7 @@ resource "env0_environment" "workflow-environment" {
     value = "v1"
   }
 
-  variable_sets = [env0_variable_set.variable_set.id]
+  variable_sets = var.second_run ? [env0_variable_set.variable_set2.id] : [env0_variable_set.variable_set1.id]
 
   sub_environment_configuration {
     alias    = "rootService1"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #829 

### Solution

1. Added 'variable_sets' to the schema (a list of ids).
2. Implemented handling in environment resource for "read, update and create".
3. Added an acceptance test.
4. Update an integration test to cover the use-case.