### PR TITLE
Feature: resource and data for gcp_cloud_configuration

### DIFF
--- a/client/cloud_account.go
+++ b/client/cloud_account.go
@@ -27,6 +27,11 @@ type AzureCloudAccountConfiguration struct {
 	LogAnalyticsWorkspaceId string `json:"logAnalyticsWorkspaceId"`
 }
 
+type GCPCloudAccountConfiguration struct {
+	GcpProjectId                       string `json:"gcpProjectId"`
+	CredentialConfigurationFileContent string `json:"credentialConfigurationFileContent"`
+}
+
 type CloudAccount struct {
 	Id            string `json:"id"`
 	Provider      string `json:"provider"`

--- a/env0/cloud_configuration.go
+++ b/env0/cloud_configuration.go
@@ -21,6 +21,8 @@ func getCloudConfigurationFromSchema(d *schema.ResourceData, provider string) (a
 		configuration = &client.AWSCloudAccountConfiguration{}
 	case "AzureLAW":
 		configuration = &client.AzureCloudAccountConfiguration{}
+	case "GCP":
+		configuration = &client.GCPCloudAccountConfiguration{}
 	default:
 		return nil, fmt.Errorf("unhandled provider: %s", provider)
 	}

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -121,6 +121,7 @@ func Provider(version string) plugin.ProviderFunc {
 				"env0_gcp_cost_credentials":                      resourceCostCredentials("google"),
 				"env0_gcp_credentials":                           resourceGcpCredentials(),
 				"env0_gcp_oidc_credentials":                      resourceGcpOidcCredentials(),
+				"env0_gcp_cloud_configuration":                   resourceGcpCloudConfiguration(),
 				"env0_vault_oidc_credentials":                    resourceVaultOidcCredentials(),
 				"env0_oci_credentials":                           resourceOciCredentials(),
 				"env0_template_project_assignment":               resourceTemplateProjectAssignment(),

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -121,7 +121,6 @@ func Provider(version string) plugin.ProviderFunc {
 				"env0_gcp_cost_credentials":                      resourceCostCredentials("google"),
 				"env0_gcp_credentials":                           resourceGcpCredentials(),
 				"env0_gcp_oidc_credentials":                      resourceGcpOidcCredentials(),
-				"env0_gcp_cloud_configuration":                   resourceGcpCloudConfiguration(),
 				"env0_vault_oidc_credentials":                    resourceVaultOidcCredentials(),
 				"env0_oci_credentials":                           resourceOciCredentials(),
 				"env0_template_project_assignment":               resourceTemplateProjectAssignment(),
@@ -166,6 +165,7 @@ func Provider(version string) plugin.ProviderFunc {
 				"env0_environment_output_configuration_variable": resourceEnvironmentOutputConfigurationVariable(),
 				"env0_aws_cloud_configuration":                   resourceAwsCloudConfiguration(),
 				"env0_azure_cloud_configuration":                 resourceAzureCloudConfiguration(),
+				"env0_gcp_cloud_configuration":                   resourceGcpCloudConfiguration(),
 				"env0_vcs_connection":                            resourceVcsConnection(),
 			},
 		}

--- a/env0/resource_gcp_cloud_configuration.go
+++ b/env0/resource_gcp_cloud_configuration.go
@@ -1,0 +1,52 @@
+package env0
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceGcpCloudConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGcpCloudConfigurationCreate,
+		UpdateContext: resourceGcpCloudConfigurationUpdate,
+		ReadContext:   readCloudConfiguration,
+		DeleteContext: deleteCloudConfiguration,
+
+		Importer: &schema.ResourceImporter{StateContext: importCloudConfiguration},
+
+		Description: "configure a GCP cloud account (Cloud Compass)",
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "name for the cloud configuration for insights",
+				Required:    true,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Description: "the GCP project ID",
+				Required:    true,
+			},
+			"json_configuration_file_content": {
+				Type:        schema.TypeString,
+				Description: "the JSON configuration file content containing the service account key",
+				Required:    true,
+			},
+			"health": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "an indicator if the configuration is valid",
+			},
+		},
+	}
+}
+
+func resourceGcpCloudConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	return createCloudConfiguration(d, meta, "GCP")
+}
+
+func resourceGcpCloudConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	return updateCloudConfiguration(d, meta, "GCP")
+}

