### PR TITLE
Feat: resource env0_environment - add support to change template_id

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -176,7 +175,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"template_id": {
 				Type:         schema.TypeString,
-				Description:  "the template id the environment is to be created from.\nImportant note: the template must first be assigned to the same project as the environment (project_id). Use 'env0_template_project_assignment' to assign the template to the project. In addition, be sure to leverage 'depends_on' if applicable.\nImportant note: After the environment is created, this field cannot be modified.",
+				Description:  "the template id the environment is to be created from.\nImportant note: the template must first be assigned to the same project as the environment (project_id). Use 'env0_template_project_assignment' to assign the template to the project. In addition, be sure to leverage 'depends_on' if applicable",
 				Optional:     true,
 				ExactlyOneOf: []string{"without_template_settings", "template_id"},
 			},
@@ -382,13 +381,6 @@ func resourceEnvironment() *schema.Resource {
 				Optional:    true,
 			},
 		},
-		CustomizeDiff: customdiff.ValidateChange("template_id", func(ctx context.Context, oldValue, newValue, meta interface{}) error {
-			if oldValue != "" && oldValue != newValue {
-				return errors.New("template_id may not be modified, create a new environment instead")
-			}
-
-			return nil
-		}),
 	}
 }
 
@@ -736,7 +728,7 @@ func shouldDeploy(d *schema.ResourceData) bool {
 		}
 	}
 
-	return d.HasChanges("revision", "configuration", "sub_environment_configuration", "variable_sets")
+	return d.HasChanges("revision", "configuration", "sub_environment_configuration", "variable_sets", "template_id")
 }
 
 func shouldUpdate(d *schema.ResourceData) bool {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -175,7 +175,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"template_id": {
 				Type:         schema.TypeString,
-				Description:  "the template id the environment is to be created from.\nImportant note: the template must first be assigned to the same project as the environment (project_id). Use 'env0_template_project_assignment' to assign the template to the project. In addition, be sure to leverage 'depends_on' if applicable",
+				Description:  "the template id the environment is to be created from.\nImportant note: the template must first be assigned to the same project as the environment (project_id). Use 'env0_template_project_assignment' to assign the template to the project. In addition, be sure to leverage 'depends_on' if applicable. Please note that changing this attribute will require environment redeploy",
 				Optional:     true,
 				ExactlyOneOf: []string{"without_template_settings", "template_id"},
 			},

--- a/tests/integration/012_environment/main.tf
+++ b/tests/integration/012_environment/main.tf
@@ -29,6 +29,15 @@ resource "env0_template" "template" {
   terraform_version      = "0.15.1"
 }
 
+resource "env0_template" "template2" {
+  repository             = data.env0_template.github_template_for_environment.repository
+  github_installation_id = data.env0_template.github_template_for_environment.github_installation_id
+  name                   = "Template for environment resource 2-${random_string.random.result}"
+  type                   = "terraform"
+  path                   = "misc/null-resource"
+  terraform_version      = "0.16.1"
+}
+
 resource "env0_template_project_assignment" "assignment" {
   template_id = env0_template.template.id
   project_id  = env0_project.test_project.id
@@ -76,6 +85,16 @@ resource "env0_environment" "move_environment" {
   template_id         = env0_template.template.id
   prevent_auto_deploy = true
 }
+
+resource "env0_environment" "modify_template" {
+  depends_on          = [env0_template_project_assignment.assignment]
+  force_destroy       = true
+  name                = "environment-modify-template-${random_string.random.result}"
+  project_id          = env0_project.test_project.id
+  template_id         = var.second_run ? env0_template.template2.id : env0_template.template.id
+  prevent_auto_deploy = true
+}
+
 
 resource "env0_custom_role" "custom_role1" {
   name = "custom-role-${random_string.random.result}"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #986 

### Solution

1. Removed the code that blocked modifying template_id from an environment.
2. Updated the schema description.
3. Will now run a redeploy if tempate_id is modified (I have verified that it's the same behavior as in env0 UI).
4. Updated acceptance tests.
5. Added a harness test.
