### PR TITLE
Chore: [ATH-30] add token_format to generated OIDC credential docs

### DIFF
--- a/docs/resources/aws_oidc_credentials.md
+++ b/docs/resources/aws_oidc_credentials.md
@@ -32,6 +32,7 @@ resource "env0_aws_oidc_credentials" "credentials" {
 
 - `duration` (Number) the session duration in seconds. If set must be one of the following: 3600 (1h), 7200 (2h), 14400 (4h), 18000 (5h default), 28800 (8h), 43200 (12h)
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/azure_oidc_credentials.md
+++ b/docs/resources/azure_oidc_credentials.md
@@ -34,6 +34,7 @@ resource "env0_azure_oidc_credentials" "credentials" {
 ### Optional
 
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/gcp_oidc_credentials.md
+++ b/docs/resources/gcp_oidc_credentials.md
@@ -32,6 +32,7 @@ resource "env0_gcp_oidc_credentials" "credentials" {
 ### Optional
 
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 

--- a/docs/resources/vault_oidc_credentials.md
+++ b/docs/resources/vault_oidc_credentials.md
@@ -38,6 +38,7 @@ resource "env0_vault_oidc_credentials" "example" {
 
 - `namespace` (String) an optional vault namespace
 - `project_id` (String) the env0 project id to associate the credentials with
+- `token_format` (String) the OIDC token format. One of: "v1" (default, legacy single-audience) or "v2" (per-provider audience). Leave unset for v1
 
 ### Read-Only
 


### PR DESCRIPTION
## What & why

The generated docs for the `token_format` attribute (added to the OIDC credential resources in #1102 / ATH-30) were never committed, because the automated Docs GH Action is currently broken — `ENV0_BOT_PAT` lost the permissions it needs to push to `main`.

As a stopgap until the PAT is fixed, this regenerates the docs locally (`./generate-docs.sh`) and commits the result manually.

## Changes

Adds the `token_format` optional attribute to the 4 OIDC credential resource docs:
- `aws_oidc_credentials`
- `azure_oidc_credentials`
- `gcp_oidc_credentials`
- `vault_oidc_credentials`

🤖 Generated with [Claude Code](https://claude.com/claude-code)