### PR TITLE
Fix: the integration test environment-without-template-start-with-no-…

### DIFF
--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -204,7 +204,7 @@ resource "env0_environment" "environment-without-template-start-with-no-vcs" {
     token_id         = data.env0_template.gitlab_template.token_id
     token_name       = data.env0_template.gitlab_template.token_name
     opentofu_version = "latest"
-    path             = "misc/null-resource"
+    path             = "null-resource"
   }
 }
 


### PR DESCRIPTION
…vcs is missing a path

### Issue & Steps to Reproduce / Feature Request
fixes #969 

### Solution

Added a path to the resource `environment-without-template-start-with-no-vcs`
