### PR TITLE
Feat: [ATH-30] Add token_format to OIDC credential resources

### DIFF
--- a/client/cloud_credentials.go
+++ b/client/cloud_credentials.go
@@ -42,6 +42,7 @@ type AzureCredentialsValuePayload struct {
 	SubscriptionId string `json:"subscriptionId"`
 	TenantId       string `json:"tenantId"`
 	ProjectId      string `json:"projectId,omitempty"`
+	TokenFormat    string `json:"tokenFormat,omitempty"`
 }
 
 type AwsCredentialsCreatePayload struct {
@@ -58,6 +59,7 @@ type AwsCredentialsValuePayload struct {
 	AccessKeyId     string `json:"accessKeyId,omitempty"`
 	SecretAccessKey string `json:"secretAccessKey,omitempty"`
 	ProjectId       string `json:"projectId,omitempty"`
+	TokenFormat     string `json:"tokenFormat,omitempty"`
 }
 
 type GoogleCostCredentialsCreatePayload struct {
@@ -85,6 +87,7 @@ type GcpCredentialsValuePayload struct {
 	ProjectId                          string `json:"projectId,omitempty"`
 	ServiceAccountKey                  string `json:"serviceAccountKey,omitempty"`
 	CredentialConfigurationFileContent string `json:"credentialConfigurationFileContent,omitempty"`
+	TokenFormat                        string `json:"tokenFormat,omitempty"`
 }
 
 type VaultCredentialsValuePayload struct {
@@ -93,6 +96,7 @@ type VaultCredentialsValuePayload struct {
 	RoleName           string `json:"roleName"`
 	Version            string `json:"version"`
 	Namespace          string `json:"namespace,omitempty"`
+	TokenFormat        string `json:"tokenFormat,omitempty"`
 }
 
 type VaultCredentialsCreatePayload struct {

--- a/env0/resource_aws_oidc_credentials.go
+++ b/env0/resource_aws_oidc_credentials.go
@@ -37,6 +37,12 @@ func resourceAwsOidcCredentials() *schema.Resource {
 				ValidateDiagFunc: NewIntInValidator([]int{3600, 7200, 14400, 18000, 28800, 43200}),
 				Default:          18000,
 			},
+			"token_format": {
+				Type:             schema.TypeString,
+				Description:      "the OIDC token format. One of: \"v1\" (default, legacy single-audience) or \"v2\" (per-provider audience). Leave unset for v1",
+				Optional:         true,
+				ValidateDiagFunc: NewStringInValidator([]string{"v1", "v2"}),
+			},
 			"project_id": {
 				Type:        schema.TypeString,
 				Description: "the env0 project id to associate the credentials with",

--- a/env0/resource_aws_oidc_credentials_test.go
+++ b/env0/resource_aws_oidc_credentials_test.go
@@ -23,9 +23,10 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 	updatedDuration := 2 * duration
 
 	awsCredentialsResource := map[string]any{
-		"name":     "test",
-		"role_arn": "11111",
-		"duration": strconv.Itoa(duration),
+		"name":         "test",
+		"role_arn":     "11111",
+		"duration":     strconv.Itoa(duration),
+		"token_format": "v2",
 	}
 
 	updatedAwsCredentialsResource := map[string]any{
@@ -37,8 +38,9 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 	createPayload := client.AwsCredentialsCreatePayload{
 		Name: awsCredentialsResource["name"].(string),
 		Value: client.AwsCredentialsValuePayload{
-			RoleArn:  awsCredentialsResource["role_arn"].(string),
-			Duration: duration,
+			RoleArn:     awsCredentialsResource["role_arn"].(string),
+			Duration:    duration,
+			TokenFormat: awsCredentialsResource["token_format"].(string),
 		},
 		Type: client.AwsOidcCredentialsType,
 	}
@@ -81,6 +83,7 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "role_arn", awsCredentialsResource["role_arn"].(string)),
 					resource.TestCheckResourceAttr(accessor, "id", returnValues.Id),
 					resource.TestCheckResourceAttr(accessor, "duration", awsCredentialsResource["duration"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", awsCredentialsResource["token_format"].(string)),
 				),
 			},
 			{
@@ -90,6 +93,7 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "role_arn", updatedAwsCredentialsResource["role_arn"].(string)),
 					resource.TestCheckResourceAttr(accessor, "id", updateReturnValues.Id),
 					resource.TestCheckResourceAttr(accessor, "duration", updatedAwsCredentialsResource["duration"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", ""),
 				),
 			},
 		},
@@ -144,7 +148,7 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           awsCredentialsResource["name"].(string),
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"role_arn", "duration"},
+					ImportStateVerifyIgnore: []string{"role_arn", "duration", "token_format"},
 				},
 			},
 		}
