### PR TITLE
[APO-118] Feat: Add is_read_only support to env0_variable_set variables

### DIFF
--- a/docs/resources/variable_set.md
+++ b/docs/resources/variable_set.md
@@ -59,6 +59,14 @@ resource "env0_variable_set" "organization_scope_example" {
     type            = "terraform"
     format          = "dropdown"
   }
+
+  variable {
+    name         = "n6"
+    value        = "v6"
+    type         = "terraform"
+    format       = "text"
+    is_read_only = true
+  }
 }
 
 resource "env0_variable_set" "project_scope_example" {
@@ -113,6 +121,7 @@ Optional:
 
 - `dropdown_values` (List of String) a list of variable values for 'dropdown' format
 - `format` (String) the value format: 'text' (free text), 'dropdown' (dropdown list), 'hcl', 'json'. Note: 'hcl' and 'json' can only be used in terraform variables.
+- `is_read_only` (Boolean) is the variable read-only, i.e. it cannot be overridden in a lower scope (defaults to 'false')
 - `is_sensitive` (Boolean) is the value sensitive (defaults to 'false'). Note: 'dropdown' value format cannot be sensitive.
 - `type` (String) variable type: terraform or environment (defaults to 'environment')
 - `value` (String) variable value for 'hcl', 'json', or 'text' format

--- a/env0/resource_variable_set.go
+++ b/env0/resource_variable_set.go
@@ -43,6 +43,12 @@ var variableSetVariableSchema *schema.Resource = &schema.Resource{
 			Optional:    true,
 			Default:     false,
 		},
+		"is_read_only": {
+			Type:        schema.TypeBool,
+			Description: "is the variable read-only, i.e. it cannot be overridden in a lower scope (defaults to 'false')",
+			Optional:    true,
+			Default:     false,
+		},
 		"format": {
 			Type:             schema.TypeString,
 			Description:      "the value format: 'text' (free text), 'dropdown' (dropdown list), 'hcl', 'json'. Note: 'hcl' and 'json' can only be used in terraform variables.",
@@ -107,6 +113,13 @@ func getVariableFromSchema(d map[string]any) (*client.ConfigurationVariable, err
 	}
 
 	res.IsSensitive = &isSensitive
+
+	isReadOnly, ok := d["is_read_only"].(bool)
+	if !ok {
+		isReadOnly = false
+	}
+
+	res.IsReadOnly = &isReadOnly
 
 	variableType := d["type"].(string)
 	if variableType == client.TERRAFORM {
@@ -196,6 +209,12 @@ func getSchemaFromVariables(variables []client.ConfigurationVariable) (any, erro
 			ivariable["is_sensitive"] = false
 		} else {
 			ivariable["is_sensitive"] = true
+		}
+
+		if variable.IsReadOnly == nil || !*variable.IsReadOnly {
+			ivariable["is_read_only"] = false
+		} else {
+			ivariable["is_read_only"] = true
 		}
 
 		switch {

--- a/env0/resource_variable_set_test.go
+++ b/env0/resource_variable_set_test.go
@@ -29,6 +29,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 		Value:          "v1",
 		OrganizationId: organizationId,
 		IsSensitive:    new(false),
+		IsReadOnly:     new(false),
 		Scope:          "SET",
 		Type:           (*client.ConfigurationVariableType)(new(1)),
 		Schema: &client.ConfigurationVariableSchema{
@@ -45,6 +46,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 		Value:          "v2",
 		OrganizationId: organizationId,
 		IsSensitive:    new(true),
+		IsReadOnly:     new(false),
 		Scope:          "SET",
 		Type:           (*client.ConfigurationVariableType)(new(0)),
 		Schema: &client.ConfigurationVariableSchema{
@@ -62,6 +64,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 		Value:          "sdzdfsdfsd",
 		OrganizationId: organizationId,
 		IsSensitive:    new(false),
+		IsReadOnly:     new(false),
 		Scope:          "SET",
 		Type:           (*client.ConfigurationVariableType)(new(1)),
 		Schema: &client.ConfigurationVariableSchema{
@@ -78,6 +81,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 		Value:          "{}",
 		OrganizationId: organizationId,
 		IsSensitive:    new(false),
+		IsReadOnly:     new(false),
 		Scope:          "SET",
 		Type:           (*client.ConfigurationVariableType)(new(1)),
 		Schema: &client.ConfigurationVariableSchema{
@@ -94,6 +98,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 		Value:          "o1",
 		OrganizationId: organizationId,
 		IsSensitive:    new(false),
+		IsReadOnly:     new(false),
 		Scope:          "SET",
 		Type:           (*client.ConfigurationVariableType)(new(1)),
 		Schema: &client.ConfigurationVariableSchema{
@@ -108,6 +113,23 @@ func TestUnitVariableSetResource(t *testing.T) {
 	dropdownVariableWithScopeId.Id = "iddropdownvariable"
 	dropdownVariableWithScopeId.ScopeId = configurationSet.Id
 
+	readOnlyVariable := client.ConfigurationVariable{
+		Name:           "ro1",
+		Value:          "rov1",
+		OrganizationId: organizationId,
+		IsSensitive:    new(false),
+		IsReadOnly:     new(true),
+		Scope:          "SET",
+		Type:           (*client.ConfigurationVariableType)(new(1)),
+		Schema: &client.ConfigurationVariableSchema{
+			Type: "string",
+		},
+	}
+
+	readOnlyVariableWithScopeId := readOnlyVariable
+	readOnlyVariableWithScopeId.Id = "idreadonlyvariable"
+	readOnlyVariableWithScopeId.ScopeId = configurationSet.Id
+
 	t.Run("basic - organization scope", func(t *testing.T) {
 		createPayload := client.CreateConfigurationSetPayload{
 			Name:        configurationSet.Name,
@@ -119,6 +141,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 				hclVariable,
 				jsonVariable,
 				dropdownVariable,
+				readOnlyVariable,
 			},
 		}
 
@@ -164,12 +187,21 @@ func TestUnitVariableSetResource(t *testing.T) {
 							type = "terraform"
 							format = "dropdown"
 						}
+
+						variable {
+							name = "%s"
+							value = "%s"
+							type = "terraform"
+							format = "text"
+							is_read_only = true
+						}
 					}`, resourceType, resourceName, createPayload.Name, createPayload.Description,
 						textVariable.Name, textVariable.Value,
 						sensitiveTextVariable.Name, sensitiveTextVariable.Value,
 						hclVariable.Name, hclVariable.Value,
 						jsonVariable.Name, jsonVariable.Value,
 						dropdownVariable.Name,
+						readOnlyVariable.Name, readOnlyVariable.Value,
 					),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", configurationSet.Id),
@@ -198,6 +230,12 @@ func TestUnitVariableSetResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "variable.4.name", dropdownVariable.Name),
 						resource.TestCheckResourceAttr(accessor, "variable.4.type", "terraform"),
 						resource.TestCheckResourceAttr(accessor, "variable.4.format", "dropdown"),
+						resource.TestCheckResourceAttr(accessor, "variable.0.is_read_only", "false"),
+						resource.TestCheckResourceAttr(accessor, "variable.5.value", readOnlyVariable.Value),
+						resource.TestCheckResourceAttr(accessor, "variable.5.name", readOnlyVariable.Name),
+						resource.TestCheckResourceAttr(accessor, "variable.5.type", "terraform"),
+						resource.TestCheckResourceAttr(accessor, "variable.5.format", "text"),
+						resource.TestCheckResourceAttr(accessor, "variable.5.is_read_only", "true"),
 					),
 				},
 			},
@@ -215,6 +253,7 @@ func TestUnitVariableSetResource(t *testing.T) {
 					hclVariableWithScopeId,
 					jsonVariableWithScopeId,
 					dropdownVariableWithScopeId,
+					readOnlyVariableWithScopeId,
 				}, nil),
 				mock.EXPECT().ConfigurationSetDelete(configurationSet.Id).Times(1).Return(nil),
 			)

--- a/examples/resources/env0_variable_set/resource.tf
+++ b/examples/resources/env0_variable_set/resource.tf
@@ -44,6 +44,14 @@ resource "env0_variable_set" "organization_scope_example" {
     type            = "terraform"
     format          = "dropdown"
   }
+
+  variable {
+    name         = "n6"
+    value        = "v6"
+    type         = "terraform"
+    format       = "text"
+    is_read_only = true
+  }
 }
 
 resource "env0_variable_set" "project_scope_example" {


### PR DESCRIPTION
Wire the is_read_only attribute into the variable {} block of the env0_variable_set resource. The backend API and the client struct (ConfigurationVariable.IsReadOnly) already supported it; only the resource schema and its config<->state mapping were missing.

- Add is_read_only (Boolean, Optional, default false) to the variable schema
- Map it in getVariableFromSchema (config -> API) and getSchemaFromVariables (API -> state)
- Cover it in the unit test and example, regenerate docs

**Manual verification**

- `go build .` and `go test -race -v ./...` are clean.

Fixes https://linear.app/env-zero/issue/APO-118/add-is-read-only-support-to-env0-variable-set-variables