### PR TITLE
Fix: drift issues with variable sets

### DIFF
--- a/client/configuration_set.go
+++ b/client/configuration_set.go
@@ -18,9 +18,10 @@ type UpdateConfigurationSetPayload struct {
 }
 
 type ConfigurationSet struct {
-	Id          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Id              string `json:"id"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	AssignmentScope string `json:"assignmentScope"`
 }
 
 func (client *ApiClient) ConfigurationSetCreate(payload *CreateConfigurationSetPayload) (*ConfigurationSet, error) {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -357,7 +357,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"variable_sets": {
 				Type:        schema.TypeList,
-				Description: "a list of variable set to assign to this environment",
+				Description: "a list of variable set to assign to this environment. Note: must not be used with 'env0_variable_set_assignment'",
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type:        schema.TypeString,
@@ -433,7 +433,7 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 
 	setEnvironmentConfigurationSchema(ctx, d, configurationVariables)
 
-	if d.Get("variable_sets") != nil {
+	if variableSets, ok := d.GetOk("variable_sets"); variableSets != nil && ok {
 		if err := d.Set("variable_sets", variableSetsIds); err != nil {
 			return fmt.Errorf("failed to set variable_sets value: %w", err)
 		}
@@ -630,7 +630,9 @@ func getEnvironmentVariableSetIdsFromApi(d *schema.ResourceData, apiClient clien
 
 	var environmentVariableSetIds []string
 	for _, variableSet := range environmentVariableSets {
-		environmentVariableSetIds = append(environmentVariableSetIds, variableSet.Id)
+		if variableSet.AssignmentScope == "ENVIRONMENT" {
+			environmentVariableSetIds = append(environmentVariableSetIds, variableSet.Id)
+		}
 	}
 
 	return environmentVariableSetIds, nil

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -433,7 +433,7 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 
 	setEnvironmentConfigurationSchema(ctx, d, configurationVariables)
 
-	if variableSets, ok := d.GetOk("variable_sets"); variableSets != nil && ok {
+	if d.Get("variable_sets") != nil {
 		if err := d.Set("variable_sets", variableSetsIds); err != nil {
 			return fmt.Errorf("failed to set variable_sets value: %w", err)
 		}

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -261,19 +261,23 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 			configurationSets := []client.ConfigurationSet{
 				{
-					Id: "id1",
+					Id:              "id1",
+					AssignmentScope: "ENVIRONMENT",
 				},
 				{
-					Id: "id2",
+					Id:              "id2",
+					AssignmentScope: "ENVIRONMENT",
 				},
 			}
 
 			updatedConfigurationSets := []client.ConfigurationSet{
 				{
-					Id: "id3",
+					Id:              "id3",
+					AssignmentScope: "ENVIRONMENT",
 				},
 				{
-					Id: "id2",
+					Id:              "id2",
+					AssignmentScope: "ENVIRONMENT",
 				},
 			}
 

--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -21,6 +21,8 @@ func resourceVariableSetAssignment() *schema.Resource {
 		ReadContext:   resourceVariableSetAssignmentRead,
 		DeleteContext: resourceVariableSetAssignmentDelete,
 
+		Description: "note: avoid assigning to environments using 'variable_sets' (see environment schema).",
+
 		Schema: map[string]*schema.Schema{
 			"scope": {
 				Type:             schema.TypeString,
@@ -87,6 +89,10 @@ func resourceVariableSetAssignmentUpdate(ctx context.Context, d *schema.Resource
 
 	// In API but not in Schema - delete.
 	for _, apiConfigurationSet := range apiConfigurationSets {
+		if apiConfigurationSet.AssignmentScope != assignmentSchema.Scope {
+			continue
+		}
+
 		found := false
 
 		apiSetId := apiConfigurationSet.Id
@@ -181,6 +187,10 @@ func resourceVariableSetAssignmentRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	for _, apiConfigurationSet := range apiConfigurationSets {
+		if apiConfigurationSet.AssignmentScope != assignmentSchema.Scope {
+			continue
+		}
+
 		apiSetId := apiConfigurationSet.Id
 		found := false
 

--- a/env0/resource_variable_set_assignment_test.go
+++ b/env0/resource_variable_set_assignment_test.go
@@ -20,29 +20,35 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 		setIds := []string{"a1", "a2"}
 		configurationSetIds := []client.ConfigurationSet{
 			{
-				Id: "a1",
+				Id:              "a1",
+				AssignmentScope: scope,
 			},
 			{
-				Id: "a2",
+				Id:              "a2",
+				AssignmentScope: scope,
 			},
 		}
 		// Validates that drifts do not occur due to ordering.
 		flippedConfigurationSetIds := []client.ConfigurationSet{
 			{
-				Id: "a2",
+				Id:              "a2",
+				AssignmentScope: scope,
 			},
 			{
-				Id: "a1",
+				Id:              "a1",
+				AssignmentScope: scope,
 			},
 		}
 
 		updatedSetIds := []string{"a1", "a3"}
 		updatedConfigurationSetIds := []client.ConfigurationSet{
 			{
-				Id: "a3",
+				Id:              "a3",
+				AssignmentScope: scope,
 			},
 			{
-				Id: "a1",
+				Id:              "a1",
+				AssignmentScope: scope,
 			},
 		}
 
@@ -97,10 +103,12 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 		setIds := []string{"a1"}
 		configurationSetIds := []client.ConfigurationSet{
 			{
-				Id: "a1",
+				Id:              "a1",
+				AssignmentScope: scope,
 			},
 			{
-				Id: "a2",
+				Id:              "a2",
+				AssignmentScope: scope,
 			},
 		}
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #888 
fixes #894 
fixes #895 

### Solution

1. Fixed conflicts between environment sets and non-environment sets.
2. Filter out scopes assigned implicitly.
3. Updated tests.
4. Updated documentation to warn about conflicts.