### PR TITLE
Fix: broken links in Terraform provider docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 # env0 Provider
 
-The [env0](https://www.env0.com) provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer tho [this guide](https://developer.env0.com/docs/api/YXBpOjY4Njc2-env0-api#creating-an-api-key) on how to generate those credentials.
+The [env0](https://www.env0.com) provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer to [this guide](https://docs.envzero.com/guides/admin-guide/user-role-and-team-management/api-keys) on how to generate those credentials.
 
 Use the navigation to the left to read about the available resources.
 

--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -178,7 +178,7 @@ Optional:
 - `is_gitlab` (Boolean) set to 'true' if the repository is Gitlab
 - `is_gitlab_enterprise` (Boolean) true if this template uses gitlab enterprise repository
 - `is_helm_repository` (Boolean) true if this template integrates with a helm repository
-- `is_terragrunt_run_all` (Boolean) true if this template should execute run-all commands on multiple modules (check https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above
+- `is_terragrunt_run_all` (Boolean) true if this template should execute run-all commands on multiple modules (check https://docs.terragrunt.com/reference/cli/commands/run/#running-multiple-units for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above
 - `opentofu_version` (String) the Opentofu version to use (example: 1.6.2). Setting to 'RESOLVE_FROM_CODE' extracts the version from the Opentofu code during runtime. Setting to `latest`, the version used will be the most recent one available for Opentofu.
 - `path` (String) terraform / terragrunt file folder inside source code
 - `retries_on_deploy` (Number) number of times to retry when deploying an environment based on this template

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -77,7 +77,7 @@ resource "env0_template_project_assignment" "assignment" {
 - `is_gitlab` (Boolean) set to 'true' if the repository is Gitlab
 - `is_gitlab_enterprise` (Boolean) true if this template uses gitlab enterprise repository
 - `is_helm_repository` (Boolean) true if this template integrates with a helm repository
-- `is_terragrunt_run_all` (Boolean) true if this template should execute run-all commands on multiple modules (check https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above
+- `is_terragrunt_run_all` (Boolean) true if this template should execute run-all commands on multiple modules (check https://docs.terragrunt.com/reference/cli/commands/run/#running-multiple-units for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above
 - `opentofu_version` (String) the Opentofu version to use (example: 1.6.2). Setting to 'RESOLVE_FROM_CODE' extracts the version from the Opentofu code during runtime. Setting to `latest`, the version used will be the most recent one available for Opentofu.
 - `path` (String) terraform / terragrunt file folder inside source code
 - `retries_on_deploy` (Number) number of times to retry when deploying an environment based on this template

--- a/env0/resource_template.go
+++ b/env0/resource_template.go
@@ -216,7 +216,7 @@ func getTemplateSchema(prefix string) map[string]*schema.Schema {
 		"is_terragrunt_run_all": {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Description: "true if this template should execute run-all commands on multiple modules (check https://terragrunt.gruntwork.io/docs/features/execute-terraform-commands-on-multiple-modules-at-once/#the-run-all-command for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above",
+			Description: "true if this template should execute run-all commands on multiple modules (check https://docs.terragrunt.com/reference/cli/commands/run/#running-multiple-units for additional details). Can only be true with 'terragrunt' template type and terragrunt version 0.28.1 and above",
 			Default:     "false",
 		},
 		"is_azure_devops": {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # env0 Provider
 
-The [env0](https://www.env0.com) provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer tho [this guide](https://developer.env0.com/docs/api/YXBpOjY4Njc2-env0-api#creating-an-api-key) on how to generate those credentials.
+The [env0](https://www.env0.com) provider is used to interact with the resources supported by env0. The provider needs to be configured with proper credentials before it can be used. Please refer to [this guide](https://docs.envzero.com/guides/admin-guide/user-role-and-team-management/api-keys) on how to generate those credentials.
 
 Use the navigation to the left to read about the available resources.
 


### PR DESCRIPTION
## Summary
- Fixes [ENG-1944](https://linear.app/env-zero/issue/ENG-1944/fix-broken-this-guide-link-in-terraform-docs): the "this guide" link in the provider index page pointed to an old readme.io reference URL that now 404s after the docs migration to docs.envzero.com. Repointed to the live guide covering API key creation.
- While checking the rest of the provider docs for other stale links, found `is_terragrunt_run_all`'s description linking to Terragrunt's old docs domain, which now redirects to an unrelated "Stacks" page instead of the run-all docs (Terragrunt moved to docs.terragrunt.com). Repointed to the current run-all page/section. This string lives in the Go schema, so it's fixed at the source and mirrored into the two generated doc files (no Go toolchain available locally to run `tfplugindocs generate`).

## Test plan
- [ ] Confirm both new URLs resolve on merge (already verified manually: docs.envzero.com/guides/admin-guide/user-role-and-team-management/api-keys and docs.terragrunt.com/reference/cli/commands/run/#running-multiple-units both return 200 with matching content)
- [ ] Run `tfplugindocs generate` in CI/dev env to confirm generated docs stay in sync with the Go source

🤖 Generated with [Claude Code](https://claude.com/claude-code)