### PR TITLE
Fix: Docs CI by installing Terraform CLI in the workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ env.GO_VERSION }}"
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Update generated docs
         run: ./generate-docs.sh
       - name: Commit changes


### PR DESCRIPTION
### Issue
tfplugindocs uses the Terraform binary from PATH if available, otherwise downloads it and verifies the signature against a bundled HashiCorp GPG key that expired on 2026-04-18 (HCSEC-2026-03). The download path has been failing on every push to main since the expiry.

### Solution
Installing Terraform via hashicorp/setup-terraform makes tfplugindocs pick it up from PATH and skip the download/verify entirely — matching how generate-docs.sh runs locally.

### QA

Reproduced the CI failure and validated the fix locally by running `./generate-docs.sh` against a restricted `PATH` that simulates the GitHub Actions `ubuntu-24.04` runner (no Terraform pre-installed):

| Scenario | Result |
|---|---|
| `PATH` excludes `terraform` (current CI) | ❌ `Error executing command: unable to generate website: error exporting provider schema from Terraform: unable to download Terraform binary: unable to verify checksums signature: openpgp: key expired` — exact CI failure reproduced |
| `PATH` includes `terraform` (post-fix CI with `setup-terraform`) | ✅ all templates render, exit 0 |

### References

- HCSEC-2026-03 — HashiCorp signing key expiry: [hc-install#370](https://github.com/hashicorp/hc-install/issues/370)
- Same failure mode reported in [terraform-plugin-testing#647](https://github.com/hashicorp/terraform-plugin-testing/issues/647)
- Official upstream fix in [terraform-plugin-docs v0.25.0](https://github.com/hashicorp/terraform-plugin-docs/releases/tag/v0.25.0) (bumps `hc-install` to v0.9.4 with the renewed key) — an alternative path to this fix if we'd rather upgrade the dep than ensure Terraform-in-PATH
