### PR TITLE
Fix: sub environment configuration handle remote drift

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -699,7 +699,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 		return diag.FromErr(err)
 	}
 
-	if err := setSubEnvironmentSchema(ctx, d, environment, apiClient); err != nil {
+	if err := setSubEnvironmentSchema(d, apiClient); err != nil {
 		return diag.Errorf("could not set sub environment schema: %v", err)
 	}
 
@@ -720,7 +720,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 	return nil
 }
 
-func setSubEnvironmentSchema(_ context.Context, d *schema.ResourceData, _ client.Environment, apiClient client.ApiClientInterface) any {
+func setSubEnvironmentSchema(d *schema.ResourceData, apiClient client.ApiClientInterface) any {
 	iSubEnvironments, ok := d.GetOk("sub_environment_configuration")
 
 	if !ok {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -720,25 +720,25 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 	return nil
 }
 
-func setSubEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environment client.Environment, apiClient client.ApiClientInterface) any {
+func setSubEnvironmentSchema(_ context.Context, d *schema.ResourceData, _ client.Environment, apiClient client.ApiClientInterface) any {
 	iSubEnvironments, ok := d.GetOk("sub_environment_configuration")
 
 	if !ok {
 		return nil
 	}
 
-	var newSubEnvironments []any
+	subEnvironmentsList := iSubEnvironments.([]any)
+	newSubEnvironments := make([]any, 0, len(subEnvironmentsList))
 
-	for _, iSubEnvironment := range iSubEnvironments.([]any) {
+	for _, iSubEnvironment := range subEnvironmentsList {
 		subEnvironment := iSubEnvironment.(map[string]any)
 
-		var environmentConfigurationVariables client.ConfigurationChanges
 		environmentConfigurationVariables, err := apiClient.ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironment["id"].(string))
 		if err != nil {
 			return fmt.Errorf("could not fetch environment configuration variables for sub environment %s: %w", subEnvironment["id"].(string), err)
 		}
 
-		var newConfiguration []any
+		newConfiguration := make([]any, 0, len(environmentConfigurationVariables))
 
 		for _, variable := range environmentConfigurationVariables {
 			newConfiguration = append(newConfiguration, createVariable(&variable))

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -3376,38 +3376,38 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 		}
 
 		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
-            gomock.InOrder(
-                mock.EXPECT().Template(environmentCreatePayload.DeployRequest.BlueprintId).Times(1).Return(template, nil),
-                mock.EXPECT().EnvironmentCreate(environmentCreatePayload).Times(1).Return(environment, nil),
+			gomock.InOrder(
+				mock.EXPECT().Template(environmentCreatePayload.DeployRequest.BlueprintId).Times(1).Return(template, nil),
+				mock.EXPECT().EnvironmentCreate(environmentCreatePayload).Times(1).Return(environment, nil),
 
-                // Read after create
-                mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-                mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
+				// Read after create
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
 
-                // Read before update
-                mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-                mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
+				// Read before update
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
 
-                // Deploy on update
-                mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
-                mock.EXPECT().EnvironmentDeploy(environment.Id, deployRequest).Times(1).Return(client.EnvironmentDeployResponse{
-                    Id: environment.Id,
-                }, nil),
+				// Deploy on update
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(subEnvironment.Configuration, nil),
+				mock.EXPECT().EnvironmentDeploy(environment.Id, deployRequest).Times(1).Return(client.EnvironmentDeployResponse{
+					Id: environment.Id,
+				}, nil),
 
-                // Read after update
-                mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
-                mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
-                mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(updatedSubEnvironment.Configuration, nil),
+				// Read after update
+				mock.EXPECT().Environment(environment.Id).Times(1).Return(environment, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, environment.Id).Times(1).Return(client.ConfigurationChanges{configurationVariable}, nil),
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).Times(1).Return(nil, nil),
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironmentWithId.Id).Times(1).Return(updatedSubEnvironment.Configuration, nil),
 
-                // Destroy
-                mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
-            )
+				// Destroy
+				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
+			)
 		})
 	})
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)

Fix https://github.com/env0/terraform-provider-env0/issues/1074

### Solution

Refresh the sub envs variables part of read

<img width="601" height="699" alt="image" src="https://github.com/user-attachments/assets/76116998-fbd5-483b-9c8d-0cdfc1e38a61" />

