### PR TITLE
Chore: move env test is flaky - use never deployed env

### DIFF
--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -40,7 +40,7 @@ resource "env0_template_project_assignment" "assignment2" {
 }
 
 resource "env0_environment" "auto_glob_envrironment" {
-  depends_on                       = [env0_template_project_assignment.assignment]
+  depends_on = [env0_template_project_assignment.assignment]
   name                             = "environment-auto-glob-${random_string.random.result}"
   project_id                       = env0_project.test_project.id
   template_id                      = env0_template.template.id
@@ -52,10 +52,10 @@ resource "env0_environment" "auto_glob_envrironment" {
 }
 
 resource "env0_environment" "example" {
-  depends_on    = [env0_template_project_assignment.assignment]
+  depends_on = [env0_template_project_assignment.assignment]
   force_destroy = true
   name          = "environment-${random_string.random.result}"
-  project_id    = var.second_run  ? env0_project.test_project2.id : env0_project.test_project.id
+  project_id    = env0_project.test_project.id
   template_id   = env0_template.template.id
   configuration {
     name  = "environment configuration variable"
@@ -65,6 +65,15 @@ resource "env0_environment" "example" {
   revision                   = "master"
   vcs_commands_alias         = "alias"
   drift_detection_cron       = var.second_run ? "*/5 * * * *" : "*/10 * * * *"
+}
+
+resource "env0_environment" "move_environment" {
+  depends_on = [env0_template_project_assignment.assignment]
+  force_destroy       = true
+  name                = "environment-move-${random_string.random.result}"
+  project_id          = var.second_run ? env0_project.test_project2.id : env0_project.test_project.id
+  template_id         = env0_template.template.id
+  prevent_auto_deploy = true
 }
 
 resource "env0_custom_role" "custom_role1" {
@@ -126,7 +135,7 @@ resource "env0_template_project_assignment" "terragrunt_assignment" {
 }
 
 resource "env0_environment" "terragrunt_environment" {
-  depends_on                       = [env0_template_project_assignment.terragrunt_assignment]
+  depends_on = [env0_template_project_assignment.terragrunt_assignment]
   force_destroy                    = true
   name                             = "environment-${random_string.random.result}"
   project_id                       = env0_project.test_project.id
@@ -175,7 +184,7 @@ resource "env0_environment" "environment-without-template" {
 }
 
 resource "env0_environment" "inactive" {
-  depends_on                 = [env0_template_project_assignment.assignment]
+  depends_on = [env0_template_project_assignment.assignment]
   force_destroy              = true
   name                       = "environment-${random_string.random.result}-inactive"
   project_id                 = env0_project.test_project.id
@@ -240,7 +249,10 @@ resource "env0_variable_set" "variable_set2" {
 }
 
 resource "env0_environment" "workflow-environment" {
-  depends_on                 = [env0_template_project_assignment.assignment_workflow, env0_template_project_assignment.assignment_sub_environment_null_template]
+  depends_on = [
+    env0_template_project_assignment.assignment_workflow,
+    env0_template_project_assignment.assignment_sub_environment_null_template
+  ]
   force_destroy              = true
   name                       = "environment-workflow-${random_string.random.result}"
   project_id                 = env0_project.test_project.id
@@ -270,7 +282,7 @@ resource "env0_environment" "workflow-environment" {
 }
 
 resource "env0_environment" "mark_as_archived" {
-  depends_on       = [env0_template_project_assignment.assignment]
+  depends_on = [env0_template_project_assignment.assignment]
   name             = "environment-mark-as-archived-${random_string.random.result}"
   project_id       = env0_project.test_project.id
   template_id      = env0_template.template.id

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -40,7 +40,7 @@ resource "env0_template_project_assignment" "assignment2" {
 }
 
 resource "env0_environment" "auto_glob_envrironment" {
-  depends_on = [env0_template_project_assignment.assignment]
+  depends_on                       = [env0_template_project_assignment.assignment]
   name                             = "environment-auto-glob-${random_string.random.result}"
   project_id                       = env0_project.test_project.id
   template_id                      = env0_template.template.id
@@ -52,7 +52,7 @@ resource "env0_environment" "auto_glob_envrironment" {
 }
 
 resource "env0_environment" "example" {
-  depends_on = [env0_template_project_assignment.assignment]
+  depends_on    = [env0_template_project_assignment.assignment]
   force_destroy = true
   name          = "environment-${random_string.random.result}"
   project_id    = env0_project.test_project.id
@@ -68,7 +68,7 @@ resource "env0_environment" "example" {
 }
 
 resource "env0_environment" "move_environment" {
-  depends_on = [env0_template_project_assignment.assignment]
+  depends_on          = [env0_template_project_assignment.assignment]
   force_destroy       = true
   name                = "environment-move-${random_string.random.result}"
   project_id          = var.second_run ? env0_project.test_project2.id : env0_project.test_project.id
@@ -135,7 +135,7 @@ resource "env0_template_project_assignment" "terragrunt_assignment" {
 }
 
 resource "env0_environment" "terragrunt_environment" {
-  depends_on = [env0_template_project_assignment.terragrunt_assignment]
+  depends_on                       = [env0_template_project_assignment.terragrunt_assignment]
   force_destroy                    = true
   name                             = "environment-${random_string.random.result}"
   project_id                       = env0_project.test_project.id
@@ -184,7 +184,7 @@ resource "env0_environment" "environment-without-template" {
 }
 
 resource "env0_environment" "inactive" {
-  depends_on = [env0_template_project_assignment.assignment]
+  depends_on                 = [env0_template_project_assignment.assignment]
   force_destroy              = true
   name                       = "environment-${random_string.random.result}-inactive"
   project_id                 = env0_project.test_project.id
@@ -282,7 +282,7 @@ resource "env0_environment" "workflow-environment" {
 }
 
 resource "env0_environment" "mark_as_archived" {
-  depends_on = [env0_template_project_assignment.assignment]
+  depends_on       = [env0_template_project_assignment.assignment]
   name             = "environment-mark-as-archived-${random_string.random.result}"
   project_id       = env0_project.test_project.id
   template_id      = env0_template.template.id


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
the test is flaky - often fails with 
```
│ Error: failed to move environment to project id 'e46ce3e9-79b5-4e4d-bba9-1d9b9f252155': 400 Bad Request: cannot move environment while in progress. id: 4cc847e7-c45d-4389-b49d-4e9bdf94f80a
```
(was added in https://github.com/env0/terraform-provider-env0/pull/939)

### Solution
use never deployed environment
