### PR TITLE
Feat: stop requiring gitlab_project_id for gitlab templates

### DIFF
--- a/client/environment_discovery.go
+++ b/client/environment_discovery.go
@@ -12,7 +12,6 @@ type EnvironmentDiscoveryPutPayload struct {
 	TerragruntTfBinary     string           `json:"terragruntTfBinary,omitempty"`
 	IsTerragruntRunAll     bool             `json:"is_terragrunt_run_all"`
 	Type                   string           `json:"type"`
-	GitlabProjectId        int              `json:"gitlabProjectId,omitempty"`
 	TokenId                string           `json:"tokenId,omitempty"`
 	SshKeys                []TemplateSshKey `json:"sshKeys,omitempty"`
 	GithubInstallationId   int              `json:"githubInstallationId,omitempty"`
@@ -35,7 +34,6 @@ type EnvironmentDiscoveryPayload struct {
 	TerragruntTfBinary     string           `json:"terragruntTfBinary" tfschema:",omitempty"`
 	IsTerragruntRunAll     bool             `json:"is_terragrunt_run_all"`
 	Type                   string           `json:"type"`
-	GitlabProjectId        int              `json:"gitlabProjectId"`
 	TokenId                string           `json:"tokenId"`
 	SshKeys                []TemplateSshKey `json:"sshKeys" tfschema:"-"`
 	GithubInstallationId   int              `json:"githubInstallationId"`

--- a/client/template.go
+++ b/client/template.go
@@ -15,6 +15,8 @@ import (
 
 const TERRAGRUNT = "terragrunt"
 const OPENTOFU = "opentofu"
+const TERRAFORM = "terraform"
+const WORKFLOW = "workflow"
 
 type TemplateRetryOn struct {
 	Times      int    `json:"times,omitempty"`
@@ -67,7 +69,6 @@ type Template struct {
 	IsGitlab             bool             `json:"isGitLab"`
 	TerragruntTfBinary   string           `json:"terragruntTfBinary" tfschema:",omitempty"`
 	TokenName            string           `json:"tokenName" tfschema:",omitempty"`
-	GitlabProjectId      int              `json:"gitlabProjectId" tfschema:",omitempty"`
 	AnsibleVersion       string           `json:"ansibleVersion" tfschema:",omitempty"`
 }
 
@@ -83,7 +84,6 @@ type TemplateCreatePayload struct {
 	TokenName            string           `json:"tokenName,omitempty"`
 	TokenId              string           `json:"tokenId,omitempty"`
 	GithubInstallationId int              `json:"githubInstallationId,omitempty"`
-	GitlabProjectId      int              `json:"gitlabProjectId,omitempty"`
 	Revision             string           `json:"revision"`
 	OrganizationId       string           `json:"organizationId"`
 	TerraformVersion     string           `json:"terraformVersion,omitempty"`

--- a/env0/configuration_template.go
+++ b/env0/configuration_template.go
@@ -26,7 +26,7 @@ func getConfigurationTemplateSchema(templateType TemplateType) map[string]*schem
 	s := map[string]*schema.Schema{
 		"id": {
 			Type:        schema.TypeString,
-			Description: fmt.Sprintf("id of the %s", text),
+			Description: "id of the " + text,
 			Computed:    true,
 		},
 		"repository": {
@@ -59,10 +59,10 @@ func getConfigurationTemplateSchema(templateType TemplateType) map[string]*schem
 			},
 		},
 		"gitlab_project_id": {
-			Type:         schema.TypeInt,
-			Description:  "the project id of the relevant repository",
-			Optional:     true,
-			RequiredWith: []string{"token_id"},
+			Type:        schema.TypeInt,
+			Description: "the project id of the relevant repository (deprecated)",
+			Deprecated:  "'repository' is used instead",
+			Optional:    true,
 		},
 		"github_installation_id": {
 			Type:        schema.TypeInt,
@@ -106,7 +106,7 @@ func getConfigurationTemplateSchema(templateType TemplateType) map[string]*schem
 		},
 		"name": {
 			Type:        schema.TypeString,
-			Description: fmt.Sprintf("name for the %s", text),
+			Description: "name for the " + text,
 			Required:    true,
 		},
 	}

--- a/env0/resource_environment_discovery_configuration.go
+++ b/env0/resource_environment_discovery_configuration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -42,8 +41,8 @@ func resourceEnvironmentDiscoveryConfiguration() *schema.Resource {
 			"type": {
 				Type:             schema.TypeString,
 				Description:      "the infrastructure type use. Valid values: 'opentofu', 'terraform', 'terragrunt', 'workflow' (default: 'opentofu')",
-				Default:          "opentofu",
-				ValidateDiagFunc: NewStringInValidator([]string{"opentofu", "terraform", "terragrunt", "workflow"}),
+				Default:          client.OPENTOFU,
+				ValidateDiagFunc: NewStringInValidator([]string{client.OPENTOFU, client.TERRAFORM, client.TERRAGRUNT, client.WORKFLOW}),
 				Optional:         true,
 			},
 			"environment_placement": {
@@ -87,8 +86,8 @@ func resourceEnvironmentDiscoveryConfiguration() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Description:      "The binary to use with Terragrunt. Valid values: 'opentofu' and 'terraform' (default: 'opentofu')",
-				ValidateDiagFunc: NewStringInValidator([]string{"opentofu", "terraform"}),
-				Default:          "opentofu",
+				ValidateDiagFunc: NewStringInValidator([]string{client.OPENTOFU, client.TERRAFORM}),
+				Default:          client.OPENTOFU,
 			},
 			"is_terragrunt_run_all": {
 				Type:        schema.TypeBool,
@@ -143,10 +142,10 @@ func resourceEnvironmentDiscoveryConfiguration() *schema.Resource {
 				Optional:    true,
 			},
 			"gitlab_project_id": {
-				Type:         schema.TypeInt,
-				Description:  "gitlab project id",
-				Optional:     true,
-				RequiredWith: []string{"token_id"},
+				Type:        schema.TypeInt,
+				Description: "gitlab project id (deprecated)",
+				Optional:    true,
+				Deprecated:  "'repository' is used instead",
 			},
 			"is_azure_devops": {
 				Type:         schema.TypeBool,
@@ -197,60 +196,29 @@ func discoveryValidatePutPayload(putPayload *client.EnvironmentDiscoveryPutPaylo
 	terragruntVersionSet := putPayload.TerragruntVersion != ""
 
 	switch putPayload.Type {
-	case "opentofu":
+	case client.OPENTOFU:
 		if !opentofuVersionSet {
 			return errors.New("'opentofu_version' not set")
 		}
-	case "terraform":
+	case client.TERRAFORM:
 		if !terraformVersionSet {
 			return errors.New("'terraform_version' not set")
 		}
-	case "terragrunt":
+	case client.TERRAGRUNT:
 		if !terragruntVersionSet {
 			return errors.New("'terragrunt_version' not set")
 		}
 
-		if putPayload.TerragruntTfBinary == "opentofu" && !opentofuVersionSet {
+		if putPayload.TerragruntTfBinary == client.OPENTOFU && !opentofuVersionSet {
 			return errors.New("'terragrunt_tf_binary' is set to 'opentofu', but 'opentofu_version' not set")
 		}
 
-		if putPayload.TerragruntTfBinary == "terraform" && !terraformVersionSet {
+		if putPayload.TerragruntTfBinary == client.TERRAFORM && !terraformVersionSet {
 			return errors.New("'terragrunt_tf_binary' is set to 'terraform', but 'terraform_version' not set")
 		}
-	case "workflow":
+	case client.WORKFLOW:
 	default:
 		return fmt.Errorf("unhandled type %s", putPayload.Type)
-	}
-
-	vcsCounter := 0
-	vcsEnabledAttributes := []string{}
-
-	if putPayload.GithubInstallationId != 0 {
-		vcsCounter++
-		vcsEnabledAttributes = append(vcsEnabledAttributes, "github_installation_id")
-	}
-
-	if putPayload.BitbucketClientKey != "" {
-		vcsCounter++
-		vcsEnabledAttributes = append(vcsEnabledAttributes, "bitbucket_client_key")
-	}
-
-	if putPayload.GitlabProjectId != 0 {
-		vcsCounter++
-		vcsEnabledAttributes = append(vcsEnabledAttributes, "gitlab_project_id")
-	}
-
-	if putPayload.IsAzureDevops {
-		vcsCounter++
-		vcsEnabledAttributes = append(vcsEnabledAttributes, "is_azure_devops")
-	}
-
-	if vcsCounter == 0 {
-		return errors.New("must set exactly one vcs, none were configured: github_installation_id, bitbucket_client_key, gitlab_project_id, or is_azure_devops")
-	}
-
-	if vcsCounter > 1 {
-		return fmt.Errorf("must set exactly one vcs, but more were configured: %s", strings.Join(vcsEnabledAttributes, ", "))
 	}
 
 	return nil
@@ -273,7 +241,7 @@ func resourceEnvironmentDiscoveryConfigurationPut(ctx context.Context, d *schema
 		return diag.Errorf("validation error: %s", err.Error())
 	}
 
-	if putPayload.Type != "terragrunt" {
+	if putPayload.Type != client.TERRAGRUNT {
 		// Remove the default terragrunt_tf_binary if terragrunt isn't used.
 		putPayload.TerragruntTfBinary = ""
 	}
@@ -347,7 +315,7 @@ func resourceEnvironmentDiscoveryConfigurationImport(ctx context.Context, d *sch
 	d.Set("project_id", projectId)
 
 	if _, ok := d.GetOk("terragrunt_tf_binary"); !ok {
-		d.Set("terragrunt_tf_binary", "opentofu")
+		d.Set("terragrunt_tf_binary", client.OPENTOFU)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_environment_discovery_configuration_test.go
+++ b/env0/resource_environment_discovery_configuration_test.go
@@ -312,7 +312,6 @@ func TestUnitEnvironmentDiscoveryConfigurationResource(t *testing.T) {
 			TerraformVersion:     "1.7.8",
 			EnvironmentPlacement: "topProject",
 			WorkspaceNaming:      "default",
-			GitlabProjectId:      12345,
 			TokenId:              "abcdefg",
 		}
 
@@ -324,7 +323,6 @@ func TestUnitEnvironmentDiscoveryConfigurationResource(t *testing.T) {
 			TerraformVersion:     putPayload.TerraformVersion,
 			EnvironmentPlacement: putPayload.EnvironmentPlacement,
 			WorkspaceNaming:      putPayload.WorkspaceNaming,
-			GitlabProjectId:      putPayload.GitlabProjectId,
 			TokenId:              putPayload.TokenId,
 		}
 
@@ -336,7 +334,6 @@ func TestUnitEnvironmentDiscoveryConfigurationResource(t *testing.T) {
 						"type":              putPayload.Type,
 						"glob_pattern":      putPayload.GlobPattern,
 						"repository":        putPayload.Repository,
-						"gitlab_project_id": putPayload.GitlabProjectId,
 						"token_id":          putPayload.TokenId,
 						"terraform_version": putPayload.TerraformVersion,
 					}),
@@ -347,7 +344,6 @@ func TestUnitEnvironmentDiscoveryConfigurationResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "type", putPayload.Type),
 						resource.TestCheckResourceAttr(accessor, "environment_placement", putPayload.EnvironmentPlacement),
 						resource.TestCheckResourceAttr(accessor, "workspace_naming", putPayload.WorkspaceNaming),
-						resource.TestCheckResourceAttr(accessor, "gitlab_project_id", strconv.Itoa(putPayload.GitlabProjectId)),
 						resource.TestCheckResourceAttr(accessor, "token_id", putPayload.TokenId),
 						resource.TestCheckResourceAttr(accessor, "terraform_version", putPayload.TerraformVersion),
 					),
@@ -704,45 +700,6 @@ func TestUnitEnvironmentDiscoveryConfigurationResource(t *testing.T) {
 						"terragrunt_tf_binary":   "terraform",
 					}),
 					ExpectError: regexp.MustCompile("'terragrunt_tf_binary' is set to 'terraform', but 'terraform_version' not set"),
-				},
-			},
-		}
-
-		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
-	})
-
-	t.Run("error: no vcs set", func(t *testing.T) {
-		testCase := resource.TestCase{
-			Steps: []resource.TestStep{
-				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"project_id":   projectId,
-						"glob_pattern": "**",
-						"repository":   "https://re.po",
-						"type":         "workflow",
-					}),
-					ExpectError: regexp.MustCompile("must set exactly one vcs, none were configured"),
-				},
-			},
-		}
-
-		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
-	})
-
-	t.Run("error: more than one vcs set", func(t *testing.T) {
-		testCase := resource.TestCase{
-			Steps: []resource.TestStep{
-				{
-					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"project_id":             projectId,
-						"glob_pattern":           "**",
-						"repository":             "https://re.po",
-						"type":                   "workflow",
-						"github_installation_id": 1234,
-						"gitlab_project_id":      5678,
-						"token_id":               "1345",
-					}),
-					ExpectError: regexp.MustCompile("must set exactly one vcs, but more were configured: github_installation_id, gitlab_project_id"),
 				},
 			},
 		}

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -16,7 +16,6 @@ import (
 func getTemplateSchema(prefix string) map[string]*schema.Schema {
 	var allVCSAttributes = []string{
 		"token_id",
-		"gitlab_project_id",
 		"github_installation_id",
 		"bitbucket_client_key",
 		"is_gitlab_enterprise",
@@ -29,14 +28,14 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 	}
 
 	var allowedTemplateTypes = []string{
-		"terraform",
-		"terragrunt",
+		client.TERRAFORM,
+		client.TERRAGRUNT,
 		"pulumi",
 		"k8s",
-		"workflow",
+		client.WORKFLOW,
 		"cloudformation",
 		"helm",
-		"opentofu",
+		client.OPENTOFU,
 		"ansible",
 	}
 
@@ -56,6 +55,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 				if prefix != "" {
 					attr = prefix + attr
 				}
+
 				butAttrs = append(butAttrs, attr)
 			}
 		}
@@ -70,6 +70,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 			if prefix != "" {
 				str = prefix + str
 			}
+
 			ret = append(ret, str)
 		}
 
