### PR TITLE
Fix: prevent perpetual drift in sub-environment configuration blocks

### DIFF
--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -728,9 +728,8 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 	return nil
 }
 
-func setSubEnvironmentSchema(d *schema.ResourceData, apiClient client.ApiClientInterface) any {
+func setSubEnvironmentSchema(d *schema.ResourceData, apiClient client.ApiClientInterface) error {
 	iSubEnvironments, ok := d.GetOk("sub_environment_configuration")
-
 	if !ok {
 		return nil
 	}
@@ -741,25 +740,73 @@ func setSubEnvironmentSchema(d *schema.ResourceData, apiClient client.ApiClientI
 	for _, iSubEnvironment := range subEnvironmentsList {
 		subEnvironment := iSubEnvironment.(map[string]any)
 
-		environmentConfigurationVariables, err := apiClient.ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvironment["id"].(string))
+		subEnvId, _ := subEnvironment["id"].(string)
+		if subEnvId == "" {
+			newSubEnvironments = append(newSubEnvironments, subEnvironment)
+			continue
+		}
+
+		remoteVariables, err := apiClient.ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvId)
 		if err != nil {
-			return fmt.Errorf("could not fetch environment configuration variables for sub environment %s: %w", subEnvironment["id"].(string), err)
+			return fmt.Errorf("could not fetch environment configuration variables for sub environment %s: %w", subEnvId, err)
 		}
 
-		newConfiguration := make([]any, 0, len(environmentConfigurationVariables))
-
-		for _, variable := range environmentConfigurationVariables {
-			newConfiguration = append(newConfiguration, createVariable(&variable))
-		}
-
-		subEnvironment["configuration"] = newConfiguration
-
+		stateVariables, _ := subEnvironment["configuration"].([]any)
+		subEnvironment["configuration"] = mergeSubEnvironmentConfiguration(stateVariables, remoteVariables)
 		newSubEnvironments = append(newSubEnvironments, subEnvironment)
 	}
 
 	d.Set("sub_environment_configuration", newSubEnvironments)
 
 	return nil
+}
+
+// mergeSubEnvironmentConfiguration aligns state variable order to the schema (TF code) and
+// appends remote-only variables as drift. Sensitive variable values come back redacted from
+// the API, so the schema value is kept to avoid false drift; the API value is never compared.
+func mergeSubEnvironmentConfiguration(stateVariables []any, remoteVariables client.ConfigurationChanges) []any {
+	merged := make([]any, 0, len(stateVariables))
+
+	for _, ivariable := range stateVariables {
+		variable := ivariable.(map[string]any)
+		variableName := variable["name"].(string)
+
+		for i := range remoteVariables {
+			remote := &remoteVariables[i]
+			if remote.Name != variableName {
+				continue
+			}
+
+			newVariable := createVariable(remote).(map[string]any)
+
+			if remote.IsSensitive != nil && *remote.IsSensitive {
+				newVariable["value"] = variable["value"]
+			}
+
+			merged = append(merged, newVariable)
+
+			break
+		}
+	}
+
+	for i := range remoteVariables {
+		remote := &remoteVariables[i]
+
+		found := false
+
+		for _, ivariable := range stateVariables {
+			if ivariable.(map[string]any)["name"].(string) == remote.Name {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			merged = append(merged, createVariable(remote))
+		}
+	}
+
+	return merged
 }
 
 func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -761,15 +761,16 @@ func setSubEnvironmentSchema(d *schema.ResourceData, apiClient client.ApiClientI
 	return nil
 }
 
-// mergeSubEnvironmentConfiguration aligns state variable order to the schema (TF code) and
-// appends remote-only variables as drift. Sensitive variable values come back redacted from
-// the API, so the schema value is kept to avoid false drift; the API value is never compared.
+// API returns a redacted value for sensitive variables, so the schema value is kept.
+// Consequence: remote value edits on sensitive variables are not detected — comparing values
+// would reintroduce the perpetual drift this function exists to fix.
 func mergeSubEnvironmentConfiguration(stateVariables []any, remoteVariables client.ConfigurationChanges) []any {
 	merged := make([]any, 0, len(stateVariables))
 
 	for _, ivariable := range stateVariables {
 		variable := ivariable.(map[string]any)
 		variableName := variable["name"].(string)
+		schemaIsSensitive, _ := variable["is_sensitive"].(bool)
 
 		for i := range remoteVariables {
 			remote := &remoteVariables[i]
@@ -779,7 +780,8 @@ func mergeSubEnvironmentConfiguration(stateVariables []any, remoteVariables clie
 
 			newVariable := createVariable(remote).(map[string]any)
 
-			if remote.IsSensitive != nil && *remote.IsSensitive {
+			remoteIsSensitive := remote.IsSensitive != nil && *remote.IsSensitive
+			if remoteIsSensitive || schemaIsSensitive {
 				newVariable["value"] = variable["value"]
 			}
 
@@ -789,9 +791,7 @@ func mergeSubEnvironmentConfiguration(stateVariables []any, remoteVariables clie
 		}
 	}
 
-	for i := range remoteVariables {
-		remote := &remoteVariables[i]
-
+	for _, remote := range remoteVariables {
 		found := false
 
 		for _, ivariable := range stateVariables {
@@ -802,7 +802,7 @@ func mergeSubEnvironmentConfiguration(stateVariables []any, remoteVariables clie
 		}
 
 		if !found {
-			merged = append(merged, createVariable(remote))
+			merged = append(merged, createVariable(&remote))
 		}
 	}
 

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/env0/terraform-provider-env0/client/http"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"go.uber.org/mock/gomock"
 )
 
@@ -3700,6 +3701,22 @@ func TestMergeSubEnvironmentConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves schema value when schema marks sensitive but API does not", func(t *testing.T) {
+		state := []any{map[string]any{"name": "secret", "value": "real-secret", "is_sensitive": true}}
+		remote := client.ConfigurationChanges{remoteVar("secret", "stale-from-api", nil)}
+
+		merged := mergeSubEnvironmentConfiguration(state, remote)
+
+		if len(merged) != 1 {
+			t.Fatalf("expected 1 var, got %d", len(merged))
+		}
+
+		got := merged[0].(map[string]any)["value"]
+		if got != "real-secret" {
+			t.Fatalf("schema-sensitive value not preserved: got %q", got)
+		}
+	})
+
 	t.Run("appends remote-only vars as drift", func(t *testing.T) {
 		state := []any{stateVar("a", "av")}
 		remote := client.ConfigurationChanges{
@@ -3734,6 +3751,67 @@ func TestMergeSubEnvironmentConfiguration(t *testing.T) {
 
 		if merged[0].(map[string]any)["name"] != "a" {
 			t.Fatalf("expected only 'a' var, got %v", merged[0])
+		}
+	})
+}
+
+func TestSetSubEnvironmentSchema(t *testing.T) {
+	t.Run("skips API call when sub-env id is empty (initial deploy not yet propagated)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mock := client.NewMockApiClientInterface(ctrl)
+
+		d := schema.TestResourceDataRaw(t, resourceEnvironment().Schema, map[string]any{
+			"name":        "env",
+			"project_id":  "p",
+			"template_id": "t",
+			"sub_environment_configuration": []any{
+				map[string]any{
+					"alias": "rootService1",
+					"configuration": []any{
+						map[string]any{"name": "ALPHA", "value": "av"},
+					},
+				},
+			},
+		})
+
+		if err := setSubEnvironmentSchema(d, mock); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("propagates API errors as wrapped error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mock := client.NewMockApiClientInterface(ctrl)
+		mock.EXPECT().
+			ConfigurationVariablesByScope(client.ScopeEnvironment, "sub-1").
+			Return(nil, errors.New("boom"))
+
+		d := schema.TestResourceDataRaw(t, resourceEnvironment().Schema, map[string]any{
+			"name":        "env",
+			"project_id":  "p",
+			"template_id": "t",
+			"sub_environment_configuration": []any{
+				map[string]any{
+					"id":    "sub-1",
+					"alias": "rootService1",
+					"configuration": []any{
+						map[string]any{"name": "ALPHA", "value": "av"},
+					},
+				},
+			},
+		})
+
+		err := setSubEnvironmentSchema(d, mock)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "sub-1") || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("expected wrapped error mentioning sub-1 and boom, got %q", err.Error())
 		}
 	})
 }

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -3638,6 +3638,106 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 	})
 }
 
