### PR TITLE
Fix: add force destroy project to flaky tests

### DIFF
--- a/tests/integration/013_downstream_environments/main.tf
+++ b/tests/integration/013_downstream_environments/main.tf
@@ -8,6 +8,7 @@ resource "env0_project" "test_project" {
   name        = "Test-Project-${random_string.random.result}"
   description = "Test Description ${var.second_run ? "after update" : ""}"
   wait        = true
+  force_destroy = true
 }
 
 resource "env0_template" "template" {

--- a/tests/integration/014_environment_scheduling/main.tf
+++ b/tests/integration/014_environment_scheduling/main.tf
@@ -7,6 +7,7 @@ resource "random_string" "random" {
 resource "env0_project" "test_project" {
   name = "Test-Project-for-environment-scheduling-${random_string.random.result}"
   wait = true
+  force_destroy = true
 }
 
 resource "env0_template" "template" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

[fixes](https://github.com/env0/terraform-provider-env0/issues/881)

We noticed two of the integration tests are flaky. It is caused by environments being deployed again just before we try to destroy the project


### Solution

since this is not the focus of the test, we decided to force destroy the project when it ends. 