@@ -101,7 +102,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Description:      fmt.Sprintf("template type (allowed values: %s)", strings.Join(allowedTemplateTypes, ", ")),
 			Optional:         true,
-			Default:          "terraform",
+			Default:          client.TERRAFORM,
 			ValidateDiagFunc: NewStringInValidator(allowedTemplateTypes),
 		},
 		"revision": {
@@ -152,14 +153,13 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 			Type:          schema.TypeString,
 			Description:   "the git token id to be used",
 			Optional:      true,
-			ConflictsWith: allVCSAttributesBut("token_id", "gitlab_project_id", "is_azure_devops", "path"),
+			ConflictsWith: allVCSAttributesBut("token_id", "is_azure_devops", "path"),
 		},
 		"gitlab_project_id": {
-			Type:          schema.TypeInt,
-			Description:   "the project id of the relevant repository",
-			Optional:      true,
-			ConflictsWith: allVCSAttributesBut("token_id", "gitlab_project_id", "path"),
-			RequiredWith:  requiredWith("token_id"),
+			Type:        schema.TypeInt,
+			Deprecated:  "'repository' is used instead",
+			Description: "the project id of the relevant repository (deprecated)",
+			Optional:    true,
 		},
 		"terraform_version": {
 			Type:             schema.TypeString,
@@ -214,7 +214,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 		"is_terragrunt_run_all": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: `true if this template should execute run-all commands on multiple modules (check https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command for additional details). Can only be true with "terragrunt" template type and terragrunt version 0.28.1 and above`,
+			Description: "true if this template should execute run-all commands on multiple modules (check https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above",
 			Default:     "false",
 		},
 		"is_azure_devops": {
@@ -243,7 +243,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Optional:         true,
 			Description:      "the binary to use if the template type is 'terragrunt'. Valid values 'opentofu' and 'terraform'. For new templates defaults to 'opentofu'",
-			ValidateDiagFunc: NewStringInValidator([]string{"opentofu", "terraform"}),
+			ValidateDiagFunc: NewStringInValidator([]string{client.OPENTOFU, client.TERRAFORM}),
 		},
 		"token_name": {
 			Type:        schema.TypeString,
@@ -411,8 +411,8 @@ func templateCreatePayloadFromParameters(prefix string, d *schema.ResourceData) 
 		// If the user has set a value - use it.
 		if terragruntTfBinary := d.Get(terragruntTfBinaryKey).(string); terragruntTfBinary != "" {
 			payload.TerragruntTfBinary = terragruntTfBinary
-		} else if templateType.(string) == "terragrunt" && isNew {
-			payload.TerragruntTfBinary = "opentofu"
+		} else if templateType.(string) == client.TERRAGRUNT && isNew {
+			payload.TerragruntTfBinary = client.OPENTOFU
 		}
 	}
 