@@ -171,7 +175,7 @@ func TestUnitAwsOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           returnValues.Id,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"role_arn", "duration"},
+					ImportStateVerifyIgnore: []string{"role_arn", "duration", "token_format"},
 				},
 			},
 		}

--- a/env0/resource_azure_oidc_credentials.go
+++ b/env0/resource_azure_oidc_credentials.go
@@ -40,6 +40,12 @@ func resourceAzureOidcCredentials() *schema.Resource {
 				Description: "the azure client id",
 				Required:    true,
 			},
+			"token_format": {
+				Type:             schema.TypeString,
+				Description:      "the OIDC token format. One of: \"v1\" (default, legacy single-audience) or \"v2\" (per-provider audience). Leave unset for v1",
+				Optional:         true,
+				ValidateDiagFunc: NewStringInValidator([]string{"v1", "v2"}),
+			},
 			"project_id": {
 				Type:        schema.TypeString,
 				Description: "the env0 project id to associate the credentials with",

--- a/env0/resource_azure_oidc_credentials_test.go
+++ b/env0/resource_azure_oidc_credentials_test.go
@@ -23,6 +23,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 		"tenant_id":       "tenantid1",
 		"subscription_id": "subscriptionid1",
 		"client_id":       "clientid1",
+		"token_format":    "v2",
 	}
 
 	updatedAzureCredentialsResource := map[string]any{
@@ -38,6 +39,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 			TenantId:       azureCredentialsResource["tenant_id"].(string),
 			SubscriptionId: azureCredentialsResource["subscription_id"].(string),
 			ClientId:       azureCredentialsResource["client_id"].(string),
+			TokenFormat:    azureCredentialsResource["token_format"].(string),
 		},
 		Type: client.AzureOidcCredentialsType,
 	}
@@ -82,6 +84,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "tenant_id", azureCredentialsResource["tenant_id"].(string)),
 					resource.TestCheckResourceAttr(accessor, "subscription_id", azureCredentialsResource["subscription_id"].(string)),
 					resource.TestCheckResourceAttr(accessor, "client_id", azureCredentialsResource["client_id"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", azureCredentialsResource["token_format"].(string)),
 				),
 			},
 			{
@@ -92,6 +95,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "tenant_id", updatedAzureCredentialsResource["tenant_id"].(string)),
 					resource.TestCheckResourceAttr(accessor, "subscription_id", updatedAzureCredentialsResource["subscription_id"].(string)),
 					resource.TestCheckResourceAttr(accessor, "client_id", updatedAzureCredentialsResource["client_id"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", ""),
 				),
 			},
 		},
@@ -146,7 +150,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           azureCredentialsResource["name"].(string),
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"tenant_id", "subscription_id", "client_id"},
+					ImportStateVerifyIgnore: []string{"tenant_id", "subscription_id", "client_id", "token_format"},
 				},
 			},
 		}
@@ -173,7 +177,7 @@ func TestUnitAzureOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           returnValues.Id,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"tenant_id", "subscription_id", "client_id"},
+					ImportStateVerifyIgnore: []string{"tenant_id", "subscription_id", "client_id", "token_format"},
 				},
 			},
 		}

--- a/env0/resource_gcp_oidc_credentials.go
+++ b/env0/resource_gcp_oidc_credentials.go
@@ -30,6 +30,12 @@ func resourceGcpOidcCredentials() *schema.Resource {
 				Description: "the JSON content of the JWT configuration file",
 				Required:    true,
 			},
