### PR TITLE
fix: integration tests templates must enforce terraform_tf_binary

### DIFF
--- a/tests/integration/004_template/main.tf
+++ b/tests/integration/004_template/main.tf
@@ -49,12 +49,13 @@ resource "env0_template" "gitlab_template" {
 }
 
 resource "env0_template" "template_tg" {
-  name               = "Template for environment resource - tg-${random_string.random.result}"
-  type               = "terragrunt"
-  repository         = "https://github.com/env0/templates"
-  path               = "terragrunt/misc/null-resource"
-  terraform_version  = "0.15.1"
-  terragrunt_version = "0.35.0"
+  name                 = "Template for environment resource - tg-${random_string.random.result}"
+  type                 = "terragrunt"
+  repository           = "https://github.com/env0/templates"
+  path                 = "terragrunt/misc/null-resource"
+  terragrunt_tf_binary = "terraform"
+  terraform_version    = "0.15.1"
+  terragrunt_version   = "0.35.0"
 }
 
 resource "env0_template" "template_opentofu" {

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -122,12 +122,13 @@ resource "env0_environment_state_access" "disallow" {
 */
 
 resource "env0_template" "terragrunt_template" {
-  name               = "Terragrunt template for environment resource-${random_string.random.result}"
-  type               = "terragrunt"
-  repository         = "https://github.com/env0/templates"
-  path               = "misc/null-resource"
-  terraform_version  = "0.15.1"
-  terragrunt_version = "0.35.0"
+  name                 = "Terragrunt template for environment resource-${random_string.random.result}"
+  type                 = "terragrunt"
+  repository           = "https://github.com/env0/templates"
+  path                 = "misc/null-resource"
+  terragrunt_tf_binary = "terraform"
+  terraform_version    = "0.15.1"
+  terragrunt_version   = "0.35.0"
 }
 
 resource "env0_template_project_assignment" "terragrunt_assignment" {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

A change on env0's API requires to enforce the `terraform_tf_binary` when `terraform_version` is specified.

Fixes #975

### Solution

Enforce `terraform_tf_binary`