### PR TITLE
Fix: implement prevent_auto_deploy flag to allow configuration updates without triggering deployments

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -73,7 +73,7 @@ If true must specify one of the following - 'github_installation_id' if using Gi
 - `is_remote_backend` (Boolean) should use remote backend
 - `k8s_namespace` (String) kubernetes (or helm) namespace to be used. If modified deletes current environment and creates a new one
 - `output` (String) the deployment log output. Returns a json string. It can be either a map of key-value, or an array of (in case of Terragrunt run-all) of moduleName and a map of key-value. Note: if the deployment is still in progress returns 'null'
-- `prevent_auto_deploy` (Boolean) use this flag to prevent auto deploy on environment creation
+- `prevent_auto_deploy` (Boolean) use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration' and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment
 - `removal_strategy` (String) by default when removing an environment, it gets destroyed. Setting this value to 'mark_as_archived' will force the environment to be archived instead of tying to destroy it ('Mark as inactive' in the UI)
 - `revision` (String) the revision the environment is to be run against. Please note that changing this attribute will require environment redeploy
 - `run_plan_on_pull_requests` (Boolean) should run terraform plan on pull requests creations.

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -73,7 +73,7 @@ If true must specify one of the following - 'github_installation_id' if using Gi
 - `is_remote_backend` (Boolean) should use remote backend
 - `k8s_namespace` (String) kubernetes (or helm) namespace to be used. If modified deletes current environment and creates a new one
 - `output` (String) the deployment log output. Returns a json string. It can be either a map of key-value, or an array of (in case of Terragrunt run-all) of moduleName and a map of key-value. Note: if the deployment is still in progress returns 'null'