--- a/env0/resource_gcp_cloud_configuration.go
+++ b/env0/resource_gcp_cloud_configuration.go
@@ -29,7 +29,7 @@ func resourceGcpCloudConfiguration() *schema.Resource {
 				Description: "the GCP project ID",
 				Required:    true,
 			},
-			"json_configuration_file_content": {
+			"credential_configuration_file_content": {
 				Type:        schema.TypeString,
 				Description: "the JSON configuration file content containing the service account key",
 				Required:    true,

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -1,0 +1,92 @@
+package env0
+
+import (
+	"testing"
+
+	"github.com/env0/terraform-provider-env0/client"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUnitGcpCloudConfigurationResource(t *testing.T) {
+	resourceType := "env0_gcp_cloud_configuration"
+	resourceName := "test"
+	accessor := resourceAccessor(resourceType, resourceName)
+
+	gcpConfig := client.GCPCloudAccountConfiguration{
+		GcpProjectId:                       "test-project-123",
+		CredentialConfigurationFileContent: "test-credentials-json",
+	}
+
+	updatedGcpConfig := client.GCPCloudAccountConfiguration{
+		GcpProjectId:                       "test-project-456",
+		CredentialConfigurationFileContent: "updated-test-credentials-json",
+	}
+
+	cloudConfig := client.CloudAccount{
+		Id:            uuid.NewString(),
+		Provider:      "GCP",
+		Name:          "name1",
+		Health:        false,
+		Configuration: &gcpConfig,
+	}
+
+	updatedCloudConfig := cloudConfig
+	updatedCloudConfig.Name = "name2"
+	updatedCloudConfig.Configuration = &updatedGcpConfig
+	updatedCloudConfig.Health = true
+
+	createPayload := client.CloudAccountCreatePayload{
+		Name:          cloudConfig.Name,
+		Provider:      "GCP",
+		Configuration: &gcpConfig,
+	}
+
+	updatePayload := client.CloudAccountUpdatePayload{
+		Name:          updatedCloudConfig.Name,
+		Configuration: &updatedGcpConfig,
+	}
+
+	getFields := func(cloudConfig *client.CloudAccount) map[string]any {
+		gcpConfig := cloudConfig.Configuration.(*client.GCPCloudAccountConfiguration)
+		return map[string]any{
+			"name":                            cloudConfig.Name,
+			"project_id":                      gcpConfig.GcpProjectId,
+			"json_configuration_file_content": gcpConfig.CredentialConfigurationFileContent,
+		}
+	}
+
+	t.Run("create and update", func(t *testing.T) {
+		runUnitTest(t, resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, getFields(&cloudConfig)),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "name", cloudConfig.Name),
+						resource.TestCheckResourceAttr(accessor, "project_id", gcpConfig.GcpProjectId),
+						resource.TestCheckResourceAttr(accessor, "json_configuration_file_content", gcpConfig.CredentialConfigurationFileContent),
+						resource.TestCheckResourceAttr(accessor, "health", "false"),
+					),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, getFields(&updatedCloudConfig)),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "name", updatedCloudConfig.Name),
+						resource.TestCheckResourceAttr(accessor, "project_id", updatedGcpConfig.GcpProjectId),
+						resource.TestCheckResourceAttr(accessor, "json_configuration_file_content", updatedGcpConfig.CredentialConfigurationFileContent),
+						resource.TestCheckResourceAttr(accessor, "health", "true"),
+					),
+				},
+			},
+		}, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				mock.EXPECT().CloudAccountCreate(&createPayload).Times(1).Return(&cloudConfig, nil),
+				mock.EXPECT().CloudAccount(cloudConfig.Id).Times(2).Return(&cloudConfig, nil),
+				mock.EXPECT().CloudAccountUpdate(cloudConfig.Id, &updatePayload).Times(1).Return(&updatedCloudConfig, nil),
+				mock.EXPECT().CloudAccount(updatedCloudConfig.Id).Times(1).Return(&updatedCloudConfig, nil),
+				mock.EXPECT().CloudAccountDelete(updatedCloudConfig.Id).Times(1).Return(nil),
+			)
+		})
+	})
+}

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -39,6 +39,7 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 
 	getFields := func(cloudConfig *client.CloudAccount) map[string]any {
 		gcpConfig := cloudConfig.Configuration.(*client.GCPCloudAccountConfiguration)
+
 		return map[string]any{
 			"name":                            cloudConfig.Name,
 			"project_id":                      gcpConfig.GcpProjectId,

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -97,9 +97,11 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 			mock.EXPECT().CloudAccountCreate(gomock.Any()).DoAndReturn(func(actual interface{}) (*client.CloudAccount, error) {
 				fmt.Fprintf(os.Stderr, "[DEBUG] Expected: %#v\n", &createPayload)
 				fmt.Fprintf(os.Stderr, "[DEBUG] Actual:   %#v\n", actual)
+
 				if !reflect.DeepEqual(actual, &createPayload) {
 					fmt.Fprintf(os.Stderr, "[MISMATCH] Arguments are not deeply equal!\n")
 				}
+
 				return &cloudConfig, nil
 			})
 

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -3,6 +3,8 @@ package env0
 import (
 	"errors"
 	"fmt"
+	"os"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -92,8 +94,16 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 		}
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().CloudAccountCreate(gomock.Any()).DoAndReturn(func(actual interface{}) (*client.CloudAccount, error) {
+				fmt.Fprintf(os.Stderr, "[DEBUG] Expected: %#v\n", &createPayload)
+				fmt.Fprintf(os.Stderr, "[DEBUG] Actual:   %#v\n", actual)
+				if !reflect.DeepEqual(actual, &createPayload) {
+					fmt.Fprintf(os.Stderr, "[MISMATCH] Arguments are not deeply equal!\n")
+				}
+				return &cloudConfig, nil
+			})
+
 			gomock.InOrder(
-				mock.EXPECT().CloudAccountCreate(&createPayload).Times(1).Return(&cloudConfig, nil),
 				mock.EXPECT().CloudAccount(cloudConfig.Id).Times(1).Return(&cloudConfig, nil),
 				mock.EXPECT().CloudAccounts().Times(1).Return([]client.CloudAccount{otherCloudConfig, cloudConfig}, nil),
 				mock.EXPECT().CloudAccount(cloudConfig.Id).Times(1).Return(&cloudConfig, nil),

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -19,8 +19,17 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 	resourceNameImport := resourceType + "." + resourceName
 
 	gcpConfig := client.GCPCloudAccountConfiguration{
-		GcpProjectId:                       "test-project-123",
-		CredentialConfigurationFileContent: "test-credentials-json",
+		GcpProjectId: "test-project-123",
+		CredentialConfigurationFileContent: `{
+  "audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider",
+  "credential_source": {
+    "file": "file.json",
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "access_token"
+    }
+  }
+}`,
 	}
 
 	cloudConfig := client.CloudAccount{

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -41,12 +41,9 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 		gcpConfig := cloudConfig.Configuration.(*client.GCPCloudAccountConfiguration)
 
 		return map[string]any{
-			"name":       cloudConfig.Name,
-			"project_id": gcpConfig.GcpProjectId,
-			"json_configuration_file_content": fmt.Sprintf(`<<EOF
-%s
-EOF
-`, gcpConfig.CredentialConfigurationFileContent),
+			"name":                                  cloudConfig.Name,
+			"project_id":                            gcpConfig.GcpProjectId,
+			"credential_configuration_file_content": gcpConfig.CredentialConfigurationFileContent,
 		}
 	}
 

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -19,17 +19,8 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 	resourceNameImport := resourceType + "." + resourceName
 
 	gcpConfig := client.GCPCloudAccountConfiguration{
-		GcpProjectId: "test-project-123",
-		CredentialConfigurationFileContent: `{
-  "audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider",
-  "credential_source": {
-    "file": "file.json",
-    "format": {
-      "type": "json",
-      "subject_token_field_name": "access_token"
-    }
-  }
-}`,
+		GcpProjectId:                       "test-project-123",
+		CredentialConfigurationFileContent: "{}",
 	}
 
 	cloudConfig := client.CloudAccount{

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -19,8 +19,17 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 	resourceNameImport := resourceType + "." + resourceName
 
 	gcpConfig := client.GCPCloudAccountConfiguration{
-		GcpProjectId:                       "test-project-123",
-		CredentialConfigurationFileContent: `{"audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider","credential_source": {"file": "file.json","format": {"type": "json","subject_token_field_name": "access_token"}}}`,
+		GcpProjectId: "test-project-123",
+		CredentialConfigurationFileContent: `{
+  "audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider",
+  "credential_source": {
+    "file": "file.json",
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "access_token"
+    }
+  }
+}`,
 	}
 
 	cloudConfig := client.CloudAccount{
@@ -43,7 +52,7 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 		return map[string]any{
 			"name":                            cloudConfig.Name,
 			"project_id":                      gcpConfig.GcpProjectId,
-			"json_configuration_file_content": gcpConfig.CredentialConfigurationFileContent,
+			"json_configuration_file_content": fmt.Sprintf(`<<EOF\n%s\nEOF\n`, gcpConfig.CredentialConfigurationFileContent),
 		}
 	}
 

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -50,9 +50,12 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 		gcpConfig := cloudConfig.Configuration.(*client.GCPCloudAccountConfiguration)
 
 		return map[string]any{
-			"name":                            cloudConfig.Name,
-			"project_id":                      gcpConfig.GcpProjectId,
-			"json_configuration_file_content": fmt.Sprintf(`<<EOF\n%s\nEOF\n`, gcpConfig.CredentialConfigurationFileContent),
+			"name":       cloudConfig.Name,
+			"project_id": gcpConfig.GcpProjectId,
+			"json_configuration_file_content": fmt.Sprintf(`<<EOF
+%s
+EOF
+`, gcpConfig.CredentialConfigurationFileContent),
 		}
 	}
 

--- a/env0/resource_gcp_cloud_configuration_test.go
+++ b/env0/resource_gcp_cloud_configuration_test.go
@@ -19,17 +19,8 @@ func TestUnitGcpCloudConfigurationResource(t *testing.T) {
 	resourceNameImport := resourceType + "." + resourceName
 
 	gcpConfig := client.GCPCloudAccountConfiguration{
-		GcpProjectId: "test-project-123",
-		CredentialConfigurationFileContent: `{
-  "audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider",
-  "credential_source": {
-    "file": "file.json",
-    "format": {
-      "type": "json",
-      "subject_token_field_name": "access_token"
-    }
-  }
-}`,
+		GcpProjectId:                       "test-project-123",
+		CredentialConfigurationFileContent: `{"audience": "//iam.googleapis.com/projects/578187717855/locations/global/workloadIdentityPools/cloudcompass-wif-pool/providers/cloudcompass-oidc-provider","credential_source": {"file": "file.json","format": {"type": "json","subject_token_field_name": "access_token"}}}`,
 	}
 
 	cloudConfig := client.CloudAccount{


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
This PR introduces the initial implementation and tests for the `resource_gcp_cloud_configuration` resource.
It addresses the need to manage GCP cloud configurations through the env0 Terraform provider, allowing users to define, create, and test GCP cloud configuration resources via infrastructure as code.

### Solution
* Implemented the `resource_gcp_cloud_configuration.go` file with the necessary CRUD logic for the GCP cloud configuration resource.
* Added comprehensive tests in `resource_gcp_cloud_configuration_test.go` to cover resource creation, update, and deletion.
* Created a new integration test scenario (039_gcp_cloud_configurations) with relevant Terraform configuration and expected outputs to validate the resource end-to-end.