+			"token_format": {
+				Type:             schema.TypeString,
+				Description:      "the OIDC token format. One of: \"v1\" (default, legacy single-audience) or \"v2\" (per-provider audience). Leave unset for v1",
+				Optional:         true,
+				ValidateDiagFunc: NewStringInValidator([]string{"v1", "v2"}),
+			},
 			"project_id": {
 				Type:        schema.TypeString,
 				Description: "the env0 project id to associate the credentials with",

--- a/env0/resource_gcp_oidc_credentials_test.go
+++ b/env0/resource_gcp_oidc_credentials_test.go
@@ -21,6 +21,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 	gcpCredentialsResource := map[string]any{
 		"name":                                  "test",
 		"credential_configuration_file_content": "content1",
+		"token_format":                          "v2",
 	}
 
 	updatedGcpCredentialsResource := map[string]any{
@@ -32,6 +33,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 		Name: gcpCredentialsResource["name"].(string),
 		Value: client.GcpCredentialsValuePayload{
 			CredentialConfigurationFileContent: gcpCredentialsResource["credential_configuration_file_content"].(string),
+			TokenFormat:                        gcpCredentialsResource["token_format"].(string),
 		},
 		Type: client.GcpOidcCredentialsType,
 	}
@@ -72,6 +74,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "id", returnValues.Id),
 					resource.TestCheckResourceAttr(accessor, "name", gcpCredentialsResource["name"].(string)),
 					resource.TestCheckResourceAttr(accessor, "credential_configuration_file_content", gcpCredentialsResource["credential_configuration_file_content"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", gcpCredentialsResource["token_format"].(string)),
 				),
 			},
 			{
@@ -80,6 +83,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "id", updateReturnValues.Id),
 					resource.TestCheckResourceAttr(accessor, "name", updatedGcpCredentialsResource["name"].(string)),
 					resource.TestCheckResourceAttr(accessor, "credential_configuration_file_content", updatedGcpCredentialsResource["credential_configuration_file_content"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", ""),
 				),
 			},
 		},
@@ -134,7 +138,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           gcpCredentialsResource["name"].(string),
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"credential_configuration_file_content"},
+					ImportStateVerifyIgnore: []string{"credential_configuration_file_content", "token_format"},
 				},
 			},
 		}
@@ -161,7 +165,7 @@ func TestUnitGcpOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           returnValues.Id,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"credential_configuration_file_content"},
+					ImportStateVerifyIgnore: []string{"credential_configuration_file_content", "token_format"},
 				},
 			},
 		}

--- a/env0/resource_vault_oidc_credentials.go
+++ b/env0/resource_vault_oidc_credentials.go
@@ -50,6 +50,12 @@ func resourceVaultOidcCredentials() *schema.Resource {
 				Description: "an optional vault namespace",
 				Optional:    true,
 			},
+			"token_format": {
+				Type:             schema.TypeString,
+				Description:      "the OIDC token format. One of: \"v1\" (default, legacy single-audience) or \"v2\" (per-provider audience). Leave unset for v1",
+				Optional:         true,
+				ValidateDiagFunc: NewStringInValidator([]string{"v1", "v2"}),
+			},
 			"project_id": {
 				Type:        schema.TypeString,
 				Description: "the env0 project id to associate the credentials with",

--- a/env0/resource_vault_oidc_credentials_test.go
+++ b/env0/resource_vault_oidc_credentials_test.go
@@ -25,6 +25,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 		"role_name":             "rolename1",
 		"jwt_auth_backend_path": "path1",
 		"namespace":             "namespace1",
+		"token_format":          "v2",
 	}
 
 	updatedVaultCredentialsResource := map[string]any{
@@ -43,6 +44,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 			RoleName:           vaultCredentialsResource["role_name"].(string),
 			JwtAuthBackendPath: vaultCredentialsResource["jwt_auth_backend_path"].(string),
 			Namespace:          vaultCredentialsResource["namespace"].(string),
+			TokenFormat:        vaultCredentialsResource["token_format"].(string),
 		},
 		Type: client.VaultOidcCredentialsType,
 	}
@@ -90,6 +92,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "role_name", vaultCredentialsResource["role_name"].(string)),
 					resource.TestCheckResourceAttr(accessor, "jwt_auth_backend_path", vaultCredentialsResource["jwt_auth_backend_path"].(string)),
 					resource.TestCheckResourceAttr(accessor, "namespace", vaultCredentialsResource["namespace"].(string)),
