### PR TITLE
Fix: env0_api_key resource does not assign user key permissions

### DIFF
--- a/client/api_key.go
+++ b/client/api_key.go
@@ -20,7 +20,7 @@ type ProjectPermission struct {
 
 type ApiKeyPermissions struct {
 	OrganizationRole   string              `json:"organizationRole"`
-	ProjectPermissions []ProjectPermission `json:"projectPermissions,omitempty"`
+	ProjectPermissions []ProjectPermission `json:"projectsPermissions,omitempty"`
 }
 
 type ApiKeyCreatePayload struct {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
[//]: <> (choose “resolves” “fixes” or “closes” and put link for the issue)
If you follow our docs the provider does create the API key, but without project permissions

### Solution
Fix the JSON serialization

### QA
Built locally and ran this snippet and saw we assign correct permissions to the API Key
```
terraform {
  required_providers {
    env0 = {
      version = "6.6.6"
      source  = "terraform.env0.com/local/env0"
    }
  }
}

provider "env0" {
  api_key         = ""
  api_secret      = ""
  organization_id = ""

}

resource "env0_api_key" "combined_key" {
  name              = "Should-have-project-permissions"
  organization_role = "User"

  project_permissions {
    project_id   = ""
    project_role = "Viewer"
  }
}
```