-- `prevent_auto_deploy` (Boolean) use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration' and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment
+- `prevent_auto_deploy` (Boolean) use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration', 'sub_environment_configuration' variables and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment
 - `removal_strategy` (String) by default when removing an environment, it gets destroyed. Setting this value to 'mark_as_archived' will force the environment to be archived instead of tying to destroy it ('Mark as inactive' in the UI)
 - `revision` (String) the revision the environment is to be run against. Please note that changing this attribute will require environment redeploy
 - `run_plan_on_pull_requests` (Boolean) should run terraform plan on pull requests creations.

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -272,7 +272,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"prevent_auto_deploy": {
 				Type:        schema.TypeBool,
-				Description: "use this flag to prevent auto deploy on environment creation",
+				Description: "use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration' and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment",
 				Optional:    true,
 			},
 			"terragrunt_working_directory": {
@@ -433,7 +433,8 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 	}
 
 	if !isTemplateless(d) {
-		if environment.LatestDeploymentLog.BlueprintId != "" {
+		preventAutoDeploy, _ := d.Get("prevent_auto_deploy").(bool)
+		if environment.LatestDeploymentLog.BlueprintId != "" && !preventAutoDeploy {
 			d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
 			d.Set("revision", environment.LatestDeploymentLog.BlueprintRevision)
 		}
@@ -844,7 +845,11 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if shouldDeploy(d) {
-		if err := deploy(d, apiClient); err != nil {
+		if d.Get("prevent_auto_deploy").(bool) {
+			if diagErr := updateWithoutDeploy(d, apiClient); diagErr != nil {
+				return diagErr
+			}
+		} else if err := deploy(d, apiClient); err != nil {
 			return err
 		}
 	}
@@ -924,6 +929,21 @@ func updateDriftDetection(d *schema.ResourceData, apiClient client.ApiClientInte
 	return nil
 }
 
+func getEnvironmentConfigurationScope(d *schema.ResourceData) client.Scope {
+	if _, ok := d.GetOk("sub_environment_configuration"); ok {
+		return client.ScopeWorkflow
+	}
+
+	return client.ScopeEnvironment
+}
+
+func getSubEnvironmentConfigurationChanges(d *schema.ResourceData, index int, subEnvironmentId string, apiClient client.ApiClientInterface) (client.ConfigurationChanges, error) {
+	configuration := d.Get(fmt.Sprintf("sub_environment_configuration.%d.configuration", index)).([]any)
+	configurationChanges := stripIsRequired(getConfigurationVariablesFromSchema(configuration))
+
+	return getUpdateConfigurationVariables(configurationChanges, subEnvironmentId, client.ScopeEnvironment, apiClient)
+}
+
 func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Diagnostics {
 	deployPayload, err := getDeployPayload(d, apiClient, true)
 	if err != nil {
@@ -952,10 +972,7 @@ func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Di
 		deployPayload.SubEnvironments = make(map[string]client.SubEnvironment)
 
 		for i, subEnvironment := range subEnvironments {
-			configuration := d.Get(fmt.Sprintf("sub_environment_configuration.%d.configuration", i)).([]any)
-			configurationChanges := stripIsRequired(getConfigurationVariablesFromSchema(configuration))
-
-			configurationChanges, err = getUpdateConfigurationVariables(configurationChanges, subEnvironment.Id, client.ScopeEnvironment, apiClient)
+			configurationChanges, err := getSubEnvironmentConfigurationChanges(d, i, subEnvironment.Id, apiClient)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -981,6 +998,157 @@ func deploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Di
 	d.Set("deployment_id", deployResponse.Id)
 
 	return nil
+}
+
+func updateWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Diagnostics {
+	if d.HasChange("configuration") {
+		if err := updateEnvironmentConfigurationWithoutDeploy(d, apiClient); err != nil {
+			return diag.Errorf("could not update environment configuration variables: %v", err)
+		}
+	}
+
+	if d.HasChange("sub_environment_configuration") {
+		if err := updateSubEnvironmentsConfigurationWithoutDeploy(d, apiClient); err != nil {
+			return diag.Errorf("could not update sub environment configuration variables: %v", err)
+		}
+	}
+
+	if d.HasChange("variable_sets") {
+		if err := updateVariableSetsWithoutDeploy(d, apiClient); err != nil {
+			return diag.Errorf("could not update variable sets: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func updateEnvironmentConfigurationWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInterface) error {
+	scope := getEnvironmentConfigurationScope(d)
+
+	var configurationChanges client.ConfigurationChanges
+	if configuration, ok := d.GetOk("configuration"); ok {
+		configurationChanges = stripIsRequired(getConfigurationVariablesFromSchema(configuration.([]any)))
+	}
+
+	configurationChanges, err := getUpdateConfigurationVariables(configurationChanges, d.Id(), scope, apiClient)
+	if err != nil {
+		return err
+	}
+
+	return applyConfigurationChangesWithoutDeploy(configurationChanges, scope, d.Id(), apiClient)
+}
+
+func updateSubEnvironmentsConfigurationWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInterface) error {
+	subEnvironments, err := getSubEnvironments(d)
+	if err != nil {
+		return fmt.Errorf("failed to extract sub environments from resource data: %w", err)
+	}
+
+	for i, subEnvironment := range subEnvironments {
+		if subEnvironment.Id == "" {
+			continue
+		}
+
+		configurationChanges, err := getSubEnvironmentConfigurationChanges(d, i, subEnvironment.Id, apiClient)
+		if err != nil {
+			return err
+		}
+
+		if err := applyConfigurationChangesWithoutDeploy(configurationChanges, client.ScopeEnvironment, subEnvironment.Id, apiClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateVariableSetsWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInterface) error {
+	changes, err := getEnvironmentConfigurationSetChanges(d, apiClient)
+	if err != nil {
+		if errors.Is(err, ErrNoChanges) {
+			return nil
+		}
+
+		return err
+	}
+
+	if len(changes.Assign) > 0 {
+		if err := apiClient.AssignConfigurationSets(client.ENVIRONMENT, d.Id(), changes.Assign); err != nil {
+			return fmt.Errorf("could not assign variable sets: %w", err)
+		}
+	}
+
+	if len(changes.Unassign) > 0 {
+		if err := apiClient.UnassignConfigurationSets(client.ENVIRONMENT, d.Id(), changes.Unassign); err != nil {
+			return fmt.Errorf("could not unassign variable sets: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func applyConfigurationChangesWithoutDeploy(configurationChanges client.ConfigurationChanges, scope client.Scope, scopeId string, apiClient client.ApiClientInterface) error {
+	for i := range configurationChanges {
+		change := configurationChanges[i]
+
+		if change.ToDelete != nil && *change.ToDelete {
+			if err := apiClient.ConfigurationVariableDelete(change.Id); err != nil {
+				return fmt.Errorf("could not delete configuration variable %q: %w", change.Name, err)
+			}
+
+			continue
+		}
+
+		params := configurationVariableCreateParams(change, scope, scopeId)
+
+		if change.Id != "" {
+			if _, err := apiClient.ConfigurationVariableUpdate(client.ConfigurationVariableUpdateParams{Id: change.Id, CommonParams: params}); err != nil {
+				return fmt.Errorf("could not update configuration variable %q: %w", change.Name, err)
+			}
+
+			continue
+		}
+
+		if _, err := apiClient.ConfigurationVariableCreate(params); err != nil {
+			return fmt.Errorf("could not create configuration variable %q: %w", change.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func configurationVariableCreateParams(change client.ConfigurationVariable, scope client.Scope, scopeId string) client.ConfigurationVariableCreateParams {
+	params := client.ConfigurationVariableCreateParams{
+		Name:        change.Name,
+		Value:       change.Value,
+		Scope:       scope,
+		ScopeId:     scopeId,
+		Description: change.Description,
+		Regex:       change.Regex,
+	}
+
+	if change.Type != nil {
+		params.Type = *change.Type
+	}
+
+	if change.IsSensitive != nil {
+		params.IsSensitive = *change.IsSensitive
+	}
+
+	if change.IsReadOnly != nil {
+		params.IsReadOnly = *change.IsReadOnly
+	}
+
+	if change.IsRequired != nil {
+		params.IsRequired = *change.IsRequired
+	}
+
+	if change.Schema != nil {
+		params.EnumValues = change.Schema.Enum
+		params.Format = change.Schema.Format
+	}
+
+	return params
 }
 
 func update(d *schema.ResourceData, apiClient client.ApiClientInterface) diag.Diagnostics {
@@ -1374,11 +1542,7 @@ func getDeployPayload(d *schema.ResourceData, apiClient client.ApiClientInterfac
 
 		if configuration, ok := d.GetOk("configuration"); ok && isRedeploy {
 			configurationChanges := stripIsRequired(getConfigurationVariablesFromSchema(configuration.([]any)))
-			scope := client.ScopeEnvironment
-
-			if _, ok := d.GetOk("sub_environment_configuration"); ok {
-				scope = client.ScopeWorkflow
-			}
+			scope := getEnvironmentConfigurationScope(d)
 
 			configurationChanges, err = getUpdateConfigurationVariables(configurationChanges, d.Get("id").(string), scope, apiClient)
 			if err != nil {

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -272,7 +272,7 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"prevent_auto_deploy": {
 				Type:        schema.TypeBool,
-				Description: "use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration' and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment",
+				Description: "use this flag to prevent the provider from triggering a deployment (run) when the environment is created or updated. On update, changes to 'configuration', 'sub_environment_configuration' variables and 'variable_sets' are still saved to env0 without a deployment, while changes to 'revision' and 'template_id' are only applied by your next deployment",
 				Optional:    true,
 			},
 			"terragrunt_working_directory": {
@@ -433,6 +433,13 @@ func setEnvironmentSchema(ctx context.Context, d *schema.ResourceData, environme
 	}
 
 	if !isTemplateless(d) {
+		// When prevent_auto_deploy is set the provider never queues a deployment, so revision and
+		// template_id are managed declaratively in Terraform and applied by the user's own deploy.
+		// Overwriting them from the latest deployment log would otherwise cause perpetual drift.
+		// Trade-off (by design): genuine external changes to these fields are not detected, and a
+		// revision change is kept in state but only takes effect on the user's next deployment.
+		// setEnvironmentSchema is shared with the environment data source (which has no
+		// prevent_auto_deploy field) - the comma-ok assertion safely defaults it to false there.
 		preventAutoDeploy, _ := d.Get("prevent_auto_deploy").(bool)
 		if environment.LatestDeploymentLog.BlueprintId != "" && !preventAutoDeploy {
 			d.Set("template_id", environment.LatestDeploymentLog.BlueprintId)
@@ -1022,6 +1029,12 @@ func updateWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInter
 	return nil
 }
 
+// updateEnvironmentConfigurationWithoutDeploy persists the environment's top-level configuration
+// variables directly, without a deployment. For a regular environment the scope is ENVIRONMENT; for
+// a workflow environment it is WORKFLOW. The WORKFLOW-scoped direct create/update path is unique to
+// this prevent_auto_deploy flow (the deploy path ships workflow vars in the deploy payload), but the
+// backend supports it: /configuration accepts WORKFLOW-scoped writes and the matching
+// workflowEnvironmentId read returns them (verified via an API round-trip on the dev stack).
 func updateEnvironmentConfigurationWithoutDeploy(d *schema.ResourceData, apiClient client.ApiClientInterface) error {
 	scope := getEnvironmentConfigurationScope(d)
 
@@ -1046,6 +1059,14 @@ func updateSubEnvironmentsConfigurationWithoutDeploy(d *schema.ResourceData, api
 
 	for i, subEnvironment := range subEnvironments {
 		if subEnvironment.Id == "" {
+			continue
+		}
+
+		// Only touch a sub-environment's variables when its own configuration block changed.
+		// updateWithoutDeploy is entered on any sub_environment_configuration change (including
+		// non-variable fields like workspace/approve_plan_automatically), so without this guard we
+		// would recompute deltas and could update/delete variables the user never touched.
+		if !d.HasChange(fmt.Sprintf("sub_environment_configuration.%d.configuration", i)) {
 			continue
 		}
 
@@ -1087,6 +1108,12 @@ func updateVariableSetsWithoutDeploy(d *schema.ResourceData, apiClient client.Ap
 	return nil
 }
 
+// applyConfigurationChangesWithoutDeploy persists configuration variable changes one by one
+// (create/update/delete) directly to the given scope, without a deployment. Unlike the deploy
+// endpoint - which applies all changes atomically - these are sequential per-variable calls, so a
+// mid-loop failure leaves the environment partially applied and returns an error; Terraform
+// re-reconciles the remaining changes on the next apply. This matches the standalone
+// env0_configuration_variable resource's behaviour.
 func applyConfigurationChangesWithoutDeploy(configurationChanges client.ConfigurationChanges, scope client.Scope, scopeId string, apiClient client.ApiClientInterface) error {
 	for i := range configurationChanges {
 		change := configurationChanges[i]

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2117,6 +2117,122 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			})
 		})
 
+		t.Run("prevent_auto_deploy - update creates and deletes configuration without deploying", func(t *testing.T) {
+			templateId := "template-id"
+
+			environment := client.Environment{
+				Id:        uuid.New().String(),
+				Name:      "my-environment",
+				ProjectId: "project-id",
+				LatestDeploymentLog: client.DeploymentLog{
+					BlueprintId:       templateId,
+					BlueprintRevision: "revision",
+				},
+			}
+
+			varType := client.ConfigurationVariableTypeEnvironment
+			varSchema := client.ConfigurationVariableSchema{Type: "string"}
+
+			// Present in env0 before the update; removed from the config on the 2nd step (delete branch).
+			droppedVariable := client.ConfigurationVariable{
+				Id:     "dropped-id",
+				Name:   "DROP_ME",
+				Value:  "old",
+				Type:   &varType,
+				Schema: &varSchema,
+			}
+			// Added to the config on the 2nd step (create branch).
+			addedVariable := client.ConfigurationVariable{
+				Id:     "added-id",
+				Name:   "ADD_ME",
+				Value:  "new",
+				Type:   &varType,
+				Schema: &varSchema,
+			}
+
+			resourceConfig := func(name string, value string) string {
+				return fmt.Sprintf(`
+				resource "%s" "%s" {
+					name                = "%s"
+					project_id          = "%s"
+					template_id         = "%s"
+					revision            = "revision"
+					prevent_auto_deploy = true
+					force_destroy       = true
+					configuration {
+						name  = "%s"
+						value = "%s"
+					}
+				}`,
+					resourceType, resourceName, environment.Name, environment.ProjectId,
+					templateId, name, value,
+				)
+			}
+
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfig("DROP_ME", "old"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "configuration.0.name", "DROP_ME"),
+							resource.TestCheckResourceAttr(accessor, "configuration.0.value", "old"),
+						),
+					},
+					{
+						// DROP_ME is removed (delete branch) and ADD_ME is added (create branch).
+						Config: resourceConfig("ADD_ME", "new"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "configuration.0.name", "ADD_ME"),
+							resource.TestCheckResourceAttr(accessor, "configuration.0.value", "new"),
+						),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				mock.EXPECT().Template(templateId).Times(1).Return(template, nil)
+				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
+
+				mock.EXPECT().Environment(environment.Id).AnyTimes().Return(environment, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).AnyTimes().Return(nil, nil)
+
+				// Before the update env0 holds DROP_ME; after it holds ADD_ME.
+				persisted := false
+
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).AnyTimes().DoAndReturn(
+					func(_ client.Scope, _ string) ([]client.ConfigurationVariable, error) {
+						if persisted {
+							return client.ConfigurationChanges{addedVariable}, nil
+						}
+
+						return client.ConfigurationChanges{droppedVariable}, nil
+					},
+				)
+
+				// create branch: the new variable is created directly (no deployment).
+				mock.EXPECT().ConfigurationVariableCreate(client.ConfigurationVariableCreateParams{
+					Name:    "ADD_ME",
+					Value:   "new",
+					Scope:   client.ScopeEnvironment,
+					ScopeId: environment.Id,
+					Type:    client.ConfigurationVariableTypeEnvironment,
+				}).Times(1).DoAndReturn(
+					func(_ client.ConfigurationVariableCreateParams) (client.ConfigurationVariable, error) {
+						persisted = true
+
+						return addedVariable, nil
+					},
+				)
+
+				// delete branch: the removed variable is deleted directly (no deployment).
+				mock.EXPECT().ConfigurationVariableDelete(droppedVariable.Id).Times(1).Return(nil)
+
+				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
+
+				// EnvironmentDeploy and ConfigurationVariableUpdate must not be called.
+			})
+		})
+
 		t.Run("prevent_auto_deploy - update persists variable sets without deploying", func(t *testing.T) {
 			templateId := "template-id"
 

--- a/env0/resource_environment_test.go
+++ b/env0/resource_environment_test.go
@@ -2011,6 +2011,201 @@ func TestUnitEnvironmentResource(t *testing.T) {
 			})
 		})
 
+		t.Run("prevent_auto_deploy - update persists configuration without deploying", func(t *testing.T) {
+			templateId := "template-id"
+
+			environment := client.Environment{
+				Id:        uuid.New().String(),
+				Name:      "my-environment",
+				ProjectId: "project-id",
+				LatestDeploymentLog: client.DeploymentLog{
+					BlueprintId:       templateId,
+					BlueprintRevision: "revision",
+				},
+			}
+
+			varType := client.ConfigurationVariableTypeEnvironment
+			varSchema := client.ConfigurationVariableSchema{Type: "string"}
+
+			existingVariable := client.ConfigurationVariable{
+				Id:     "var-id",
+				Name:   "FOO",
+				Value:  "bar",
+				Type:   &varType,
+				Schema: &varSchema,
+			}
+			updatedVariable := existingVariable
+			updatedVariable.Value = "baz"
+
+			resourceConfig := func(revision string, value string) string {
+				return fmt.Sprintf(`
+				resource "%s" "%s" {
+					name                = "%s"
+					project_id          = "%s"
+					template_id         = "%s"
+					revision            = "%s"
+					prevent_auto_deploy = true
+					force_destroy       = true
+					configuration {
+						name  = "FOO"
+						value = "%s"
+					}
+				}`,
+					resourceType, resourceName, environment.Name, environment.ProjectId,
+					templateId, revision, value,
+				)
+			}
+
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfig("revision", "bar"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+							resource.TestCheckResourceAttr(accessor, "revision", "revision"),
+							resource.TestCheckResourceAttr(accessor, "prevent_auto_deploy", "true"),
+							resource.TestCheckResourceAttr(accessor, "configuration.0.value", "bar"),
+						),
+					},
+					{
+						Config: resourceConfig("updated-revision", "baz"),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "revision", "updated-revision"),
+							resource.TestCheckResourceAttr(accessor, "configuration.0.value", "baz"),
+						),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				mock.EXPECT().Template(templateId).Times(1).Return(template, nil)
+				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
+
+				mock.EXPECT().Environment(environment.Id).AnyTimes().Return(environment, nil)
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).AnyTimes().Return(nil, nil)
+
+				persisted := false
+
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).AnyTimes().DoAndReturn(
+					func(_ client.Scope, _ string) ([]client.ConfigurationVariable, error) {
+						if persisted {
+							return client.ConfigurationChanges{updatedVariable}, nil
+						}
+
+						return client.ConfigurationChanges{existingVariable}, nil
+					},
+				)
+
+				mock.EXPECT().ConfigurationVariableUpdate(client.ConfigurationVariableUpdateParams{
+					Id: existingVariable.Id,
+					CommonParams: client.ConfigurationVariableCreateParams{
+						Name:    "FOO",
+						Value:   "baz",
+						Scope:   client.ScopeEnvironment,
+						ScopeId: environment.Id,
+						Type:    client.ConfigurationVariableTypeEnvironment,
+					},
+				}).Times(1).DoAndReturn(
+					func(_ client.ConfigurationVariableUpdateParams) (client.ConfigurationVariable, error) {
+						persisted = true
+
+						return updatedVariable, nil
+					},
+				)
+
+				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
+			})
+		})
+
+		t.Run("prevent_auto_deploy - update persists variable sets without deploying", func(t *testing.T) {
+			templateId := "template-id"
+
+			environment := client.Environment{
+				Id:        uuid.New().String(),
+				Name:      "my-environment",
+				ProjectId: "project-id",
+				LatestDeploymentLog: client.DeploymentLog{
+					BlueprintId:       templateId,
+					BlueprintRevision: "revision",
+				},
+			}
+
+			vs1 := client.ConfigurationSet{Id: "vs-1", AssignmentScope: "environment"}
+			vs2 := client.ConfigurationSet{Id: "vs-2", AssignmentScope: "environment"}
+			vs3 := client.ConfigurationSet{Id: "vs-3", AssignmentScope: "environment"}
+
+			resourceConfig := func(setA string, setB string) string {
+				return fmt.Sprintf(`
+				resource "%s" "%s" {
+					name                = "%s"
+					project_id          = "%s"
+					template_id         = "%s"
+					revision            = "revision"
+					prevent_auto_deploy = true
+					force_destroy       = true
+					variable_sets       = ["%s", "%s"]
+				}`,
+					resourceType, resourceName, environment.Name, environment.ProjectId,
+					templateId, setA, setB,
+				)
+			}
+
+			testCase := resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						Config: resourceConfig(vs1.Id, vs2.Id),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "id", environment.Id),
+							resource.TestCheckResourceAttr(accessor, "prevent_auto_deploy", "true"),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.0", vs1.Id),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.1", vs2.Id),
+						),
+					},
+					{
+						Config: resourceConfig(vs2.Id, vs3.Id),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr(accessor, "variable_sets.0", vs2.Id),
+							resource.TestCheckResourceAttr(accessor, "variable_sets.1", vs3.Id),
+						),
+					},
+				},
+			}
+
+			runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+				mock.EXPECT().Template(templateId).AnyTimes().Return(template, nil)
+				mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(environment, nil)
+
+				mock.EXPECT().Environment(environment.Id).AnyTimes().Return(environment, nil)
+				mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, environment.Id).AnyTimes().Return(client.ConfigurationChanges{}, nil)
+
+				assigned := []client.ConfigurationSet{vs1, vs2}
+
+				mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", environment.Id).AnyTimes().DoAndReturn(
+					func(_ string, _ string) ([]client.ConfigurationSet, error) {
+						return assigned, nil
+					},
+				)
+
+				mock.EXPECT().AssignConfigurationSets("environment", environment.Id, []string{vs3.Id}).Times(1).DoAndReturn(
+					func(_ string, _ string, _ []string) error {
+						assigned = []client.ConfigurationSet{vs2, vs3}
+
+						return nil
+					},
+				)
+
+				mock.EXPECT().UnassignConfigurationSets("environment", environment.Id, []string{vs1.Id}).Times(1).DoAndReturn(
+					func(_ string, _ string, _ []string) error {
+						assigned = []client.ConfigurationSet{vs2, vs3}
+
+						return nil
+					},
+				)
+
+				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1)
+			})
+		})
+
 		t.Run("No drift with unspecified fields", func(t *testing.T) {
 			truthyValue := true
 			falseyValue := false
@@ -3635,6 +3830,122 @@ func TestUnitEnvironmentWithSubEnvironment(t *testing.T) {
 				// Destroy
 				mock.EXPECT().EnvironmentDestroy(environment.Id).Times(1),
 			)
+		})
+	})
+
+	t.Run("prevent_auto_deploy - update persists sub environment configuration without deploying", func(t *testing.T) {
+		subEnvId := "subenv1id"
+		alias := "alias1"
+
+		workflowEnvironment := client.Environment{
+			Id:               uuid.New().String(),
+			Name:             "my-workflow",
+			ProjectId:        template.ProjectId,
+			BlueprintId:      "workflow-template-id",
+			RequiresApproval: new(false),
+			LatestDeploymentLog: client.DeploymentLog{
+				BlueprintId: "workflow-template-id",
+				WorkflowFile: &client.WorkflowFile{
+					Environments: map[string]client.WorkflowSubEnvironment{
+						alias: {EnvironmentId: subEnvId},
+					},
+				},
+			},
+		}
+
+		varType := client.ConfigurationVariableTypeEnvironment
+		varSchema := client.ConfigurationVariableSchema{Type: "string"}
+
+		existingSubVar := client.ConfigurationVariable{
+			Id:     "sub-var-id",
+			Name:   "name",
+			Value:  "value",
+			Type:   &varType,
+			Schema: &varSchema,
+		}
+		updatedSubVar := existingSubVar
+		updatedSubVar.Value = "value2"
+
+		resourceConfig := func(value string) string {
+			return fmt.Sprintf(`
+			resource "%s" "%s" {
+				name                = "%s"
+				project_id          = "%s"
+				template_id         = "%s"
+				prevent_auto_deploy = true
+				force_destroy       = true
+				sub_environment_configuration {
+					alias    = "%s"
+					revision = "revision1"
+					configuration {
+						name  = "name"
+						value = "%s"
+					}
+				}
+			}`,
+				resourceType, resourceName, workflowEnvironment.Name, workflowEnvironment.ProjectId,
+				workflowEnvironment.BlueprintId, alias, value,
+			)
+		}
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfig("value"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "id", workflowEnvironment.Id),
+						resource.TestCheckResourceAttr(accessor, "sub_environment_configuration.0.id", subEnvId),
+						resource.TestCheckResourceAttr(accessor, "sub_environment_configuration.0.configuration.0.value", "value"),
+					),
+				},
+				{
+					Config: resourceConfig("value2"),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "sub_environment_configuration.0.configuration.0.value", "value2"),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().Template(workflowEnvironment.BlueprintId).AnyTimes().Return(template, nil)
+			mock.EXPECT().EnvironmentCreate(gomock.Any()).Times(1).Return(workflowEnvironment, nil)
+
+			mock.EXPECT().Environment(workflowEnvironment.Id).AnyTimes().Return(workflowEnvironment, nil)
+			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeWorkflow, workflowEnvironment.Id).AnyTimes().Return(client.ConfigurationChanges{}, nil)
+			mock.EXPECT().ConfigurationSetsAssignments("ENVIRONMENT", workflowEnvironment.Id).AnyTimes().Return(nil, nil)
+
+			persisted := false
+
+			mock.EXPECT().ConfigurationVariablesByScope(client.ScopeEnvironment, subEnvId).AnyTimes().DoAndReturn(
+				func(_ client.Scope, _ string) ([]client.ConfigurationVariable, error) {
+					if persisted {
+						return client.ConfigurationChanges{updatedSubVar}, nil
+					}
+
+					return client.ConfigurationChanges{existingSubVar}, nil
+				},
+			)
+
+			// The sub environment variable must be persisted directly, without a deployment.
+			mock.EXPECT().ConfigurationVariableUpdate(client.ConfigurationVariableUpdateParams{
+				Id: existingSubVar.Id,
+				CommonParams: client.ConfigurationVariableCreateParams{
+					Name:    "name",
+					Value:   "value2",
+					Scope:   client.ScopeEnvironment,
+					ScopeId: subEnvId,
+					Type:    client.ConfigurationVariableTypeEnvironment,
+				},
+			}).Times(1).DoAndReturn(
+				func(_ client.ConfigurationVariableUpdateParams) (client.ConfigurationVariable, error) {
+					persisted = true
+
+					return updatedSubVar, nil
+				},
+			)
+
+			mock.EXPECT().EnvironmentDestroy(workflowEnvironment.Id).Times(1)
 		})
 	})
 }


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

