### PR TITLE
Feat: add wait_for_destroy option when destroying and environment

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -66,7 +66,7 @@ type ApiClientInterface interface {
 	Environment(id string) (Environment, error)
 	EnvironmentCreate(payload EnvironmentCreate) (Environment, error)
 	EnvironmentCreateWithoutTemplate(payload EnvironmentCreateWithoutTemplate) (Environment, error)
-	EnvironmentDestroy(id string) (Environment, error)
+	EnvironmentDestroy(id string) (*EnvironmentDestroyResponse, error)
 	EnvironmentMarkAsArchived(id string) error
 	EnvironmentUpdate(id string, payload EnvironmentUpdate) (Environment, error)
 	EnvironmentDeploy(id string, payload DeployRequest) (EnvironmentDeployResponse, error)
@@ -75,6 +75,7 @@ type ApiClientInterface interface {
 	EnvironmentScheduling(environmentId string) (EnvironmentScheduling, error)
 	EnvironmentSchedulingUpdate(environmentId string, payload EnvironmentScheduling) (EnvironmentScheduling, error)
 	EnvironmentSchedulingDelete(environmentId string) error
+	EnvironmentDeployment(id string) (*DeploymentLog, error)
 	WorkflowTrigger(environmentId string) ([]WorkflowTrigger, error)
 	WorkflowTriggerUpsert(environmentId string, request WorkflowTriggerUpsertPayload) ([]WorkflowTrigger, error)
 	EnvironmentDriftDetection(environmentId string) (EnvironmentSchedulingExpression, error)

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -75,7 +75,7 @@ type ApiClientInterface interface {
 	EnvironmentScheduling(environmentId string) (EnvironmentScheduling, error)
 	EnvironmentSchedulingUpdate(environmentId string, payload EnvironmentScheduling) (EnvironmentScheduling, error)
 	EnvironmentSchedulingDelete(environmentId string) error
-	EnvironmentDeployment(id string) (*DeploymentLog, error)
+	EnvironmentDeploymentLog(id string) (*DeploymentLog, error)
 	WorkflowTrigger(environmentId string) ([]WorkflowTrigger, error)
 	WorkflowTriggerUpsert(environmentId string, request WorkflowTriggerUpsertPayload) ([]WorkflowTrigger, error)
 	EnvironmentDriftDetection(environmentId string) (EnvironmentSchedulingExpression, error)

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -852,11 +852,26 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDeploy(arg0, arg1 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDeploy", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDeploy), arg0, arg1)
 }
 
+// EnvironmentDeployment mocks base method.
+func (m *MockApiClientInterface) EnvironmentDeployment(arg0 string) (*DeploymentLog, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnvironmentDeployment", arg0)
+	ret0, _ := ret[0].(*DeploymentLog)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnvironmentDeployment indicates an expected call of EnvironmentDeployment.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDeployment(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDeployment", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDeployment), arg0)
+}
+
 // EnvironmentDestroy mocks base method.
-func (m *MockApiClientInterface) EnvironmentDestroy(arg0 string) (Environment, error) {
+func (m *MockApiClientInterface) EnvironmentDestroy(arg0 string) (*EnvironmentDestroyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnvironmentDestroy", arg0)
-	ret0, _ := ret[0].(Environment)
+	ret0, _ := ret[0].(*EnvironmentDestroyResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -852,19 +852,19 @@ func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDeploy(arg0, arg1 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDeploy", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDeploy), arg0, arg1)
 }
 
-// EnvironmentDeployment mocks base method.
-func (m *MockApiClientInterface) EnvironmentDeployment(arg0 string) (*DeploymentLog, error) {
+// EnvironmentDeploymentLog mocks base method.
+func (m *MockApiClientInterface) EnvironmentDeploymentLog(arg0 string) (*DeploymentLog, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnvironmentDeployment", arg0)
+	ret := m.ctrl.Call(m, "EnvironmentDeploymentLog", arg0)
 	ret0, _ := ret[0].(*DeploymentLog)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EnvironmentDeployment indicates an expected call of EnvironmentDeployment.
-func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDeployment(arg0 any) *gomock.Call {
+// EnvironmentDeploymentLog indicates an expected call of EnvironmentDeploymentLog.
+func (mr *MockApiClientInterfaceMockRecorder) EnvironmentDeploymentLog(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDeployment", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDeployment), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnvironmentDeploymentLog", reflect.TypeOf((*MockApiClientInterface)(nil).EnvironmentDeploymentLog), arg0)
 }
 
 // EnvironmentDestroy mocks base method.

--- a/client/environment.go
+++ b/client/environment.go
@@ -29,7 +29,7 @@ func (c *ConfigurationVariableType) WriteResourceData(fieldName string, d *schem
 
 	switch val := *c; val {
 	case 0:
-		valStr = "environment"
+		valStr = ENVIRONMENT
 	case 1:
 		valStr = TERRAFORM
 	default:
@@ -93,6 +93,7 @@ type DeploymentLog struct {
 	Output              json.RawMessage `json:"output,omitempty"`
 	Error               json.RawMessage `json:"error,omitempty"`
 	Type                string          `json:"type"`
+	Status              string          `json:"status"`
 	WorkflowFile        *WorkflowFile   `json:"workflowFile,omitempty" tfschema:"-"`
 }
 
@@ -163,6 +164,10 @@ type EnvironmentCreateWithoutTemplate struct {
 
 type EnvironmentMoveRequest struct {
 	ProjectId string `json:"projectId"`
+}
+
+type EnvironmentDestroyResponse struct {
+	Id string `json:"id"`
 }
 
 func GetConfigurationVariableType(variableType string) (ConfigurationVariableType, error) {
@@ -258,6 +263,15 @@ func (client *ApiClient) Environment(id string) (Environment, error) {
 	return result, nil
 }
 
+func (client *ApiClient) EnvironmentDeployment(id string) (*DeploymentLog, error) {
+	var result DeploymentLog
+	err := client.http.Get("/environments/deployments/"+id, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (client *ApiClient) EnvironmentCreate(payload EnvironmentCreate) (Environment, error) {
 	var result Environment
 
@@ -285,13 +299,13 @@ func (client *ApiClient) EnvironmentCreateWithoutTemplate(payload EnvironmentCre
 	return result, nil
 }
 
-func (client *ApiClient) EnvironmentDestroy(id string) (Environment, error) {
-	var result Environment
+func (client *ApiClient) EnvironmentDestroy(id string) (*EnvironmentDestroyResponse, error) {
+	var result EnvironmentDestroyResponse
 	err := client.http.Post("/environments/"+id+"/destroy", nil, &result)
 	if err != nil {
-		return Environment{}, err
+		return nil, err
 	}
-	return result, nil
+	return &result, nil
 }
 
 func (client *ApiClient) EnvironmentUpdate(id string, payload EnvironmentUpdate) (Environment, error) {

--- a/client/environment.go
+++ b/client/environment.go
@@ -263,7 +263,7 @@ func (client *ApiClient) Environment(id string) (Environment, error) {
 	return result, nil
 }
 
-func (client *ApiClient) EnvironmentDeployment(id string) (*DeploymentLog, error) {
+func (client *ApiClient) EnvironmentDeploymentLog(id string) (*DeploymentLog, error) {
 	var result DeploymentLog
 	err := client.http.Get("/environments/deployments/"+id, nil, &result)
 	if err != nil {

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -467,7 +467,7 @@ var _ = Describe("Environment Client", func() {
 					*response = mockDeployment
 				}).Times(1)
 
-			deployment, err = apiClient.EnvironmentDeployment(mockDeployment.Id)
+			deployment, err = apiClient.EnvironmentDeploymentLog(mockDeployment.Id)
 		})
 
 		It("Should return deployment", func() {

--- a/client/environment_test.go
+++ b/client/environment_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/env0/terraform-provider-env0/client"
 	. "github.com/env0/terraform-provider-env0/client"
 	"github.com/jinzhu/copier"
 	. "github.com/onsi/ginkgo"
@@ -281,9 +280,9 @@ var _ = Describe("Environment Client", func() {
 
 	Describe("EnvironmentDelete", func() {
 		var err error
-		var res *client.EnvironmentDestroyResponse
+		var res *EnvironmentDestroyResponse
 
-		mockedRes := client.EnvironmentDestroyResponse{
+		mockedRes := EnvironmentDestroyResponse{
 			Id: "id123",
 		}
 

--- a/env0/data_agent_values_test.go
+++ b/env0/data_agent_values_test.go
@@ -63,5 +63,4 @@ func TestAgentValues(t *testing.T) {
 			},
 		)
 	})
-
 }

--- a/env0/data_cloud_credentials.go
+++ b/env0/data_cloud_credentials.go
@@ -62,6 +62,7 @@ func dataCloudCredentialsRead(ctx context.Context, d *schema.ResourceData, meta 
 		if filter && credential_type != credentials.Type {
 			continue
 		}
+
 		data = append(data, credentials.Name)
 	}
 

--- a/env0/data_credentials_test.go
+++ b/env0/data_credentials_test.go
@@ -146,5 +146,4 @@ func TestCredentialsDataSource(t *testing.T) {
 			)
 		})
 	}
-
 }

--- a/env0/data_custom_flow.go
+++ b/env0/data_custom_flow.go
@@ -31,6 +31,7 @@ func dataCustomFlow() *schema.Resource {
 
 func dataCustomFlowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var err error
+
 	var customFlow *client.CustomFlow
 
 	id, ok := d.GetOk("id")
@@ -41,6 +42,7 @@ func dataCustomFlowRead(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 	} else {
 		name := d.Get("name")
+
 		customFlow, err = getCustomFlowByName(name.(string), meta)
 		if err != nil {
 			return diag.Errorf("failed to get custom flow by name: %v", err)

--- a/env0/data_custom_role.go
+++ b/env0/data_custom_role.go
@@ -31,6 +31,7 @@ func dataCustomRole() *schema.Resource {
 
 func dataCustomRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var err error
+
 	var role *client.Role
 
 	id, ok := d.GetOk("id")

--- a/env0/data_custom_roles.go
+++ b/env0/data_custom_roles.go
@@ -28,6 +28,7 @@ func dataCustomRoles() *schema.Resource {
 
 func dataCustomRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(client.ApiClientInterface)
+
 	roles, err := apiClient.Roles()
 	if err != nil {
 		return diag.Errorf("Failed to get custom roles: %v", err)

--- a/env0/data_environment.go
+++ b/env0/data_environment.go
@@ -125,6 +125,7 @@ func dataEnvironment() *schema.Resource {
 
 func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var err diag.Diagnostics
+
 	var environment client.Environment
 
 	projectId := d.Get("project_id").(string)
@@ -138,6 +139,7 @@ func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 	} else {
 		name := d.Get("name").(string)
 		excludeArchived := d.Get("exclude_archived")
+
 		environment, err = getEnvironmentByName(meta, name, projectId, excludeArchived.(bool))
 		if err != nil {
 			return err

--- a/env0/data_git_token.go
+++ b/env0/data_git_token.go
@@ -31,6 +31,7 @@ func dataGitToken() *schema.Resource {
 
 func dataGitTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var gitToken *client.GitToken
+
 	var err error
 
 	id, ok := d.GetOk("id")

--- a/env0/data_kubernetes_credentials_test.go
+++ b/env0/data_kubernetes_credentials_test.go
@@ -125,5 +125,4 @@ func TestKubernetesCredentialsDataSource(t *testing.T) {
 			)
 		})
 	}
-
 }

--- a/env0/data_module_testing_project_test.go
+++ b/env0/data_module_testing_project_test.go
@@ -61,5 +61,4 @@ func TestModuleTestingProjectDataSource(t *testing.T) {
 			},
 		)
 	})
-
 }

--- a/env0/data_notifications.go
+++ b/env0/data_notifications.go
@@ -28,6 +28,7 @@ func dataNotifications() *schema.Resource {
 
 func dataNotificationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(client.ApiClientInterface)
+
 	notifications, err := apiClient.Notifications()
 	if err != nil {
 		return diag.Errorf("could not get notifications: %v", err)

--- a/env0/data_oidc_credentials_test.go
+++ b/env0/data_oidc_credentials_test.go
@@ -125,5 +125,4 @@ func TestOidcCredentialDataSource(t *testing.T) {
 			)
 		})
 	}
-
 }

--- a/env0/data_project_policy.go
+++ b/env0/data_project_policy.go
@@ -115,9 +115,11 @@ func dataPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{
 
 func getPolicyByProjectId(projectId string, meta interface{}) (client.Policy, diag.Diagnostics) {
 	apiClient := meta.(client.ApiClientInterface)
+
 	policy, err := apiClient.Policy(projectId)
 	if err != nil {
 		return client.Policy{}, diag.Errorf("Could not query policy: %v", err)
 	}
+
 	return policy, nil
 }

--- a/env0/data_projects.go
+++ b/env0/data_projects.go
@@ -68,6 +68,7 @@ func dataProjectsRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	filteredProjects := []client.Project{}
+
 	for _, project := range projects {
 		if includeArchivedProjects || !project.IsArchived {
 			filteredProjects = append(filteredProjects, project)

--- a/env0/data_source_code_variables_test.go
+++ b/env0/data_source_code_variables_test.go
@@ -102,5 +102,4 @@ func TestSourceCodeVariablesDataSource(t *testing.T) {
 			},
 		)
 	})
-
 }

--- a/env0/data_sshkey.go
+++ b/env0/data_sshkey.go
@@ -80,6 +80,7 @@ func getSshKeyByName(name interface{}, meta interface{}) (*client.SshKey, error)
 		if len(sshKeysByName) > 1 {
 			return nil, backoff.Permanent(fmt.Errorf("found multiple ssh keys with name: %s. Use id instead or make sure ssh key names are unique %v", name, sshKeysByName))
 		}
+
 		if len(sshKeysByName) == 0 {
 			return nil, fmt.Errorf("ssh key with name %v not found", name)
 		}
@@ -97,6 +98,7 @@ func getSshKeyById(id interface{}, meta interface{}) (*client.SshKey, error) {
 	}
 
 	var sshKey *client.SshKey
+
 	for _, candidate := range sshKeys {
 		if candidate.Id == id.(string) {
 			sshKey = &candidate

--- a/env0/data_team.go
+++ b/env0/data_team.go
@@ -49,6 +49,7 @@ func dataTeamRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 		if !ok {
 			return diag.Errorf("Either 'name' or 'id' must be specified")
 		}
+
 		team, err = getTeamByName(name.(string), meta)
 		if err != nil {
 			return err

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -205,5 +205,6 @@ func getTemplateById(id interface{}, meta interface{}) (client.Template, diag.Di
 	if err != nil {
 		return client.Template{}, diag.Errorf("Could not query template: %v", err)
 	}
+
 	return template, nil
 }

--- a/env0/data_variable_set.go
+++ b/env0/data_variable_set.go
@@ -56,6 +56,7 @@ func dataVariableSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	switch resource.Scope {
 	case "ORGANIZATION":
 		var err error
+
 		scopeId, err = apiClient.OrganizationId()
 		if err != nil {
 			return diag.Errorf("could not get organization id: %v", err)
@@ -64,6 +65,7 @@ func dataVariableSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 		if resource.ProjectId == "" {
 			return diag.Errorf("'project_id' is required")
 		}
+
 		scopeId = resource.ProjectId
 	}
 
@@ -75,6 +77,7 @@ func dataVariableSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	for _, variableSet := range variableSets {
 		if variableSet.Name == resource.Name {
 			d.SetId(variableSet.Id)
+
 			return nil
 		}
 	}

--- a/env0/data_variable_set_test.go
+++ b/env0/data_variable_set_test.go
@@ -54,6 +54,7 @@ func TestVariableSetDataSource(t *testing.T) {
 			if organizationId != "" {
 				mock.EXPECT().OrganizationId().AnyTimes().Return(organizationId, nil)
 			}
+
 			mock.EXPECT().ConfigurationSets(scope, scopeId).AnyTimes().Return(returnValue, nil)
 		}
 	}

--- a/env0/data_workflow_triggers.go
+++ b/env0/data_workflow_triggers.go
@@ -47,7 +47,9 @@ func dataWorkflowTriggersRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	d.SetId(environmentId)
-	var triggerIds []string
+
+	triggerIds := []string{}
+
 	for _, value := range triggers {
 		triggerIds = append(triggerIds, value.Id)
 	}

--- a/env0/errors.go
+++ b/env0/errors.go
@@ -28,6 +28,7 @@ func ResourceGetFailure(ctx context.Context, resourceName string, d *schema.Reso
 	if driftDetected(err) {
 		tflog.Warn(ctx, "Drift Detected: Terraform will remove id from state", map[string]interface{}{"id": d.Id()})
 		d.SetId("")
+
 		return nil
 	}
 

--- a/env0/resource_api_key.go
+++ b/env0/resource_api_key.go
@@ -119,11 +119,13 @@ func getApiKeyById(id string, meta interface{}) (*client.ApiKey, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	for _, apiKey := range apiKeys {
 		if apiKey.Id == id {
 			return &apiKey, nil
 		}
 	}
+
 	return nil, nil
 }
 
@@ -174,7 +176,7 @@ func resourceApiKeyImport(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := writeResourceData(apiKey, d); err != nil {
-		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_api_key_test.go
+++ b/env0/resource_api_key_test.go
@@ -258,5 +258,4 @@ func TestUnitApiKeyResource(t *testing.T) {
 			mock.EXPECT().ApiKeyDelete(updatedApiKey.Id).Times(1)
 		})
 	})
-
 }

--- a/env0/resource_approval_policy.go
+++ b/env0/resource_approval_policy.go
@@ -135,7 +135,7 @@ func resourceApprovalPolicyImport(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err := writeResourceData(approvalPolicy, d); err != nil {
-		return nil, fmt.Errorf("schema resource data serialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data serialization failed: %w", err)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/env0/resource_approval_policy_assignment.go
+++ b/env0/resource_approval_policy_assignment.go
@@ -88,6 +88,7 @@ func resourceApprovalPolicyAssignmentRead(ctx context.Context, d *schema.Resourc
 	for _, approvalPolicyByScope := range approvalPolicyByScopeArr {
 		if approvalPolicyByScope.ApprovalPolicy.Id == assignment.BlueprintId {
 			found = true
+
 			break
 		}
 	}

--- a/env0/resource_approval_policy_test.go
+++ b/env0/resource_approval_policy_test.go
@@ -34,6 +34,7 @@ func TestUnitApprovalPolicyResource(t *testing.T) {
 	}
 
 	var template client.Template
+
 	require.NoError(t, copier.Copy(&template, &approvalPolicy))
 	template.Type = string(ApprovalPolicy)
 
@@ -54,6 +55,7 @@ func TestUnitApprovalPolicyResource(t *testing.T) {
 	}
 
 	var updatedTemplate client.Template
+
 	require.NoError(t, copier.Copy(&updatedTemplate, &updatedApprovalPolicy))
 	updatedTemplate.Type = string(ApprovalPolicy)
 

--- a/env0/resource_azure_credentials_test.go
+++ b/env0/resource_azure_credentials_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestUnitAzureCredentialsResource(t *testing.T) {
-
 	resourceType := "env0_azure_credentials"
 	resourceName := "test"
 	resourceNameImport := resourceType + "." + resourceName

--- a/env0/resource_cloud_credentials_project_assignment.go
+++ b/env0/resource_cloud_credentials_project_assignment.go
@@ -43,11 +43,14 @@ func resourceCloudCredentialsProjectAssignmentCreate(ctx context.Context, d *sch
 	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId, projectId := getCredentialIdAndProjectId(d)
+
 	result, err := apiClient.AssignCloudCredentialsToProject(projectId, credentialId)
 	if err != nil {
 		return diag.Errorf("could not assign cloud credentials to project: %v", err)
 	}
+
 	d.SetId(getResourceId(result.CredentialId, result.ProjectId))
+
 	return nil
 }
 
@@ -55,11 +58,14 @@ func resourceCloudCredentialsProjectAssignmentRead(ctx context.Context, d *schem
 	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId, projectId := getCredentialIdAndProjectId(d)
+
 	credentialsList, err := apiClient.CloudCredentialIdsInProject(projectId)
 	if err != nil {
 		return diag.Errorf("could not get cloud_credentials: %v", err)
 	}
+
 	found := false
+
 	for _, candidate := range credentialsList {
 		if candidate == credentialId {
 			found = true

--- a/env0/resource_cloud_credentials_project_assignment_test.go
+++ b/env0/resource_cloud_credentials_project_assignment_test.go
@@ -23,10 +23,12 @@ func TestUnitResourceCloudCredentialsProjectAssignmentResource(t *testing.T) {
 		CredentialId: "cred-it",
 		ProjectId:    "proj-it-update",
 	}
+
 	stepConfig := resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
 		"credential_id": assignment.CredentialId,
 		"project_id":    assignment.ProjectId,
 	})
+
 	t.Run("Create", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{

--- a/env0/resource_configuration_variable.go
+++ b/env0/resource_configuration_variable.go
@@ -152,7 +152,7 @@ func getConfigurationVariableCreateParams(d *schema.ResourceData) (*client.Confi
 	scope, scopeId := whichScope(d)
 	params := client.ConfigurationVariableCreateParams{Scope: scope, ScopeId: scopeId}
 	if err := readResourceData(&params, d); err != nil {
-		return nil, fmt.Errorf("schema resource data deserialization failed: %v", err)
+		return nil, fmt.Errorf("schema resource data deserialization failed: %w", err)
 	}
 
 	if err := validateNilValue(params.IsReadOnly, params.IsRequired, params.Value); err != nil {
@@ -191,6 +191,7 @@ func getEnum(d *schema.ResourceData, selectedValue string) ([]string, error) {
 	if specified, ok := d.GetOk("enum"); ok {
 		enumValues = specified.([]interface{})
 		valueExists := false
+
 		for i, enumValue := range enumValues {
 			if enumValue == nil {
 				return nil, fmt.Errorf("an empty enum value is not allowed (at index %d)", i)
@@ -267,8 +268,10 @@ func resourceConfigurationVariableDelete(ctx context.Context, d *schema.Resource
 func resourceConfigurationVariableImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	var configurationParams ConfigurationVariableParams
 	inputData := d.Id()
+
 	// soft delete isn't part of the configuration variable, so we need to set it
 	d.Set("soft_delete", false)
+
 	err := json.Unmarshal([]byte(inputData), &configurationParams)
 	// We need this conversion since getConfigurationVariable query by the scope and in our BE we use blueprint as the scope name instead of template
 	if string(configurationParams.Scope) == "TEMPLATE" {

--- a/env0/resource_cost_credentials.go
+++ b/env0/resource_cost_credentials.go
@@ -69,7 +69,7 @@ func resourceCostCredentials(providerName string) *schema.Resource {
 				},
 			}
 		default:
-			panic(fmt.Sprintf("unhandled provider name: %s", providerName))
+			panic("unhandled provider name: " + providerName)
 		}
 	}
 
@@ -94,7 +94,7 @@ func resourceCostCredentials(providerName string) *schema.Resource {
 			}
 			value = &payload.(*client.GoogleCostCredentialsCreatePayload).Value
 		default:
-			panic(fmt.Sprintf("unhandled provider name: %s", providerName))
+			panic("unhandled provider name: " + providerName)
 		}
 
 		if err := readResourceData(value, d); err != nil {

--- a/env0/resource_cost_credentials_project_assignment.go
+++ b/env0/resource_cost_credentials_project_assignment.go
@@ -39,7 +39,9 @@ func resourceCostCredentialsProjectAssignmentCreate(ctx context.Context, d *sche
 	if err != nil {
 		return diag.Errorf("could not assign cost credentials to project: %v", err)
 	}
+
 	d.SetId(getResourceId(result.CredentialsId, result.ProjectId))
+
 	return nil
 }
 
@@ -47,16 +49,20 @@ func resourceCostdCredentialsProjectAssignmentRead(ctx context.Context, d *schem
 	apiClient := meta.(client.ApiClientInterface)
 
 	credentialId, projectId := getCredentialIdAndProjectId(d)
+
 	credentialsList, err := apiClient.CostCredentialIdsInProject(projectId)
 	if err != nil {
 		return diag.Errorf("could not get cost credentials: %v", err)
 	}
+
 	found := false
+
 	for _, candidate := range credentialsList {
 		if candidate.CredentialsId == credentialId {
 			found = true
 		}
 	}
+
 	if !found && !d.IsNewResource() {
 		d.SetId("")
 		return nil

--- a/env0/resource_cost_credentials_project_assignment_test.go
+++ b/env0/resource_cost_credentials_project_assignment_test.go
@@ -35,6 +35,7 @@ func TestUnitResourceCostCredentialsProjectAssignmentResource(t *testing.T) {
 		"credential_id": assignment.CredentialsId,
 		"project_id":    assignment.ProjectId,
 	})
+
 	t.Run("Create", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{

--- a/env0/resource_cost_credentials_test.go
+++ b/env0/resource_cost_credentials_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestUnitAwsCostCredentialsResource(t *testing.T) {
-
 	resourceType := "env0_aws_cost_credentials"
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)
@@ -154,11 +153,9 @@ func TestUnitAwsCostCredentialsResource(t *testing.T) {
 		}, func(mock *client.MockApiClientInterface) {
 		})
 	})
-
 }
 
 func TestUnitAzureCostCredentialsResource(t *testing.T) {
-
 	resourceType := "env0_azure_cost_credentials"
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)
@@ -289,17 +286,15 @@ func TestUnitAzureCostCredentialsResource(t *testing.T) {
 		}
 		for _, testCase := range missingArgumentsTestCases {
 			tc := testCase
+
 			t.Run("validate specific argument", func(t *testing.T) {
 				runUnitTest(t, tc, func(mock *client.MockApiClientInterface) {})
 			})
-
 		}
 	})
-
 }
 
 func TestUnitGoogleCostCredentialsResource(t *testing.T) {
-
 	resourceType := "env0_gcp_cost_credentials"
 	resourceName := "test"
 	accessor := resourceAccessor(resourceType, resourceName)

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -374,7 +374,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"wait_for_destroy": {
 				Type:        schema.TypeBool,
-				Description: "during destroy, waits for the environment status to be 'INACTIVE'. Times out after 30 minutes.",
+				Description: "(Important note: this option is experimental, please report any issues found). During destroy, waits for the environment status to be 'INACTIVE'. Times out after 30 minutes.",
 				Default:     false,
 				Optional:    true,
 			},

--- a/env0/resource_environment_output_configuration_variable_test.go
+++ b/env0/resource_environment_output_configuration_variable_test.go
@@ -53,7 +53,6 @@ func TestUnitEnvironmentOutputConfigurationVariableResource(t *testing.T) {
 	updatedConfigurationVariable.Value = updatedValueStr
 
 	t.Run("create and update", func(t *testing.T) {
-
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{
 				{

--- a/env0/resource_environment_scheduling_test.go
+++ b/env0/resource_environment_scheduling_test.go
@@ -1,7 +1,6 @@
 package env0
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -47,7 +46,7 @@ func TestUnitEnvironmentSchedulingResource(t *testing.T) {
 	})
 
 	for _, key := range cronExprKeys {
-		t.Run(fmt.Sprintf("Failure due to invalid cron expression for %s", key), func(t *testing.T) {
+		t.Run("Failure due to invalid cron expression for "+key, func(t *testing.T) {
 			testCase := resource.TestCase{
 				Steps: []resource.TestStep{
 					{

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -872,9 +872,9 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 						mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("QUEUED"), nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("IN_PROGRESS"), nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("QUEUED"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("IN_PROGRESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
 					)
 				})
 			})
@@ -889,7 +889,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						{
 							Config:      config,
 							Destroy:     true,
-							ExpectError: regexp.MustCompile("failed to wait for environment destroy to complete, deployment status is: WAITING_FOR_USER"),
+							ExpectError: regexp.MustCompile("failed to wait for environment destroy to complete, deployment status is: CANCELLED"),
 						},
 					},
 				}
@@ -905,9 +905,9 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 						mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("WAITING_FOR_USER"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("CANCELLED"), nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
 					)
 				})
 			})
@@ -938,9 +938,9 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 						mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(nil, errors.New("error")),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(nil, errors.New("error")),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
 					)
 				})
 			})
@@ -955,7 +955,7 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						{
 							Config:      config,
 							Destroy:     true,
-							ExpectError: regexp.MustCompile("timeout! last destroy deployment status was 'IN_PROGRESS'"),
+							ExpectError: regexp.MustCompile("timeout! last 'destroy' deployment status was 'IN_PROGRESS'"),
 						},
 					},
 				}
@@ -971,10 +971,10 @@ func TestUnitEnvironmentResource(t *testing.T) {
 						mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).Times(1).Return(client.ConfigurationChanges{}, nil),
 						mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("QUEUED"), nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).AnyTimes().Return(deploymentWithStatus("IN_PROGRESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("QUEUED"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).AnyTimes().Return(deploymentWithStatus("IN_PROGRESS"), nil),
 						mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1).Return(destroyResponse, nil),
-						mock.EXPECT().EnvironmentDeployment(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
+						mock.EXPECT().EnvironmentDeploymentLog(deploymentLog.Id).Times(1).Return(deploymentWithStatus("SUCCESS"), nil),
 					)
 				})
 			})

--- a/env0/resource_gcp_credentials_test.go
+++ b/env0/resource_gcp_credentials_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestUnitGcpCredentialsResource(t *testing.T) {
-
 	resourceType := "env0_gcp_credentials"
 	resourceName := "test"
 	resourceNameImport := resourceType + "." + resourceName

--- a/env0/resource_notification.go
+++ b/env0/resource_notification.go
@@ -63,11 +63,13 @@ func getNotificationById(id string, meta interface{}) (*client.Notification, err
 	if err != nil {
 		return nil, err
 	}
+
 	for _, notification := range notifications {
 		if notification.Id == id {
 			return &notification, nil
 		}
 	}
+
 	return nil, nil
 }
 

--- a/env0/resource_notification_project_assignment.go
+++ b/env0/resource_notification_project_assignment.go
@@ -77,6 +77,7 @@ func resourceNotificationProjectAssignmentCreateOrUpdate(ctx context.Context, d 
 	if err != nil {
 		return diag.Errorf("could not create or update notification project assignment: %v", err)
 	}
+
 	d.SetId(assignment.Id)
 
 	return nil

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -482,6 +482,7 @@ func templateReadRetryOnHelper(prefix string, d *schema.ResourceData, retryType 
 			value["retries_on_"+retryType] = 0
 			value["retry_on_"+retryType+"_only_when_matches_regex"] = ""
 		}
+
 		d.Set(prefix, []interface{}{value})
 	} else {
 		if retryOn != nil {

--- a/env0/resource_template_test.go
+++ b/env0/resource_template_test.go
@@ -761,6 +761,7 @@ func TestUnitTemplateResource(t *testing.T) {
 			})
 		})
 	}
+
 	t.Run("Basic template", func(t *testing.T) {
 		template := client.Template{
 			Id:         "id0",
@@ -956,6 +957,7 @@ func TestUnitTemplateResource(t *testing.T) {
 
 		for _, testCase := range testCases {
 			tc := testCase
+
 			t.Run("Invalid retry times field", func(t *testing.T) {
 				runUnitTest(t, tc, func(mockFunc *client.MockApiClientInterface) {})
 			})
@@ -982,6 +984,7 @@ func TestUnitTemplateResource(t *testing.T) {
 
 		for _, testCase := range testCases {
 			tc := testCase
+
 			t.Run("Invalid retry regex field", func(t *testing.T) {
 				runUnitTest(t, tc, func(mockFunc *client.MockApiClientInterface) {})
 			})

--- a/env0/resource_user_organization_assignment.go
+++ b/env0/resource_user_organization_assignment.go
@@ -70,7 +70,6 @@ func resourceUserOrganizationAssignmentRead(ctx context.Context, d *schema.Resou
 		tflog.Warn(ctx, "Drift Detected: Terraform will remove id from state", map[string]interface{}{"id": d.Id()})
 		d.SetId("")
 		return nil
-
 	}
 
 	if isBuiltinOrganizationRole(user.Role) {

--- a/env0/resource_user_team_assignment.go
+++ b/env0/resource_user_team_assignment.go
@@ -91,6 +91,7 @@ func resourceUserTeamAssignmentCreate(ctx context.Context, d *schema.ResourceDat
 		if user.UserId == newAssignment.UserId {
 			return diag.Errorf("assignment for user id %v and team id %v already exist", newAssignment.UserId, newAssignment.TeamId)
 		}
+
 		userIds = append(userIds, user.UserId)
 	}
 
@@ -166,6 +167,7 @@ func resourceUserTeamAssignmentDelete(ctx context.Context, d *schema.ResourceDat
 		if user.UserId == assignment.UserId {
 			continue
 		}
+
 		userIds = append(userIds, user.UserId)
 	}
 

--- a/env0/resource_variable_set.go
+++ b/env0/resource_variable_set.go
@@ -300,11 +300,14 @@ func mergeVariables(schema []client.ConfigurationVariable, api []client.Configur
 		for _, avariable := range api {
 			if svariable.Name == avariable.Name && *svariable.Type == *avariable.Type {
 				found = true
+
 				if avariable.IsSensitive != nil && *avariable.IsSensitive {
 					// Sensitive - to avoid drift use the value from the schema
 					avariable.Value = svariable.Value
 				}
+
 				res.currentVariables = append(res.currentVariables, avariable)
+
 				break
 			}
 		}

--- a/env0/resource_workflow_triggers.go
+++ b/env0/resource_workflow_triggers.go
@@ -47,7 +47,7 @@ func resourceWorkflowTriggersRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("could not get workflow triggers: %v", err)
 	}
 
-	var triggerIds []string
+	triggerIds := []string{}
 	for _, value := range triggers {
 		triggerIds = append(triggerIds, value.Id)
 	}
@@ -62,7 +62,7 @@ func resourceWorkflowTriggersCreateOrUpdate(ctx context.Context, d *schema.Resou
 	environmentId := d.Get("environment_id").(string)
 	rawDownstreamIds := d.Get("downstream_environment_ids").([]interface{})
 
-	var requestDownstreamIds []string
+	requestDownstreamIds := []string{}
 
 	for _, rawId := range rawDownstreamIds {
 		requestDownstreamIds = append(requestDownstreamIds, rawId.(string))
@@ -75,7 +75,7 @@ func resourceWorkflowTriggersCreateOrUpdate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("could not Create or Update workflow triggers: %v", err)
 	}
 
-	var downstreamIds []string
+	downstreamIds := []string{}
 	for _, trigger := range triggers {
 		downstreamIds = append(downstreamIds, trigger.Id)
 	}

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -49,6 +49,7 @@ resource "env0_environment" "auto_glob_envrironment" {
   approve_plan_automatically       = true
   deploy_on_push                   = true
   force_destroy                    = true
+  wait_for_destroy                 = true
 }
 
 resource "env0_environment" "example" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #686 

### Solution

1. Added the option in the schema.
2. When an environment is 'destroyed', added the 'wait' code if the option is enabled.
3. Added acceptance tests.
4. Some misc changes to enable (in the future) a more modern linter checkers.
