### PR TITLE
Chore: Change description of `variable_sets` field on environment_resource

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -84,7 +84,7 @@ Important note: the template must first be assigned to the same project as the e
 Important note: After the environment is created, this field cannot be modified.
 - `terragrunt_working_directory` (String) The working directory path to be used by a Terragrunt template. If left empty '/' is used. Note: modifying this field destroys the current environment and creates a new one
 - `ttl` (String) the date the environment should be destroyed at (iso format). omitting this attribute will result in infinite ttl.
-- `variable_sets` (List of String) a list of variable set to assign to this environment. Note: must not be used with 'env0_variable_set_assignment'
+- `variable_sets` (List of String) a list of IDs of variable sets to assign to this environment. Note: must not be used with 'env0_variable_set_assignment'
 - `vcs_commands_alias` (String) set an alias for this environment in favor of running VCS commands using PR comments against it. Additional details: https://docs.env0.com/docs/plan-and-apply-from-pr-comments
 - `vcs_pr_comments_enabled` (Boolean) set to 'true' to enable running VCS PR plan/apply commands using PR comments. This can be set to 'true' (enabled) without setting alias in 'vcs_commands_alias'. Additional details: https://docs.env0.com/docs/plan-and-apply-from-pr-comments#configuration
 - `without_template_settings` (Block List, Max: 1) settings for creating an environment without a template (see [below for nested schema](#nestedblock--without_template_settings))

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -362,7 +362,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"variable_sets": {
 				Type:        schema.TypeList,
-				Description: "a list of variable set to assign to this environment. Note: must not be used with 'env0_variable_set_assignment'",
+				Description: "a list of IDs of variable sets to assign to this environment. Note: must not be used with 'env0_variable_set_assignment'",
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type:        schema.TypeString,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Right now the description of variable_sets` of the environment resource is unclear, and does not mention that this should contain the IDs of the variable sets

### Solution
Adapt the description
