### PR TITLE
[ENG-1740] Fix: prevent false drift in env0_module vcs_connection_id

### DIFF
--- a/env0/resource_module.go
+++ b/env0/resource_module.go
@@ -217,10 +217,15 @@ func resourceModuleRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		return nil
 	}
 
-	_, vcsConnectionIdOk := d.GetOk("vcs_connection_id")
-	if vcsConnectionIdOk {
-		module.GithubInstallationId = nil
-	}
+	// Avoid drifts: the backend automatically populates VCS fields from one another.
+	suppressVcsFieldDrift("", VcsFields{
+		GithubInstallationId: module.GithubInstallationId,
+		VcsConnectionId:      module.VcsConnectionId,
+		BitbucketClientKey:   module.BitbucketClientKey,
+		TokenId:              &module.TokenId,
+		IsAzureDevOps:        &module.IsAzureDevOps,
+		IsGitlab:             &module.IsGitlab,
+	}, d)
 
 	if err := writeResourceData(module, d); err != nil {
 		return diag.Errorf("schema resource data serialization failed: %v", err)

--- a/env0/resource_module_test.go
+++ b/env0/resource_module_test.go
@@ -686,6 +686,61 @@ func TestUnitModuleResource(t *testing.T) {
 		})
 	})
 
+	t.Run("legacy VCS field ignores vcs_connection_id from backend to avoid drift", func(t *testing.T) {
+		legacyModule := client.Module{
+			ModuleName:     "legacy-module",
+			ModuleProvider: "provider1",
+			Repository:     "repository1",
+			TokenId:        "tokenid",
+			OrganizationId: "org1",
+			Author:         author,
+			AuthorId:       "author1",
+			Id:             uuid.NewString(),
+		}
+
+		legacyModuleFromBackend := client.Module{
+			ModuleName:      legacyModule.ModuleName,
+			ModuleProvider:  legacyModule.ModuleProvider,
+			Repository:      legacyModule.Repository,
+			TokenId:         legacyModule.TokenId,
+			VcsConnectionId: new("vcs-conn-123"),
+			OrganizationId:  legacyModule.OrganizationId,
+			Author:          legacyModule.Author,
+			AuthorId:        legacyModule.AuthorId,
+			Id:              legacyModule.Id,
+		}
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]any{
+						"module_name":     legacyModule.ModuleName,
+						"module_provider": legacyModule.ModuleProvider,
+						"repository":      legacyModule.Repository,
+						"token_id":        legacyModule.TokenId,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", legacyModule.Id),
+						resource.TestCheckResourceAttr(accessor, "module_name", legacyModule.ModuleName),
+						resource.TestCheckResourceAttr(accessor, "token_id", legacyModule.TokenId),
+						resource.TestCheckNoResourceAttr(accessor, "vcs_connection_id"),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
+				ModuleName:     legacyModule.ModuleName,
+				ModuleProvider: legacyModule.ModuleProvider,
+				Repository:     legacyModule.Repository,
+				TokenId:        legacyModule.TokenId,
+			}).Times(1).Return(&legacyModule, nil)
+			mock.EXPECT().Module(legacyModule.Id).Times(1).Return(&legacyModuleFromBackend, nil)
+			mock.EXPECT().ModuleDelete(legacyModule.Id).Times(1)
+		})
+	})
+
 	t.Run("vcs_connection_id and github_installation_id are mutually exclusive", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Fixes [ENG-1740](https://linear.app/env-zero/issue/ENG-1740/env0-module-shows-false-drift-vcs-connection-id-flagged-for-removal-on)

When an `env0_module` is configured with **legacy VCS fields only** (e.g. `token_id`, `is_gitlab`, `github_installation_id`) and no `vcs_connection_id`, the backend resolves and returns a populated `vcs_connection_id`. `resourceModuleRead` wrote that value straight into state, so on the next plan Terraform saw config (empty) ≠ state (populated) and proposed removing `vcs_connection_id` — a perpetual, spurious `UPDATE` on every plan.

Repro:
1. Define an `env0_module` using a legacy VCS field (e.g. `token_id`), no `vcs_connection_id` in config
2. `terraform apply` — succeeds
3. `terraform plan` with no config changes
4. Module is flagged for `UPDATE`, `vcs_connection_id` shown as removed

`env0_module` was the one resource missed by #1093, which added `suppressVcsFieldDrift` to `env0_template`, `env0_approval_policy`, `env0_custom_flow`, and `env0_environment_discovery_configuration`.

### Solution

Replaced the partial, one-direction handling in `resourceModuleRead` (which only zeroed `github_installation_id` when `vcs_connection_id` was set) with the shared `suppressVcsFieldDrift` helper, matching the four resources from #1093. When legacy fields are configured, the backend-returned `vcs_connection_id` is now zeroed before being written to state.

Note: unlike the other resources, `client.Module` uses **pointer** types (`*int`/`*string`) for `GithubInstallationId`, `VcsConnectionId`, and `BitbucketClientKey`. Those are passed to `VcsFields` directly (they're already pointers); the value-typed fields (`TokenId`, `IsAzureDevOps`, `IsGitlab`) are passed by address. The helper's existing `nil` guard makes nil module pointers safe — a nil pointer is already "zeroed" from the `omitempty` writer's perspective — so no helper change was needed.

### How I _manually_ verified it works

- [x] I verified it works
- [x] I verified I didn't break anything

- Added a regression unit test `legacy VCS field ignores vcs_connection_id from backend to avoid drift`: config sets `token_id`, the mocked backend returns a populated `vcs_connection_id`, and state is asserted to contain **no** `vcs_connection_id`. Confirmed the test **fails on the pre-fix code** and passes with the fix.
- The existing `Success with vcs_connection_id` and `vcs_connection_id ignores github_installation_id from backend to avoid drift` tests still pass, confirming the opposite direction (the previous behavior) is preserved.
- Ran the full `go test ./env0/` suite (exit 0), `go vet ./env0/`, and `gofmt` — all clean. `resourceModuleRead` is the only caller touched; create/update/delete and import flows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)