@@ -420,7 +420,7 @@ func templateCreatePayloadFromParameters(prefix string, d *schema.ResourceData) 
 	templateCreatePayloadRetryOnHelper(prefix, d, "destroy", &payload.Retry.OnDestroy)
 
 	if err := payload.Invalidate(); err != nil {
-		return payload, diag.Errorf(err.Error())
+		return payload, diag.FromErr(err)
 	}
 
 	return payload, nil

--- a/env0/resource_template_test.go
+++ b/env0/resource_template_test.go
@@ -85,7 +85,6 @@ func TestUnitTemplateResource(t *testing.T) {
 		TokenId:          "1",
 		TerraformVersion: "0.12.24",
 		TokenName:        "token_name",
-		GitlabProjectId:  1234,
 		IsGitlab:         true,
 	}
 	gitlabUpdatedTemplate := client.Template{
@@ -110,7 +109,6 @@ func TestUnitTemplateResource(t *testing.T) {
 		TokenId:           "2",
 		TerraformVersion:  "0.15.1",
 		TokenName:         "token_name2",
-		GitlabProjectId:   5678,
 	}
 	githubTemplate := client.Template{
 		Id:          "id0",
@@ -530,9 +528,6 @@ func TestUnitTemplateResource(t *testing.T) {
 		if template.TokenName != "" {
 			templateAsDictionary["token_name"] = template.TokenName
 		}
-		if template.GitlabProjectId != 0 {
-			templateAsDictionary["gitlab_project_id"] = template.GitlabProjectId
-		}
 		if template.GithubInstallationId != 0 {
 			templateAsDictionary["github_installation_id"] = template.GithubInstallationId
 		}
@@ -576,11 +571,6 @@ func TestUnitTemplateResource(t *testing.T) {
 		return resourceConfigCreate(resourceType, resourceName, templateAsDictionary)
 	}
 	fullTemplateResourceCheck := func(resourceFullName string, template client.Template) resource.TestCheckFunc {
-		gitlabProjectIdAssertion := resource.TestCheckResourceAttr(resourceFullName, "gitlab_project_id", strconv.Itoa(template.GitlabProjectId))
-		if template.GitlabProjectId == 0 {
-			gitlabProjectIdAssertion = resource.TestCheckNoResourceAttr(resourceFullName, "gitlab_project_id")
-		}
-
 		tokenIdAssertion := resource.TestCheckResourceAttr(resourceFullName, "token_id", template.TokenId)
 		if template.TokenId == "" {
 			tokenIdAssertion = resource.TestCheckNoResourceAttr(resourceFullName, "token_id")
@@ -644,7 +634,6 @@ func TestUnitTemplateResource(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceFullName, "is_gitlab_enterprise", strconv.FormatBool(template.IsGitlabEnterprise)),
 			tokenIdAssertion,
 			filenameAssertion,
-			gitlabProjectIdAssertion,
 			terragruntVersionAssertion,
 			githubInstallationIdAssertion,
 			helmChartNameAssertion,
@@ -686,7 +675,6 @@ func TestUnitTemplateResource(t *testing.T) {
 				GithubInstallationId: templateUseCase.template.GithubInstallationId,
 				IsGitlabEnterprise:   templateUseCase.template.IsGitlabEnterprise,
 				IsGitlab:             templateUseCase.template.IsGitlab,
-				GitlabProjectId:      templateUseCase.template.GitlabProjectId,
 				TokenId:              templateUseCase.template.TokenId,
 				Path:                 templateUseCase.template.Path,
 				Revision:             templateUseCase.template.Revision,
@@ -714,25 +702,25 @@ func TestUnitTemplateResource(t *testing.T) {
 				GithubInstallationId: templateUseCase.updatedTemplate.GithubInstallationId,
 				IsGitlabEnterprise:   templateUseCase.updatedTemplate.IsGitlabEnterprise,
 				IsGitlab:             templateUseCase.updatedTemplate.IsGitlab,
-				GitlabProjectId:      templateUseCase.updatedTemplate.GitlabProjectId,
-				TokenId:              templateUseCase.updatedTemplate.TokenId,
-				Path:                 templateUseCase.updatedTemplate.Path,
-				Revision:             templateUseCase.updatedTemplate.Revision,
-				Type:                 templateUseCase.updatedTemplate.Type,
-				Retry:                templateUseCase.updatedTemplate.Retry,
-				TerraformVersion:     templateUseCase.updatedTemplate.TerraformVersion,
-				BitbucketClientKey:   templateUseCase.updatedTemplate.BitbucketClientKey,
-				IsGithubEnterprise:   templateUseCase.updatedTemplate.IsGithubEnterprise,
-				IsBitbucketServer:    templateUseCase.updatedTemplate.IsBitbucketServer,
-				FileName:             templateUseCase.updatedTemplate.FileName,
-				TerragruntVersion:    templateUseCase.updatedTemplate.TerragruntVersion,
-				IsTerragruntRunAll:   templateUseCase.updatedTemplate.IsTerragruntRunAll,
-				IsAzureDevOps:        templateUseCase.updatedTemplate.IsAzureDevOps,
-				IsHelmRepository:     templateUseCase.updatedTemplate.IsHelmRepository,
-				HelmChartName:        templateUseCase.updatedTemplate.HelmChartName,
-				OpentofuVersion:      templateUseCase.updatedTemplate.OpentofuVersion,
-				TokenName:            templateUseCase.updatedTemplate.TokenName,
-				AnsibleVersion:       templateUseCase.updatedTemplate.AnsibleVersion,
+
+				TokenId:            templateUseCase.updatedTemplate.TokenId,
+				Path:               templateUseCase.updatedTemplate.Path,
+				Revision:           templateUseCase.updatedTemplate.Revision,
+				Type:               templateUseCase.updatedTemplate.Type,
+				Retry:              templateUseCase.updatedTemplate.Retry,
+				TerraformVersion:   templateUseCase.updatedTemplate.TerraformVersion,
+				BitbucketClientKey: templateUseCase.updatedTemplate.BitbucketClientKey,
+				IsGithubEnterprise: templateUseCase.updatedTemplate.IsGithubEnterprise,
+				IsBitbucketServer:  templateUseCase.updatedTemplate.IsBitbucketServer,
+				FileName:           templateUseCase.updatedTemplate.FileName,
+				TerragruntVersion:  templateUseCase.updatedTemplate.TerragruntVersion,
+				IsTerragruntRunAll: templateUseCase.updatedTemplate.IsTerragruntRunAll,
+				IsAzureDevOps:      templateUseCase.updatedTemplate.IsAzureDevOps,
+				IsHelmRepository:   templateUseCase.updatedTemplate.IsHelmRepository,
+				HelmChartName:      templateUseCase.updatedTemplate.HelmChartName,
+				OpentofuVersion:    templateUseCase.updatedTemplate.OpentofuVersion,
+				TokenName:          templateUseCase.updatedTemplate.TokenName,
+				AnsibleVersion:     templateUseCase.updatedTemplate.AnsibleVersion,
 			}
 
 			if templateUseCase.template.Type == "terragrunt" {
@@ -1215,7 +1203,6 @@ func TestUnitTemplateResource(t *testing.T) {
 						"name":              "template0",
 						"repository":        "env0/repo",
 						"type":              "terraform",
-						"gitlab_project_id": 123456,
 						"token_id":          "abcdefg",
 						"terraform_version": "v0.15.1",
 					}),
@@ -1232,12 +1219,11 @@ func TestUnitTemplateResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":              "template0",
-						"repository":        "env0/repo",
-						"type":              "opentofu",
-						"gitlab_project_id": 123456,
-						"token_id":          "abcdefg",
-						"opentofu_version":  "v0.20.1",
+						"name":             "template0",
+						"repository":       "env0/repo",
+						"type":             "opentofu",
+						"token_id":         "abcdefg",
+						"opentofu_version": "v0.20.1",
 					}),
 					ExpectError: regexp.MustCompile("must match pattern"),
 				},
@@ -1252,11 +1238,10 @@ func TestUnitTemplateResource(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
-						"name":              "template0",
-						"repository":        "env0/repo",
-						"type":              "opentofu",
-						"gitlab_project_id": 123456,
-						"token_id":          "abcdefg",
+						"name":       "template0",
+						"repository": "env0/repo",
+						"type":       "opentofu",
+						"token_id":   "abcdefg",
 					}),
 					ExpectError: regexp.MustCompile("must supply opentofu version"),
 				},

--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -41,7 +41,6 @@ resource "env0_template" "gitlab_template" {
   type                                    = "terraform"
   repository                              = data.env0_template.gitlab_template.repository
   token_id                                = data.env0_template.gitlab_template.token_id
-  gitlab_project_id                       = 32315446
   path                                    = var.second_run ? "second" : "misc/null-resource"
   retries_on_deploy                       = 3
   retry_on_deploy_only_when_matches_regex = "abc"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #940 

### Solution

1. Deprecate the field in all relevant schemas.
2. Updated code.
3. Update tests.
4. Update structs.