### PR TITLE
[APO-185] Fix: Data races in terraform-provider-env0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         run: |
           echo "Using Terraform at: $TF_PATH"
           echo "Terraform version: $TERRAFORM_VERSION"
-          # Run tests with detailed logging and increased timeout
-          TF_LOG=DEBUG go test -timeout 20m -v ./...
+          # Run tests with the race detector, detailed logging and increased timeout
+          TF_LOG=DEBUG go test -race -timeout 20m -v ./...
         env:
           TF_ACC: true
           TF_ACC_TERRAFORM_PATH: ${{ env.TF_PATH }}

--- a/env0/cloud_configuration.go
+++ b/env0/cloud_configuration.go
@@ -90,9 +90,12 @@ func getCloudConfigurationFromApi(apiClient client.ApiClientInterface, id string
 		return nil, fmt.Errorf("failed to json unmarshal %s configuration: %w", cloudAccount.Provider, err)
 	}
 
-	cloudAccount.Configuration = configuration
+	// Return a copy rather than mutating the cloudAccount returned by the API client in place: the
+	// client may hand back a shared instance, and concurrent reads would otherwise race on Configuration.
+	cloudAccountCopy := *cloudAccount
+	cloudAccountCopy.Configuration = configuration
 
-	return cloudAccount, nil
+	return &cloudAccountCopy, nil
 }
 
 func createCloudConfiguration(d *schema.ResourceData, meta any, provider string) diag.Diagnostics {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Running the test suite with the race detector surfaces data races in the cloud-configuration resource:

```
TF_ACC_TERRAFORM_PATH=/usr/bin/terraform go test -race ./...
```

`TestUnitAzureCloudConfigurationResource` and `TestUnitGcpCloudConfigurationResource` fail with `WARNING: DATA RACE` in `getCloudConfigurationFromApi` / `readCloudConfiguration`.

### Solution

`getCloudConfigurationFromApi` mutated the `*client.CloudAccount` returned by the API client **in place**:

```go
cloudAccount.Configuration = configuration
return cloudAccount, nil
```

When the same `*CloudAccount` instance is shared across concurrent `ReadResource` calls, goroutines race on the `Configuration` field — one marshaling it (read), another reassigning it (write). The fix returns a shallow copy and sets `Configuration` on the copy, so the shared instance is only ever read. This is also more defensive in production (callers shouldn't have their input object mutated).

Additionally, CI now runs the unit tests with the race detector (`go test -race`) so future data races are caught.

Verified locally:
- `go test -race ./...` — all packages `ok`, 0 data races (previously Azure + GCP failed)
- `gofmt`, `go vet`, `golangci-lint` all clean

---
### How I _manually_ verified it works
<!-- Think about the flows and features that are affected by this PR -->
<!-- QA Guide: https://env0.slack.com/canvas/C04CLU6J0V9 -->

- [x] How did I verify this works — ran `go test -race ./...` locally against a real Terraform CLI; the cloud-configuration tests that previously reported data races now pass, and the whole suite is race-clean.

- [x] How did I verify I didn't break anything — full `go test -race ./...` passes (all packages `ok`); the change only avoids in-place mutation of the returned struct and does not alter the data written to state.