### PR TITLE
Fix: fail when trying to create an in_active environment

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -272,7 +272,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"is_inactive": {
 				Type:        schema.TypeBool,
-				Description: "If 'true', it marks the environment as inactive. It can be re-activated by setting it to 'false' or removing this field.",
+				Description: "If 'true', it marks the environment as inactive. It can be re-activated by setting it to 'false' or removing this field. Note: it's not allowed to create an inactive environment",
 				Default:     false,
 				Optional:    true,
 			},
@@ -599,6 +599,10 @@ func validateTemplateProjectAssignment(d *schema.ResourceData, apiClient client.
 
 func resourceEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	apiClient := meta.(client.ApiClientInterface)
+
+	if d.Get("is_inactive").(bool) {
+		return diag.Errorf("cannot create an inactive environment (remove 'is_inactive' or set it to 'false')")
+	}
 
 	environmentPayload, createEnvPayloadErr := getCreatePayload(d, apiClient)
 	if createEnvPayloadErr != nil {

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2201,6 +2201,26 @@ func TestUnitEnvironmentResource(t *testing.T) {
 
 		})
 
+		t.Run("fail when trying to create an inactive environment", func(t *testing.T) {
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfigCreate(resourceType, resourceName, map[string]interface{}{
+							"name":          updatedEnvironment.Name,
+							"project_id":    updatedEnvironment.ProjectId,
+							"template_id":   updatedEnvironment.LatestDeploymentLog.BlueprintId,
+							"is_inactive":   true,
+							"force_destroy": true,
+						}),
+						ExpectError: regexp.MustCompile("cannot create an inactive environment"),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
+
+		})
+
 		t.Run("Failure in create", func(t *testing.T) {
 			testCase := resource.TestCase{
 				Steps: []resource.TestStep{

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2218,7 +2218,6 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			}
 
 			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
-
 		})
 
 		t.Run("Failure in create", func(t *testing.T) {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #951 

### Solution

Creating an 'inactive' account should be blocked (not supported).
1. Updated the documents.
2. Fail this use-case.
3. Added an acceptance test.