### PR TITLE
Feat: Environment Resource with properties from Project gets created …

### DIFF
--- a/client/environment.go
+++ b/client/environment.go
@@ -118,7 +118,7 @@ type Environment struct {
 	AutoDeployOnPathChangesOnly *bool         `json:"autoDeployOnPathChangesOnly,omitempty" tfschema:",omitempty"`
 	AutoDeployByCustomGlob      string        `json:"autoDeployByCustomGlob,omitempty"`
 	Status                      string        `json:"status"`
-	LifespanEndAt               string        `json:"lifespanEndAt" tfschema:"ttl"`
+	LifespanEndAt               string        `json:"lifespanEndAt" tfschema:"ttl,omitempty"`
 	LatestDeploymentLogId       string        `json:"latestDeploymentLogId" tfschema:"deployment_id"`
 	LatestDeploymentLog         DeploymentLog `json:"latestDeploymentLog"`
 	TerragruntWorkingDirectory  string        `json:"terragruntWorkingDirectory,omitempty"`

--- a/env0/data_environment.go
+++ b/env0/data_environment.go
@@ -150,6 +150,24 @@ func dataEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
+	// Set this explicitly because these are not set in setEnvironmentSchema due to possible project inheritance.
+
+	if environment.AutoDeployOnPathChangesOnly != nil {
+		d.Set("auto_deploy_on_path_changes_only", *environment.AutoDeployOnPathChangesOnly)
+	}
+
+	if environment.ContinuousDeployment != nil {
+		d.Set("deploy_on_push", *environment.ContinuousDeployment)
+	}
+
+	if environment.PullRequestPlanDeployments != nil {
+		d.Set("run_plan_on_pull_requests", *environment.PullRequestPlanDeployments)
+	}
+
+	if environment.LifespanEndAt != "" {
+		d.Set("ttl", environment.LifespanEndAt)
+	}
+
 	subEnvironments := []interface{}{}
 
 	if environment.LatestDeploymentLog.WorkflowFile != nil {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -386,7 +386,6 @@ func resourceEnvironment() *schema.Resource {
 
 func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, configurationVariables client.ConfigurationChanges, variableSetsIds []string) error {
 	// Some of the fields can be inherited from the project. Ignore them if not explicitly set.
-
 	//nolint:staticcheck // https://github.com/hashicorp/terraform-plugin-sdk/issues/817
 	if _, exists := d.GetOkExists("auto_deploy_on_path_changes_only"); !exists {
 		environment.AutoDeployOnPathChangesOnly = nil

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -655,14 +655,6 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("could not get environment: %v", err)
 	}
 
-	// _, exists := d.GetOkExists("auto_deploy_on_path_changes_only"
-	// return diag.Errorf("!!!!!! ", environment.AutoDeployOnPathChangesOnly, " ????? ")
-
-	// //nolint:staticcheck // https://github.com/hashicorp/terraform-plugin-sdk/issues/817
-	// if _, exists := d.GetOkExists("auto_deploy_on_path_changes_only"); !exists {
-	// 	environment.AutoDeployOnPathChangesOnly = nil
-	// }
-
 	scope := client.ScopeEnvironment
 	if _, ok := d.GetOk("sub_environment_configuration"); ok {
 		scope = client.ScopeWorkflow


### PR DESCRIPTION
…with a drift

### Issue & Steps to Reproduce / Feature Request
resolves #1014 

### Solution

This was not a straightforward solution.
I ignore the fields if they're not set in the environment schema.
This required some manual fixing in the environment data source.

It's not a perfect solution. But I believe there's no better way to resolve it.