### PR TITLE
Fix: env0_variable_set_assignment 404, Error: failed to unassign vari…

### DIFF
--- a/env0/resource_variable_set_assignment.go
+++ b/env0/resource_variable_set_assignment.go
@@ -2,7 +2,6 @@ package env0
 
 import (
 	"context"
-	"strings"
 
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -90,7 +89,7 @@ func resourceVariableSetAssignmentUpdate(ctx context.Context, d *schema.Resource
 
 	// In API but not in Schema - delete.
 	for _, apiConfigurationSet := range apiConfigurationSets {
-		if !strings.EqualFold(apiConfigurationSet.AssignmentScope, assignmentSchema.Scope) {
+		if apiConfigurationSet.AssignmentScopeId != assignmentSchema.ScopeId {
 			continue
 		}
 

--- a/env0/resource_variable_set_assignment_test.go
+++ b/env0/resource_variable_set_assignment_test.go
@@ -61,6 +61,11 @@ func TestUnitVariableSetAssignmentResource(t *testing.T) {
 				AssignmentScope:   scope,
 				AssignmentScopeId: scopeId,
 			},
+			{
+				Id:                "a1111",
+				AssignmentScope:   scope,
+				AssignmentScopeId: "some other scope id",
+			},
 		}
 
 		testCase := resource.TestCase{


### PR DESCRIPTION
…able sets: 404 Not Found: Configuration Set "..." is not assigned to project.

### Issue & Steps to Reproduce / Feature Request
fixes #966 

### Solution

Modified the filter to check scopeId instead of scope.
