### PR TITLE
Chore: Add assign reviewers GHA

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,20 @@
+name: Assign PR Reviewers
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request != null && github.event.comment.body == '/review' }}
+    steps:
+      - name: Assign PR Reviewers
+        env:
+          GITHUB_TOKEN: ${{ secrets.ENV0_BOT_PAT }}
+        run: |
+          curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/requested_reviewers \
+          -d '{"team_reviewers":["env0-team"]}'


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
Outside collaborators of this repository are not allowed to directly assign teams of env0 as reviewers

### Solution
Add the ability to do so via a GHA that uses a common PAT