`prevent_auto_deploy` is respected when an `env0_environment` is **created**, but is
**ignored on update**. Changing `configuration`, `revision`, `variable_sets`, `template_id`,
or `sub_environment_configuration` on an existing environment triggers a deployment (run) -
even though the environment is explicitly flagged not to auto-deploy. Teams that manage the
*shape* of their environments with Terraform but run deployments themselves (CI/CD, behind
review gates) get runs kicked off outside their pipeline including production.

#### Minimal repro

```hcl
resource "env0_environment" "this" {
  name                = "example"
  project_id          = env0_project.this.id
  template_id         = var.template_id
  prevent_auto_deploy = true

  configuration {
    name  = "FOO"
    value = "bar" # change to "baz", apply -> a deployment is triggered
  }
}
```

After changing `value` to `"baz"`, `terraform apply` queues a new deployment on the
environment (env0 → Activity) instead of just updating the variable.

Root cause: `shouldDeploy` decides whether to deploy on update purely from which fields
changed and never consults `prevent_auto_deploy`, so the update path always hits the deploy
endpoint.

### Solution

On update, when `prevent_auto_deploy` is set, the provider no longer queues a deployment.
Instead it persists what env0 can apply *without* a run, directly:

- **`configuration`** and **`sub_environment_configuration.*.configuration`** - written via the
  configuration endpoints (create / update / delete per variable).
