### PR TITLE
Fix: variable set assignment drifts with parent projects

### DIFF
--- a/client/configuration_set.go
+++ b/client/configuration_set.go
@@ -21,15 +21,17 @@ type UpdateConfigurationSetPayload struct {
 }
 
 type ConfigurationSet struct {
-	Id              string `json:"id"`
-	Name            string `json:"name"`
-	Description     string `json:"description"`
-	AssignmentScope string `json:"assignmentScope"`
-	CreationScopeId string `json:"creationScopeId"`
+	Id                string `json:"id"`
+	Name              string `json:"name"`
+	Description       string `json:"description"`
+	AssignmentScope   string `json:"assignmentScope"`
+	CreationScopeId   string `json:"creationScopeId"`
+	AssignmentScopeId string `json:"assignmentScopeId"`
 }
 
 func (client *ApiClient) ConfigurationSetCreate(payload *CreateConfigurationSetPayload) (*ConfigurationSet, error) {
 	var result ConfigurationSet
+
 	var err error
 
 	if payload.Scope == "organization" && payload.ScopeId == "" {

--- a/env0/resource_variable_set.go
+++ b/env0/resource_variable_set.go
@@ -300,11 +300,13 @@ func mergeVariables(schema []client.ConfigurationVariable, api []client.Configur
 		for _, avariable := range api {
 			if svariable.Name == avariable.Name && *svariable.Type == *avariable.Type {
 				found = true
+
 				if avariable.IsSensitive != nil && *avariable.IsSensitive {
 					// Sensitive - to avoid drift use the value from the schema
 					avariable.Value = svariable.Value
 				}
 				res.currentVariables = append(res.currentVariables, avariable)
+
 				break
 			}
 		}

--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -188,11 +188,6 @@ func resourceVariableSetAssignmentRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	for _, apiConfigurationSet := range apiConfigurationSets {
-		// Filter out irrelevant scopes.
-		if !strings.EqualFold(apiConfigurationSet.AssignmentScope, assignmentSchema.Scope) {
-			continue
-		}
-
 		// Filter out inherited assignments (e.g parent project).
 		if apiConfigurationSet.AssignmentScopeId != assignmentSchema.ScopeId {
 			continue

--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -188,7 +188,13 @@ func resourceVariableSetAssignmentRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	for _, apiConfigurationSet := range apiConfigurationSets {
+		// Filter out irrelevant scopes.
 		if !strings.EqualFold(apiConfigurationSet.AssignmentScope, assignmentSchema.Scope) {
+			continue
+		}
+
+		// Filter out inherited scopes (e.g parent project).
+		if apiConfigurationSet.CreationScopeId != assignmentSchema.ScopeId {
 			continue
 		}
 

--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -194,7 +194,7 @@ func resourceVariableSetAssignmentRead(ctx context.Context, d *schema.ResourceDa
 		}
 
 		// Filter out inherited assignments (e.g parent project).
-		if apiConfigurationSet.CreationScopeId != assignmentSchema.ScopeId {
+		if apiConfigurationSet.AssignmentScopeId != assignmentSchema.ScopeId {
 			continue
 		}
 

--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -193,7 +193,7 @@ func resourceVariableSetAssignmentRead(ctx context.Context, d *schema.ResourceDa
 			continue
 		}
 
-		// Filter out inherited scopes (e.g parent project).
+		// Filter out inherited assignments (e.g parent project).
 		if apiConfigurationSet.CreationScopeId != assignmentSchema.ScopeId {
 			continue
 		}

--- a/env0/resource_variable_set_assignment_test.go
+++ b/env0/resource_variable_set_assignment_test.go
@@ -22,10 +22,17 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 			{
 				Id:              "a1",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 			{
 				Id:              "a2",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
+			},
+			{
+				Id:              "filtered_out",
+				AssignmentScope: scope,
+				CreationScopeId: "otherCreationScopeId",
 			},
 		}
 		// Validates that drifts do not occur due to ordering.
@@ -33,10 +40,12 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 			{
 				Id:              "a2",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 			{
 				Id:              "a1",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 		}
 
@@ -45,10 +54,12 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 			{
 				Id:              "a3",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 			{
 				Id:              "a1",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 		}
 
@@ -105,10 +116,12 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 			{
 				Id:              "a1",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 			{
 				Id:              "a2",
 				AssignmentScope: scope,
+				CreationScopeId: scopeId,
 			},
 		}
 

--- a/env0/resource_variable_set_assignment_test.go
+++ b/env0/resource_variable_set_assignment_test.go
@@ -20,46 +20,46 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 		setIds := []string{"a1", "a2"}
 		configurationSetIds := []client.ConfigurationSet{
 			{
-				Id:              "a1",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a1",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 			{
-				Id:              "a2",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a2",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 			{
-				Id:              "filtered_out",
-				AssignmentScope: scope,
-				CreationScopeId: "otherCreationScopeId",
+				Id:                "filtered_out",
+				AssignmentScope:   scope,
+				AssignmentScopeId: "otherAssignmentScopeId",
 			},
 		}
 		// Validates that drifts do not occur due to ordering.
 		flippedConfigurationSetIds := []client.ConfigurationSet{
 			{
-				Id:              "a2",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a2",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 			{
-				Id:              "a1",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a1",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 		}
 
 		updatedSetIds := []string{"a1", "a3"}
 		updatedConfigurationSetIds := []client.ConfigurationSet{
 			{
-				Id:              "a3",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a3",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 			{
-				Id:              "a1",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a1",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 		}
 
@@ -114,14 +114,14 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 		setIds := []string{"a1"}
 		configurationSetIds := []client.ConfigurationSet{
 			{
-				Id:              "a1",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a1",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 			{
-				Id:              "a2",
-				AssignmentScope: scope,
-				CreationScopeId: scopeId,
+				Id:                "a2",
+				AssignmentScope:   scope,
+				AssignmentScopeId: scopeId,
 			},
 		}
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
fixes #960 

### Solution

1. Filtered out assignments returned by inheritence (E.g. parent project), by using `AssignmentScopeId`.
2. Updated acceptance tests.

/review
