### PR TITLE
Feat: add support for 'move environment' backend

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -71,6 +71,7 @@ type ApiClientInterface interface {
 	EnvironmentUpdate(id string, payload EnvironmentUpdate) (Environment, error)
 	EnvironmentDeploy(id string, payload DeployRequest) (EnvironmentDeployResponse, error)
 	EnvironmentUpdateTTL(id string, payload TTL) (Environment, error)
+	EnvironmentMove(id string, projectId string) error
 	EnvironmentScheduling(environmentId string) (EnvironmentScheduling, error)
 	EnvironmentSchedulingUpdate(environmentId string, payload EnvironmentScheduling) (EnvironmentScheduling, error)
 	EnvironmentSchedulingDelete(environmentId string) error

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -896,6 +896,20 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentMarkAsArchived(arg0 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentMarkAsArchived", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentMarkAsArchived), arg0)
 }
 
+// EnvironmentMove mocks base method.
+func (m *MockApiClientInterface) EnvironmentMove(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentMove", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnvironmentMove indicates an expected call of EnvironmentMove.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentMove(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentMove", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentMove), arg0, arg1)
+}
+
 // EnvironmentScheduling mocks base method.
 func (m *MockApiClientInterface) EnvironmentScheduling(arg0 string) (EnvironmentScheduling, error) {
 	m.ctrl.T.Helper()

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -279,13 +279,15 @@ var _ = Describe("Environment Client", func() {
 	})
 
 	Describe("EnvironmentDelete", func() {
+		var err error
+
 		BeforeEach(func() {
-			httpCall = mockHttpClient.EXPECT().Post("/environments/"+mockEnvironment.Id+"/destroy", nil, gomock.Any())
-			apiClient.EnvironmentDestroy(mockEnvironment.Id)
+			httpCall = mockHttpClient.EXPECT().Post("/environments/"+mockEnvironment.Id+"/destroy", nil, gomock.Any()).Times(1)
+			_, err = apiClient.EnvironmentDestroy(mockEnvironment.Id)
 		})
 
-		It("Should send a destroy request", func() {
-			httpCall.Times(1)
+		It("Should not return error", func() {
+			Expect(err).To(BeNil())
 		})
 	})
 
@@ -414,6 +416,26 @@ var _ = Describe("Environment Client", func() {
 			It("Should return the deployment id received from API", func() {
 				Expect(updatedEnvironment).To(Equal(mockEnvironment))
 			})
+		})
+	})
+
+	Describe("Environment Move", func() {
+		var err error
+
+		environmentId := "envid"
+		projectId := "projid"
+
+		request := EnvironmentMoveRequest{
+			ProjectId: projectId,
+		}
+
+		BeforeEach(func() {
+			httpCall = mockHttpClient.EXPECT().Post("/environments/"+environmentId+"/move", &request, nil).Times(1)
+			err = apiClient.EnvironmentMove(environmentId, projectId)
+		})
+
+		It("Should not return an error", func() {
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -167,7 +167,6 @@ func resourceEnvironment() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "project id of the environment",
 				Required:    true,
-				ForceNew:    true,
 			},
 			"template_id": {
 				Type:         schema.TypeString,
@@ -717,6 +716,13 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(client.ApiClientInterface)
+
+	if d.HasChange("project_id") {
+		newProjectId := d.Get("project_id").(string)
+		if err := apiClient.EnvironmentMove(d.Id(), newProjectId); err != nil {
+			return diag.Errorf("failed to move environment to project id '%s': %s", newProjectId, err)
+		}
+	}
 
 	if shouldUpdate(d) {
 		if err := update(d, apiClient); err != nil {
@@ -1274,7 +1280,7 @@ func typeEqual(variable client.ConfigurationVariable, search client.Configuratio
 }
 
 func getConfigurationVariableFromSchema(variable map[string]interface{}) client.ConfigurationVariable {
-	varType := client.VariableTypes[variable["type"].(string)]
+	varType, _ := client.GetConfigurationVariableType(variable["type"].(string))
 
 	configurationVariable := client.ConfigurationVariable{
 		Name:  variable["name"].(string),

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -11,6 +11,11 @@ resource "env0_project" "test_project" {
   force_destroy = true
 }
 
+resource "env0_project" "test_project2" {
+  name          = "Test-Project2-for-environment-${random_string.random.result}"
+  force_destroy = true
+}
+
 data "env0_template" "github_template_for_environment" {
   name = "Github Integrated Template"
 }
@@ -29,6 +34,11 @@ resource "env0_template_project_assignment" "assignment" {
   project_id  = env0_project.test_project.id
 }
 
+resource "env0_template_project_assignment" "assignment2" {
+  template_id = env0_template.template.id
+  project_id  = env0_project.test_project2.id
+}
+
 resource "env0_environment" "auto_glob_envrironment" {
   depends_on                       = [env0_template_project_assignment.assignment]
   name                             = "environment-auto-glob-${random_string.random.result}"
@@ -41,11 +51,11 @@ resource "env0_environment" "auto_glob_envrironment" {
   force_destroy                    = true
 }
 
-resource "env0_environment" "example" {
+resource "env0_environment" "environment" {
   depends_on    = [env0_template_project_assignment.assignment]
   force_destroy = true
   name          = "environment-${random_string.random.result}"
-  project_id    = env0_project.test_project.id
+  project_id    = var.second_run  ? env0_project.test_project2.id : env0_project.test_project.id
   template_id   = env0_template.template.id
   configuration {
     name  = "environment configuration variable"

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -51,7 +51,7 @@ resource "env0_environment" "auto_glob_envrironment" {
   force_destroy                    = true
 }
 
-resource "env0_environment" "environment" {
+resource "env0_environment" "example" {
   depends_on    = [env0_template_project_assignment.assignment]
   force_destroy = true
   name          = "environment-${random_string.random.result}"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #938 

### Solution

1. Added a new API call for moving environments.
2. Added a unit test for the new API call.
3. Removed 'forceNew' from 'project_id' in the environment schema.
4. On environment update, if project_id is updated, call the move API.
5. Added an acceptance tests.
6. Updated harness tests.