+					resource.TestCheckResourceAttr(accessor, "token_format", vaultCredentialsResource["token_format"].(string)),
 				),
 			},
 			{
@@ -102,6 +105,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 					resource.TestCheckResourceAttr(accessor, "role_name", updatedVaultCredentialsResource["role_name"].(string)),
 					resource.TestCheckResourceAttr(accessor, "jwt_auth_backend_path", updatedVaultCredentialsResource["jwt_auth_backend_path"].(string)),
 					resource.TestCheckResourceAttr(accessor, "namespace", ""),
+					resource.TestCheckResourceAttr(accessor, "token_format", ""),
 				),
 			},
 		},
@@ -156,7 +160,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           vaultCredentialsResource["name"].(string),
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"address", "version", "role_name", "jwt_auth_backend_path", "namespace"},
+					ImportStateVerifyIgnore: []string{"address", "version", "role_name", "jwt_auth_backend_path", "namespace", "token_format"},
 				},
 			},
 		}
@@ -183,7 +187,7 @@ func TestUnitVaultOidcCredentialsResource(t *testing.T) {
 					ImportState:             true,
 					ImportStateId:           returnValues.Id,
 					ImportStateVerify:       true,
-					ImportStateVerifyIgnore: []string{"address", "version", "role_name", "jwt_auth_backend_path", "namespace"},
+					ImportStateVerifyIgnore: []string{"address", "version", "role_name", "jwt_auth_backend_path", "namespace", "token_format"},
 				},
 			},
 		}

--- a/tests/integration/006_aws_credentials/expected_outputs.json
+++ b/tests/integration/006_aws_credentials/expected_outputs.json
@@ -1,4 +1,5 @@
 {
   "name_by_arn": "Test Role arn ",
-  "name_access_key": "Test Role access key "
+  "name_access_key": "Test Role access key ",
+  "aws_oidc_token_format": "v2"
 }

--- a/tests/integration/006_aws_credentials/expected_outputs.json
+++ b/tests/integration/006_aws_credentials/expected_outputs.json
@@ -1,5 +1,5 @@
 {
   "name_by_arn": "Test Role arn ",
   "name_access_key": "Test Role access key ",
-  "aws_oidc_token_format": "v2"
+  "aws_oidc_token_format": "v1"
 }

