### PR TITLE
Feat: one-click release via manual workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,12 @@
-# This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+# This GitHub action publishes release assets to the Terraform Public Registry.
 #
-# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your
+# It runs either:
+#   - manually via the "Run workflow" button (workflow_dispatch) — pick a bump
+#     (patch/minor/major); the next tag is computed from the latest tag, created,
+#     and pushed for you; or
+#   - automatically when a "v*.*.*" tag is pushed (the legacy flow).
+#
+# This uses an action (crazy-max/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
@@ -11,22 +16,57 @@
 #
 name: release
 on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
   push:
     tags:
       - "v*.*.*"
+
+permissions:
+  contents: write
 
 env:
   GO_VERSION: "1.26"
 
 jobs:
   goreleaser:
-    environment: release
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+      - name: Create and push tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          latest=$(git tag --sort=-v:refname | head -n1)
+          latest=${latest#v}
+          IFS='.' read -r ma mi pa <<< "$latest"
+          case "${{ inputs.bump }}" in
+            major) ma=$((ma+1)); mi=0; pa=0;;
+            minor) mi=$((mi+1)); pa=0;;
+            patch) pa=$((pa+1));;
+          esac
+          new="v${ma}.${mi}.${pa}"
+          if git rev-parse "$new" >/dev/null 2>&1; then
+            echo "::error::tag $new already exists"; exit 1
+          fi
+          echo "Bumping $latest -> $new"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$new"
+          # Pushed with the default GITHUB_TOKEN, so GitHub does NOT re-trigger
+          # the push:tags run above — no double release.
+          git push origin "$new"
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ go generate ./...
 To release a version to the [Terraform Public Registry](https://registry.terraform.io/providers/env0/env0/latest?pollNotifications=true):
 
 1. Validate that all status checks are ✅ on `main` branch (specifically that docs generation is complete)
-2. Pull from remote first - `git pull origin main`
-3. Create and push a tag **locally**, in semver format - `git tag v0.0.9 && git push origin --tags`
-4. New release with binaries **will be automatically generated** by the GitHub action defined in `.github/workflows/release.yml`. It needs to be approved.
-5. The Registry will automatically pick up on the new version.
+2. Go to **Actions → release → Run workflow**, select the branch (`main`) and the version bump (`patch`/`minor`/`major`), then **Run workflow**. It computes the next tag from the latest one, creates & pushes it, and publishes the release with binaries — no approval needed.
+3. The Registry will automatically pick up on the new version.
+
+Alternatively, pushing a `v*.*.*` tag manually (`git tag v0.0.9 && git push origin --tags`) also triggers the same release.


### PR DESCRIPTION
## What

Collapse the two-step release flow (create tag locally → push → approve gated action) into a single manually-triggered GitHub Action.

## Changes

- **`workflow_dispatch` with a `bump` dropdown** (`patch`/`minor`/`major`, default `patch`) added to `release.yml`. Run it from **Actions → release → Run workflow**: it computes the next tag from the latest one, verifies it doesn't exist, tags HEAD, and pushes it — then GoReleaser publishes as before.
- **Kept the `push: tags: v*.*.*` trigger** as a fallback. The manual path pushes the tag with the default `GITHUB_TOKEN`, which GitHub does *not* use to re-trigger workflows, so there's no duplicate release.
- **Removed the `environment: release` approval gate** so the action runs unattended. Verified via `gh api` that `GPG_PRIVATE_KEY`/`PASSPHRASE` are repo-level secrets (the `release` environment holds 0 secrets), so signing is unaffected.
- Added `permissions: contents: write` and `fetch-depth: 0` (replacing the separate Unshallow step).
- Updated README §Release.

## Verification

- Bump logic self-checked for patch/minor/major (`v1.31.3` → `v1.31.4` / `v1.32.0` / `v2.0.0`).
- Workflow YAML parses clean.
- End-to-end: run Actions → release → Run workflow (bump=patch) from `main`, confirm the new tag, signed `SHA256SUMS`, registry pickup, and no duplicate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)