### PR TITLE
Fix Docs CI by installing Terraform CLI in the workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Update generated docs
         run: ./generate-docs.sh
       - name: Commit changes


### PR DESCRIPTION
## Summary

- `tfplugindocs` (invoked by `./generate-docs.sh`) uses the Terraform binary from PATH if available, otherwise downloads it and verifies the checksums signature against a bundled HashiCorp GPG key
- That key expired on 2026-04-18 (HCSEC-2026-03), so every push to main since then has failed the Docs workflow with `unable to verify checksums signature: openpgp: key expired`
- Adding `hashicorp/setup-terraform` makes Terraform available in PATH so `tfplugindocs` skips the download path entirely — matching how `generate-docs.sh` runs locally

## Test plan

- [ ] Docs workflow runs successfully on push to main after merge (cannot test on PR — the workflow only triggers on `push: main`)
- [ ] No regression in other workflows (this change is workflow-only and isolated to `docs.yml`)