### PR TITLE
Fix: Drift Notification for Variable Sets (due to ordering) in env0_e…

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -446,7 +446,34 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 	setEnvironmentConfigurationSchema(ctx, d, configurationVariables)
 
 	if d.Get("variable_sets") != nil {
-		if err := d.Set("variable_sets", variableSetsIds); err != nil {
+		// To avoid drifts keep the schema order as much as possible.
+		variableSetsFromSchema := getEnvironmentVariableSetIdsFromSchema(d)
+		sortedVariablesSet := []string{}
+
+		for _, schemav := range variableSetsFromSchema {
+			for _, newv := range variableSetsIds {
+				if schemav == newv {
+					sortedVariablesSet = append(sortedVariablesSet, schemav)
+					break
+				}
+			}
+		}
+
+		for _, newv := range variableSetsIds {
+			found := false
+			for _, sortedv := range sortedVariablesSet {
+				if newv == sortedv {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				sortedVariablesSet = append(sortedVariablesSet, newv)
+			}
+		}
+
+		if err := d.Set("variable_sets", sortedVariablesSet); err != nil {
 			return fmt.Errorf("failed to set variable_sets value: %w", err)
 		}
 	}

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -372,6 +372,18 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 			updatedConfigurationSets := []client.ConfigurationSet{
 				{
+					Id:              "id2",
+					AssignmentScope: "ENVIRONMENT",
+				},
+				{
+					Id:              "id3",
+					AssignmentScope: "ENVIRONMENT",
+				},
+			}
+
+			// Same as updatedConfigurationSets, but in a different order.
+			updatedConfigurationSets2 := []client.ConfigurationSet{
+				{
 					Id:              "id3",
 					AssignmentScope: "ENVIRONMENT",
 				},
@@ -398,7 +410,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			environmentDeployRequest := client.DeployRequest{
 				BlueprintId: environment.LatestDeploymentLog.BlueprintId,
 				ConfigurationSetChanges: &client.ConfigurationSetChanges{
-					Assign:   []string{updatedConfigurationSets[0].Id},
+					Assign:   []string{updatedConfigurationSets[1].Id},
 					Unassign: []string{configurationSets[0].Id},
 				},
 			}
@@ -465,7 +477,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 					mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
 					mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
-					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(updatedConfigurationSets, nil),
+					mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(updatedConfigurationSets2, nil),
 
 					mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 				)


### PR DESCRIPTION
…nvironment

### Issue & Steps to Reproduce / Feature Request
fixes #908 

### Solution

1. Updated to code to maintain schema order as much as possible.
2. Update the acceptance tests to cover this use-case.
