### PR TITLE
Feat: Make sub_environment_configuration not require the revision field

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -319,7 +319,7 @@ func resourceEnvironment() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "sub environment revision",
 							Optional:    true,
-							Deprecated:  "this field is depreacted and no longer used, will be removed in the future",
+							Deprecated:  "this field is deprecated and no longer used, will be removed in the future",
 						},
 						"workspace": {
 							Type:        schema.TypeString,

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -318,7 +318,8 @@ func resourceEnvironment() *schema.Resource {
 						"revision": {
 							Type:        schema.TypeString,
 							Description: "sub environment revision",
-							Required:    true,
+							Optional:    true,
+							Deprecated:  "this field is depreacted and no longer used, will be removed in the future",
 						},
 						"workspace": {
 							Type:        schema.TypeString,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
resolves #1025 

### Solution

Marked the field in the schema as deprecated and optional. Also added a note to remove it in one of the future versions.