- **`variable_sets`** - assigned / unassigned via the configuration-set assignment endpoints.
- **`revision` / `template_id`** - these only take effect as part of a deployment, so under
  `prevent_auto_deploy` they're kept declaratively in state and applied by the user's own
  deploy. The read no longer overwrites them from the latest deployment log, avoiding
  perpetual drift.

This mirrors what the env0 backend already does at **create** time (`createWithoutDeploy`):
on create the provider just sends `preventAutoDeploy` in the payload and the backend forks;
on update there's no equivalent endpoint, so the provider makes the same decision client-side.

Notes (by design):

- A `revision` change under `prevent_auto_deploy` is recorded in state but is a no-op until the
  next deployment; external changes to `revision`/`template_id` are not surfaced as drift
  (documented on the field).
- Variables are persisted with sequential per-variable calls (not atomically like the deploy
  endpoint); a mid-loop failure leaves a partial apply that Terraform reconciles next run -
  same behavior as the standalone `env0_configuration_variable` resource.

After the fix the repro updates `FOO` to `baz` with **no** deployment queued, and
`terraform plan` afterwards reports `No changes`.

---

### Manual E2E verification:

- [x] Built the provider locally, wired in via `dev_overrides`, ran against the env0 **dev** stack
- [x] Created an `env0_environment` with `prevent_auto_deploy = true` and a `configuration`
      variable (self-contained config: project + template + assignment + environment)