+func TestMergeSubEnvironmentConfiguration(t *testing.T) {
+	varType := client.ConfigurationVariableType(0)
+	trueVal := true
+
+	stateVar := func(name, value string) map[string]any {
+		return map[string]any{"name": name, "value": value}
+	}
+
+	remoteVar := func(name, value string, sensitive *bool) client.ConfigurationVariable {
+		return client.ConfigurationVariable{
+			Name:        name,
+			Value:       value,
+			Type:        &varType,
+			IsSensitive: sensitive,
+			Schema:      &client.ConfigurationVariableSchema{Type: "string"},
+		}
+	}
+
+	t.Run("preserves schema order when API returns reversed", func(t *testing.T) {
+		state := []any{stateVar("a", "av"), stateVar("b", "bv"), stateVar("c", "cv")}
+		remote := client.ConfigurationChanges{
+			remoteVar("c", "cv", nil),
+			remoteVar("b", "bv", nil),
+			remoteVar("a", "av", nil),
+		}
+
+		merged := mergeSubEnvironmentConfiguration(state, remote)
+
+		if len(merged) != 3 {
+			t.Fatalf("expected 3 vars, got %d", len(merged))
+		}
+
+		names := []string{
+			merged[0].(map[string]any)["name"].(string),
+			merged[1].(map[string]any)["name"].(string),
+			merged[2].(map[string]any)["name"].(string),
+		}
+		expected := []string{"a", "b", "c"}
+
+		for i, name := range names {
+			if name != expected[i] {
+				t.Fatalf("order mismatch at %d: got %q want %q", i, name, expected[i])
+			}
+		}
+	})
+
+	t.Run("preserves schema value for sensitive vars without comparing API value", func(t *testing.T) {
+		state := []any{stateVar("secret", "real-secret")}
+		remote := client.ConfigurationChanges{remoteVar("secret", "", &trueVal)}
+
+		merged := mergeSubEnvironmentConfiguration(state, remote)
+
+		if len(merged) != 1 {
+			t.Fatalf("expected 1 var, got %d", len(merged))
+		}
+
+		got := merged[0].(map[string]any)["value"]
+		if got != "real-secret" {
+			t.Fatalf("sensitive value not preserved: got %q", got)
+		}
+	})
+
+	t.Run("appends remote-only vars as drift", func(t *testing.T) {
+		state := []any{stateVar("a", "av")}
+		remote := client.ConfigurationChanges{
+			remoteVar("a", "av", nil),
+			remoteVar("b", "remote-only", nil),
+		}
+
+		merged := mergeSubEnvironmentConfiguration(state, remote)
+
+		if len(merged) != 2 {
+			t.Fatalf("expected 2 vars (incl drift), got %d", len(merged))
+		}
+
+		if merged[0].(map[string]any)["name"] != "a" {
+			t.Fatalf("expected schema var first, got %v", merged[0])
+		}
+
+		if merged[1].(map[string]any)["name"] != "b" {
+			t.Fatalf("expected drift var second, got %v", merged[1])
+		}
+	})
+
+	t.Run("schema var missing from API is dropped", func(t *testing.T) {
+		state := []any{stateVar("a", "av"), stateVar("gone", "v")}
+		remote := client.ConfigurationChanges{remoteVar("a", "av", nil)}
+
+		merged := mergeSubEnvironmentConfiguration(state, remote)
+
+		if len(merged) != 1 {
+			t.Fatalf("expected 1 var, got %d", len(merged))
+		}
+
+		if merged[0].(map[string]any)["name"] != "a" {
+			t.Fatalf("expected only 'a' var, got %v", merged[0])
+		}
+	})
+}
+
 func TestUnitEnvironmentIsRequiredDeprecated(t *testing.T) {
 	resourceType := "env0_environment"
 	resourceName := "test"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

`sub_environment_configuration.configuration` blocks show perpetual drift after `terraform apply`. The plan keeps re-adding the same changes, and applies never reach a converged state.

#### Minimal repro

```hcl
resource "env0_environment" "test" {
  name        = "drift-repro"
  project_id  = var.project_id
  template_id = var.workflow_template_id

  sub_environment_configuration {
    alias = var.sub_env_alias

    configuration {
      name         = "DB_PASSWORD"
      value        = "super-secret"
      is_sensitive = true
    }
  }
}
```

`terraform plan` immediately after a successful `terraform apply`:

```
~ sub_environment_configuration {
    ~ configuration {
        name  = "DB_PASSWORD"
      ~ value = "***************" -> "super-secret"
      }
  }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Running `apply` again produces the same diff on the next `plan`. State never converges.

### Solution

Refresh sub-environment configuration in schema order and keep the schema value for sensitive variables (the API returns a redacted value, which previously got written into state). Remote-only variables are still surfaced as drift, so the original UI-edit drift detection still works.

After the fix, `terraform plan` against the same state and same TF code:

```
No changes. Your infrastructure matches the configuration.
```

---
### How I _manually_ verified it works

- [x] Built local provider, repro'd perpetual drift on remote `env0/env0 v1.31.0` against a workflow env with multiple configuration blocks including a sensitive one
- [x] Swapped to local fixed build against the same state — `terraform plan` after `apply` reports `No changes`
- [x] Unit tests cover ordering, sensitive-value preservation, remote-only drift, and missing-from-API drop
