### PR TITLE
Chore: Retry tofu init on transient provider-download failures

### DIFF
--- a/tests/harness.go
+++ b/tests/harness.go
@@ -202,23 +202,27 @@ func terraformDestroy(testName string) {
 // terraformInit retries `tofu init` because provider downloads from the public
 // registry occasionally time out with transient network errors.
 func terraformInit(testName string) ([]byte, error) {
-	var output []byte
-	var err error
+	var lastErr error
 
 	for attempt := 1; attempt <= initMaxAttempts; attempt++ {
-		output, err = terraformCommand(testName, "init")
+		output, err := terraformCommand(testName, "init")
 		if err == nil {
 			return output, nil
 		}
 
+		lastErr = err
+
+		log.Printf("tofu init failed in %s (attempt %d/%d), reason: %v", testName, attempt, initMaxAttempts, err)
+
 		if attempt < initMaxAttempts {
 			backoff := time.Duration(attempt*5) * time.Second
-			log.Printf("tofu init failed in %s (attempt %d/%d), retrying in %s: %v", testName, attempt, initMaxAttempts, backoff, err)
+
+			log.Printf("retrying tofu init in %s (%s)", testName, backoff)
 			time.Sleep(backoff)
 		}
 	}
 
-	return output, err
+	return nil, lastErr
 }
 
 func terraformCommand(testName string, arg ...string) ([]byte, error) {

--- a/tests/harness.go
+++ b/tests/harness.go
@@ -12,9 +12,12 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 const TESTS_FOLDER = "tests/integration"
+
+const initMaxAttempts = 3
 
 func main() {
 	if err := compileProvider(); err != nil {
@@ -79,7 +82,7 @@ func runTest(testName string, destroy bool) (bool, error) {
 
 	log.Println("Running test ", testName)
 
-	_, err := terraformCommand(testName, "init")
+	_, err := terraformInit(testName)
 	if err != nil {
 		return false, err
 	}
@@ -194,6 +197,28 @@ func terraformDestroy(testName string) {
 	}
 
 	log.Println("Done running tofu destroy in", testName)
+}
+
+// terraformInit retries `tofu init` because provider downloads from the public
+// registry occasionally time out with transient network errors.
+func terraformInit(testName string) ([]byte, error) {
+	var output []byte
+	var err error
+
+	for attempt := 1; attempt <= initMaxAttempts; attempt++ {
+		output, err = terraformCommand(testName, "init")
+		if err == nil {
+			return output, nil
+		}
+
+		if attempt < initMaxAttempts {
+			backoff := time.Duration(attempt*5) * time.Second
+			log.Printf("tofu init failed in %s (attempt %d/%d), retrying in %s: %v", testName, attempt, initMaxAttempts, backoff, err)
+			time.Sleep(backoff)
+		}
+	}
+
+	return output, err
 }
 
 func terraformCommand(testName string, arg ...string) ([]byte, error) {


### PR DESCRIPTION
Retries tofu init up to 3 times with backoff so a transient provider-download/checksum timeout from the public registry no longer fails the whole integration harness.