- [x] Changed the variable value **and** `revision`, then `terraform apply` → **no new
      deployment** on the environment (env0 → Activity) and the variable value is updated
      (env0 → Variables)
- [x] `terraform plan` after the apply → `No changes. Your infrastructure matches the
      configuration.` (no drift on the variable or revision)
- [x] Unit tests cover update / create / delete of variables under `prevent_auto_deploy`
      (asserting `ConfigurationVariableUpdate/Create/Delete` fire and `EnvironmentDeploy` does
      **not**), variable-set assign/unassign, sub-environment configuration, and
      revision/template_id drift suppression

> Re @liranfarage89 (WORKFLOW-scoped top-level config): **confirmed.** The env0 backend treats
> `WORKFLOW` as a first-class scope on the direct `/configuration` write
> (`assert-configuration-scopes.ts`) and returns it for the matching `workflowEnvironmentId`
> query (`find-by-scope.ts`) - the exact query the provider's read issues. Verified end-to-end via
> an API round-trip on the dev stack: a direct `scope=WORKFLOW` write returned HTTP 200 and was
> persisted (`scopeSortKey=WORKFLOW:<envId>`), then read back with `scope=WORKFLOW, scopeId=<envId>`.

Closes https://linear.app/env-zero/issue/APO-96/preventautodeploy-is-ignored-on-certain-environment-updates

