### PR TITLE
Fix: update custom_role permissions docs URL

### DIFF
--- a/docs/resources/custom_role.md
+++ b/docs/resources/custom_role.md
@@ -28,7 +28,7 @@ resource "env0_custom_role" "custom_role_example" {
 ### Required
 
 - `name` (String) The name of the custom role
-- `permissions` (List of String) The list of permissions assigned to the role. The allowed values are available within the 'permissions' attribute at this URL: https://docs.env0.com/reference/roles-create
+- `permissions` (List of String) The list of permissions assigned to the role. The allowed values are available within the 'permissions' attribute at this URL: https://docs.envzero.com/api-reference/roles/create-a-role#create-a-role
 
 ### Optional
 

--- a/env0/resource_custom_role.go
+++ b/env0/resource_custom_role.go
@@ -28,7 +28,7 @@ func resourceCustomRole() *schema.Resource {
 			},
 			"permissions": {
 				Type:        schema.TypeList,
-				Description: "The list of permissions assigned to the role. The allowed values are available within the 'permissions' attribute at this URL: https://docs.env0.com/reference/roles-create",
+				Description: "The list of permissions assigned to the role. The allowed values are available within the 'permissions' attribute at this URL: https://docs.envzero.com/api-reference/roles/create-a-role#create-a-role",
 				Required:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

The `env0_custom_role` resource documentation contains a broken link for the permissions reference.

**Old URL:** https://docs.env0.com/reference/roles-create (no longer valid)
**New URL:** https://docs.envzero.com/api-reference/roles/create-a-role#create-a-role

### Solution

Updated the URL in:
- `env0/resource_custom_role.go` (schema description)
- `docs/resources/custom_role.md` (generated docs)