### PR TITLE
Feat: is_remote_apply_enabled not being sent to BE

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -29,7 +29,7 @@ func (c *ConfigurationVariableType) WriteResourceData(fieldName string, d *schem
 	case 0:
 		valStr = "environment"
 	case 1:
-		valStr = "terraform"
+		valStr = TERRAFORM
 	default:
 		return fmt.Errorf("unknown configuration variable type %d", val)
 	}
@@ -150,6 +150,7 @@ type EnvironmentCreate struct {
 	PreventAutoDeploy           *bool                    `json:"preventAutoDeploy,omitempty" tfschema:"-"`
 	K8sNamespace                string                   `json:"k8sNamespace,omitempty"`
 	ConfigurationSetChanges     *ConfigurationSetChanges `json:"configurationSetChanges,omitempty" tfschema:"-"`
+	IsRemoteApplyEnabled        bool                     `json:"isRemoteApplyEnabled"`
 }
 
 // When converted to JSON needs to be flattened. See custom MarshalJSON below.

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -342,7 +342,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"is_remote_apply_enabled": {
 				Type:        schema.TypeBool,
-				Description: "enables remote apply when set to true (defaults to false). Can only be enabled when is_remote_backend and approve_plan_automatically are enabled. Can only enabled for an existing environment",
+				Description: "enables remote apply when set to true (defaults to false). Can only be enabled when is_remote_backend and approve_plan_automatically are enabled",
 				Optional:    true,
 				Default:     false,
 			},

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -253,7 +253,6 @@ func getFieldName(field reflect.StructField) *parsedField {
 				res.omitEmpty = true
 			}
 		}
-
 	}
 
 	return &res


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #942 

### Solution

1. Added `isRemoteApplyEnabled` to the create structs.
2. Updated schema text.
3. Added a new test.
