### PR TITLE
Fix: approve_plan_automatically attribute fails for sub_environment

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -1179,6 +1179,11 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 		payload.BlueprintRevision = revision.(string)
 	}
 
+	// For 'Workflows', the 'root' environment should never require a user approval.
+	if _, ok := d.GetOk("sub_environment_configuration"); ok {
+		payload.UserRequiresApproval = boolPtr(false)
+	}
+
 	if isRedeploy {
 		if revision, ok := d.GetOk("without_template_settings.0.revision"); ok {
 			payload.BlueprintRevision = revision.(string)

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -989,7 +989,7 @@ func getCreatePayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 	}
 
 	// For 'Workflows', the 'root' environment should never require an approval.
-	if _, ok := d.GetOk("sub_environment_configuration"); ok {
+	if isWorkflow {
 		payload.RequiresApproval = boolPtr(false)
 	}
 

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -415,7 +415,8 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 		d.Set("output", string(environment.LatestDeploymentLog.Output))
 	}
 
-	if environment.RequiresApproval != nil {
+	// Don't update this value for workflow environments - this value should always be 'false'.
+	if _, isWorkflow := d.GetOk("sub_environment_configuration"); !isWorkflow && environment.RequiresApproval != nil {
 		d.Set("approve_plan_automatically", !*environment.RequiresApproval)
 	}
 

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2929,7 +2929,8 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 			},
 		},
 		DeployRequest: &client.DeployRequest{
-			BlueprintId: environment.BlueprintId,
+			BlueprintId:          environment.BlueprintId,
+			UserRequiresApproval: boolPtr(false),
 			SubEnvironments: map[string]client.SubEnvironment{
 				subEnvironment.Alias: {
 					Workspace:            subEnvironment.Workspace,
@@ -2946,8 +2947,9 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 	}
 
 	deployRequest := client.DeployRequest{
-		BlueprintId:       environment.BlueprintId,
-		BlueprintRevision: environment.LatestDeploymentLog.BlueprintRevision,
+		BlueprintId:          environment.BlueprintId,
+		BlueprintRevision:    environment.LatestDeploymentLog.BlueprintRevision,
+		UserRequiresApproval: boolPtr(false),
 		SubEnvironments: map[string]client.SubEnvironment{
 			subEnvironment.Alias: {
 				Revision:             subEnvironment.Revision,

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2888,10 +2888,11 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 	subEnvrionmentWithId.Id = workflowSubEnvironment.EnvironmentId
 
 	environment := client.Environment{
-		Id:          "id",
-		Name:        "environment",
-		ProjectId:   "project-id",
-		BlueprintId: "template-id",
+		Id:               "id",
+		Name:             "environment",
+		ProjectId:        "project-id",
+		BlueprintId:      "template-id",
+		RequiresApproval: boolPtr(false),
 		LatestDeploymentLog: client.DeploymentLog{
 			WorkflowFile: &client.WorkflowFile{
 				Environments: map[string]client.WorkflowSubEnvironment{

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2961,6 +2961,39 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 		},
 	}
 
+	t.Run("Fail when approve plan automatically is false", func(t *testing.T) {
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+					resource "%s" "%s" {
+						name = "%s"
+						project_id = "%s"
+						template_id = "%s"
+						force_destroy = true
+						approve_plan_automatically = false
+						sub_environment_configuration {
+							alias = "%s"
+							revision = "%s"
+							workspace = "%s"
+						}
+					}`,
+						resourceType, resourceName,
+						environmentCreatePayload.Name,
+						environmentCreatePayload.ProjectId,
+						environment.BlueprintId,
+						subEnvironment.Alias,
+						subEnvironment.Revision,
+						subEnvironment.Workspace,
+					),
+					ExpectError: regexp.MustCompile("approve_plan_automatically cannot be 'false' for workflows"),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {})
+	})
+
 	t.Run("Success in create", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2892,7 +2892,6 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 		Name:        "environment",
 		ProjectId:   "project-id",
 		BlueprintId: "template-id",
-
 		LatestDeploymentLog: client.DeploymentLog{
 			WorkflowFile: &client.WorkflowFile{
 				Environments: map[string]client.WorkflowSubEnvironment{
@@ -2912,8 +2911,9 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 	}
 
 	environmentCreatePayload := client.EnvironmentCreate{
-		Name:      environment.Name,
-		ProjectId: environment.ProjectId,
+		Name:             environment.Name,
+		ProjectId:        environment.ProjectId,
+		RequiresApproval: boolPtr(false),
 		ConfigurationChanges: &client.ConfigurationChanges{
 			{
 				Name:        "n1",

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -257,7 +257,6 @@ resource "env0_environment" "workflow-environment" {
   name                       = "environment-workflow-${random_string.random.result}"
   project_id                 = env0_project.test_project.id
   template_id                = env0_template.workflow_template.id
-  approve_plan_automatically = true
 
   configuration {
     name  = "n1"
@@ -269,7 +268,7 @@ resource "env0_environment" "workflow-environment" {
   sub_environment_configuration {
     alias                      = "rootService1"
     revision                   = "master"
-    approve_plan_automatically = var.second_run ? true : false
+    approve_plan_automatically = var.second_run ? false : true 
     configuration {
       name  = "sub_env1_var1"
       value = "hello"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #947 

### Solution

1. For workflow - always pass `RequiredUserApproval` as `false` in the deploy payload (for the root env).
2. Updated acceptance tests.
3. Updated harness tests.