--- a/tests/integration/006_aws_credentials/main.tf
+++ b/tests/integration/006_aws_credentials/main.tf
@@ -30,7 +30,7 @@ resource "env0_aws_oidc_credentials" "oidc_credentials" {
   name         = "Test Oidc Credentials ${random_string.random.result}"
   role_arn     = var.second_run ? "Role ARN2" : "Role ARN1"
   duration     = 7200
-  token_format = "v2"
+  token_format = var.second_run ? "v1" : "v2"
 }
 
 data "env0_aws_oidc_credentials" "oidc_credentials" {

--- a/tests/integration/006_aws_credentials/main.tf
+++ b/tests/integration/006_aws_credentials/main.tf
@@ -27,9 +27,10 @@ data "env0_aws_credentials" "my_role_by_access_key" {
 }
 
 resource "env0_aws_oidc_credentials" "oidc_credentials" {
-  name     = "Test Oidc Credentials ${random_string.random.result}"
-  role_arn = var.second_run ? "Role ARN2" : "Role ARN1"
-  duration = 7200
+  name         = "Test Oidc Credentials ${random_string.random.result}"
+  role_arn     = var.second_run ? "Role ARN2" : "Role ARN1"
+  duration     = 7200
+  token_format = "v2"
 }
 
 data "env0_aws_oidc_credentials" "oidc_credentials" {
@@ -43,4 +44,8 @@ output "name_by_arn" {
 
 output "name_access_key" {
   value = replace(data.env0_aws_credentials.my_role_by_access_key.name, random_string.random.result, "")
+}
+
+output "aws_oidc_token_format" {
+  value = env0_aws_oidc_credentials.oidc_credentials.token_format
 }

--- a/tests/integration/015_gcp_credentials/expected_outputs.json
+++ b/tests/integration/015_gcp_credentials/expected_outputs.json
@@ -1,2 +1,3 @@
 {
+  "gcp_oidc_token_format": "v2"
 }

--- a/tests/integration/015_gcp_credentials/expected_outputs.json
+++ b/tests/integration/015_gcp_credentials/expected_outputs.json
@@ -1,3 +1,3 @@
 {
-  "gcp_oidc_token_format": "v2"
+  "gcp_oidc_token_format": "v1"
 }

--- a/tests/integration/015_gcp_credentials/main.tf
+++ b/tests/integration/015_gcp_credentials/main.tf
@@ -30,7 +30,7 @@ resource "env0_gcp_oidc_credentials" "oidc_credentials" {
   credential_configuration_file_content = jsonencode({
     "key" : "value"
   })
-  token_format = "v2"
+  token_format = var.second_run ? "v1" : "v2"
 }
 
 data "env0_gcp_oidc_credentials" "gcp_credentials" {

--- a/tests/integration/015_gcp_credentials/main.tf
+++ b/tests/integration/015_gcp_credentials/main.tf
@@ -30,6 +30,7 @@ resource "env0_gcp_oidc_credentials" "oidc_credentials" {
   credential_configuration_file_content = jsonencode({
     "key" : "value"
   })
+  token_format = "v2"
 }
 
 data "env0_gcp_oidc_credentials" "gcp_credentials" {
@@ -45,4 +46,8 @@ output "gcp_cred_name" {
 
 output "gcp_cred_name_with_project_id" {
   value = data.env0_gcp_credentials.gcp_cred_with_project_id.name
+}
+
+output "gcp_oidc_token_format" {
+  value = env0_gcp_oidc_credentials.oidc_credentials.token_format
 }

--- a/tests/integration/016_azure_credentials/expected_outputs.json
+++ b/tests/integration/016_azure_credentials/expected_outputs.json
@@ -1,3 +1,4 @@
 {
-  "azure_cred_name": "test azure credentials 1 "
+  "azure_cred_name": "test azure credentials 1 ",
+  "azure_oidc_token_format": "v2"
 }

--- a/tests/integration/016_azure_credentials/expected_outputs.json
+++ b/tests/integration/016_azure_credentials/expected_outputs.json
@@ -1,4 +1,4 @@
 {
   "azure_cred_name": "test azure credentials 1 ",
-  "azure_oidc_token_format": "v2"
+  "azure_oidc_token_format": "v1"
 }

--- a/tests/integration/016_azure_credentials/main.tf
+++ b/tests/integration/016_azure_credentials/main.tf
@@ -17,7 +17,7 @@ resource "env0_azure_oidc_credentials" "oidc_credentials" {
   client_id       = "client_id"
   subscription_id = var.second_run ? "subscription_id2" : "subscription_id1"
   tenant_id       = "tenant_id"
-  token_format    = "v2"
+  token_format    = var.second_run ? "v1" : "v2"
 }
 
 data "env0_azure_oidc_credentials" "oidc_credentials" {

--- a/tests/integration/016_azure_credentials/main.tf
+++ b/tests/integration/016_azure_credentials/main.tf
@@ -17,6 +17,7 @@ resource "env0_azure_oidc_credentials" "oidc_credentials" {
   client_id       = "client_id"
   subscription_id = var.second_run ? "subscription_id2" : "subscription_id1"
   tenant_id       = "tenant_id"
+  token_format    = "v2"
 }
 
 data "env0_azure_oidc_credentials" "oidc_credentials" {
@@ -30,6 +31,10 @@ data "env0_azure_credentials" "azure_cred" {
 
 output "azure_cred_name" {
   value = replace(data.env0_azure_credentials.azure_cred.name, random_string.random.result, "")
+}
+
+output "azure_oidc_token_format" {
+  value = env0_azure_oidc_credentials.oidc_credentials.token_format
 }
 
 

--- a/tests/integration/031_vault_credentials/expected_outputs.json
+++ b/tests/integration/031_vault_credentials/expected_outputs.json
@@ -1,3 +1,3 @@
 {
-  "vault_oidc_token_format": "v2"
+  "vault_oidc_token_format": "v1"
 }

--- a/tests/integration/031_vault_credentials/expected_outputs.json
+++ b/tests/integration/031_vault_credentials/expected_outputs.json
@@ -1,2 +1,3 @@
 {
+  "vault_oidc_token_format": "v2"
 }

--- a/tests/integration/031_vault_credentials/main.tf
+++ b/tests/integration/031_vault_credentials/main.tf
@@ -11,7 +11,7 @@ resource "env0_vault_oidc_credentials" "oidc_credentials" {
   role_name             = "role_name"
   jwt_auth_backend_path = var.second_run ? "path2" : "path1"
   namespace             = "namespace"
-  token_format          = "v2"
+  token_format          = var.second_run ? "v1" : "v2"
 }
 
 data "env0_vault_oidc_credentials" "oidc_credentials" {

--- a/tests/integration/031_vault_credentials/main.tf
+++ b/tests/integration/031_vault_credentials/main.tf
@@ -11,10 +11,15 @@ resource "env0_vault_oidc_credentials" "oidc_credentials" {
   role_name             = "role_name"
   jwt_auth_backend_path = var.second_run ? "path2" : "path1"
   namespace             = "namespace"
+  token_format          = "v2"
 }
 
 data "env0_vault_oidc_credentials" "oidc_credentials" {
   name       = "test vault oidc credentials ${random_string.random.result}"
   depends_on = [env0_vault_oidc_credentials.oidc_credentials]
+}
+
+output "vault_oidc_token_format" {
+  value = env0_vault_oidc_credentials.oidc_credentials.token_format
 }
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Resolves [ATH-30](https://linear.app/env-zero/issue/ATH-30). Phase 1 (Terraform provider side) of [ATH-29 — Dynamic OIDC Audience Claim for Multi-Cloud Security](https://linear.app/env-zero/issue/ATH-29).

env0 historically mints **one OIDC token with a static `aud`** per deployment, replayable across every relying party (AWS/GCP/Azure/Vault) — a confused-deputy vector. The v2 fix mints **per-provider audiences**; the opt-in is per-credential. The backend opt-in already shipped in [env0#21266](https://github.com/env0/env0/pull/21266) (ATH-48/ENG-1757): each OIDC credential **value** object gained an optional `tokenFormat` enum (`v1`/`v2`). This PR exposes that opt-in in the Terraform provider.

> **Note on naming:** the ticket title says `use_v2_oidc`, but the as-built attribute is **`token_format`** (string `v1`/`v2`) to match the merged API enum and stay reusable for future formats.

### Solution
Adds an optional `token_format` attribute (string, validated to `"v1"`/`"v2"`) to the four OIDC credential resources: `env0_aws_oidc_credentials`, `env0_azure_oidc_credentials`, `env0_gcp_oidc_credentials`, `env0_vault_oidc_credentials`.

- **`client/cloud_credentials.go`** — `TokenFormat string \`json:"tokenFormat,omitempty"\`` on the four OIDC value payloads. `omitempty` means an unset value is not sent, so the API treats it as legacy `v1`.
- **`env0/resource_*_oidc_credentials.go`** — the optional `token_format` schema attribute, validated via the existing `NewStringInValidator([]string{"v1","v2"})`. No `Default` (avoids forcing `token_format = "v1"` diffs on existing resources). The existing `*GetValue` helpers are unchanged — the reflection-based `readResourceData` maps `token_format` → `TokenFormat` automatically.
- **`env0/resource_*_oidc_credentials_test.go`** — each `TestUnit*OidcCredentialsResource` now sets `token_format: "v2"` on create (asserting the payload carries `TokenFormat: "v2"`), omits it on update (asserting the attribute clears, exercising `omitempty`), and adds `token_format` to the import `ImportStateVerifyIgnore` lists (credential values are write-only and never returned by the API).

Docs (`docs/resources/*.md`) are regenerated by the existing docs GitHub Action — not hand-edited here.

### Manual Verification
- `go build ./...` — clean.
- `go test ./env0/ -run 'TestUnit(Aws|Azure|Gcp|Vault)OidcCredentialsResource'` — **28 passed**, asserting `tokenFormat` is sent for `v2` and omitted when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01565Z5SgHFbuw7iK5mHsJuc
