### PR TITLE
Fix: run docs generation on PRs and commit to the PR branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,8 @@
 name: Docs
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   GO_VERSION: "1.26"
@@ -19,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # Check out the PR head branch (not the merge ref) so generated-doc
+          # changes can be committed straight back onto it.
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -34,6 +33,7 @@ jobs:
       - name: Update generated docs
         run: ./generate-docs.sh
       - name: Commit changes
+        # Only commits & pushes when generate-docs.sh produced a diff.
         uses: EndBug/add-and-commit@v9
         with:
           author_name: update generated docs action

--- a/README.md
+++ b/README.md
@@ -202,15 +202,15 @@ go generate ./...
 ## Documentation
 
 - Docs are generated using github.com/hashicorp/terraform-plugin-docs
-- Run `./generate-docs.sh` to generate docs
-- Must be run manually before releasing a version
+- The `Docs` GitHub Action regenerates docs on every PR and commits any changes back to the PR branch, so generated docs stay in sync automatically — no manual step is needed.
+- You can run `./generate-docs.sh` locally to preview changes if you want.
 - Please add an example to `examples/<resources or data-sources>/env0_<name>` dir and make sure it is added to the docs.
 
 ## Release
 
 To release a version to the [Terraform Public Registry](https://registry.terraform.io/providers/env0/env0/latest?pollNotifications=true):
 
-1. Validate that all status checks are ✅ on `main` branch (specifically that docs generation is complete)
+1. Validate that all status checks are ✅ on `main` branch (generated docs are kept in sync per-PR, so `main` should already be current)
 2. Go to **Actions → release → Run workflow**, select the branch (`main`) and the version bump (`patch`/`minor`/`major`), then **Run workflow**. It computes the next tag from the latest one, creates & pushes it, and publishes the release with binaries — no approval needed.
 3. The Registry will automatically pick up on the new version.
 

--- a/docs/resources/aws_oidc_credentials.md
+++ b/docs/resources/aws_oidc_credentials.md
@@ -32,6 +32,7 @@ resource "env0_aws_oidc_credentials" "credentials" {
 
 - `duration` (Number) the session duration in seconds. If set must be one of the following: 3600 (1h), 7200 (2h), 14400 (4h), 18000 (5h default), 28800 (8h), 43200 (12h)
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/azure_oidc_credentials.md
+++ b/docs/resources/azure_oidc_credentials.md
@@ -34,6 +34,7 @@ resource "env0_azure_oidc_credentials" "credentials" {
 ### Optional
 
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/gcp_oidc_credentials.md
+++ b/docs/resources/gcp_oidc_credentials.md
@@ -32,6 +32,7 @@ resource "env0_gcp_oidc_credentials" "credentials" {
 ### Optional
 
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/vault_oidc_credentials.md
+++ b/docs/resources/vault_oidc_credentials.md
@@ -38,6 +38,7 @@ resource "env0_vault_oidc_credentials" "example" {
 
 - `namespace` (String) an optional vault namespace
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 


### PR DESCRIPTION
## What & why

Our org made `ENV0_BOT_PAT` **permanently read-only**, so the Docs action can no longer push generated docs to `main` (the previous model, and the reason #1112's `GITHUB_TOKEN` switch broke — branch protection blocked it).

New model: the Docs action runs **on each PR**, regenerates the docs, and commits any changes **back onto the PR branch** so generated docs stay in sync with source before merge.

## Changes to `.github/workflows/docs.yml`

- **Trigger**: `push` to `main` → `pull_request` (`opened`, `synchronize`, `reopened`).
- **Checkout**: `ref: ${{ github.head_ref }}` so it checks out the PR head branch (not the detached merge ref), and commits land on the right branch.
- **Token**: `ENV0_BOT_PAT` → `GITHUB_TOKEN` with `permissions: contents: write` — enough to push to a same-repo PR branch, and keeps the CodeQL `missing-workflow-permissions` alert resolved.
- Dropped the `Unshallow` step (only needed for the old main-push flow).
- `EndBug/add-and-commit` is a no-op when `generate-docs.sh` produces no diff.

## Notes / trade-offs

- Works for same-repo PR branches. PRs **from forks** get a read-only `GITHUB_TOKEN`, so the auto-commit would be skipped there — acceptable for this internal provider repo (matches the other `pull_request` workflows).
- ~~The auto-commit is pushed with `GITHUB_TOKEN`, so per GitHub's recursion guard it does **not** re-trigger workflows (including CI) on that new commit — avoids an infinite docs-commit loop.~~ they are triggered, but are waiting for approval by maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)