### PR TITLE
[APO-291] Fix: Resolve env0_template by name via server-side filter

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -35,6 +35,7 @@ type ApiClientInterface interface {
 	ModuleTestingProject() (*ModuleTestingProject, error)
 	Template(id string) (Template, error)
 	Templates() ([]Template, error)
+	TemplatesByName(name string) ([]Template, error)
 	TemplateCreate(payload TemplateCreatePayload) (Template, error)
 	TemplateUpdate(id string, payload TemplateCreatePayload) (Template, error)
 	TemplateDelete(id string) error

--- a/client/api_client_mock.go
+++ b/client/api_client_mock.go
@@ -2324,6 +2324,21 @@ func (mr *MockApiClientInterfaceMockRecorder) Templates() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Templates", reflect.TypeOf((*MockApiClientInterface)(nil).Templates))
 }
 
+// TemplatesByName mocks base method.
+func (m *MockApiClientInterface) TemplatesByName(name string) ([]Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TemplatesByName", name)
+	ret0, _ := ret[0].([]Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TemplatesByName indicates an expected call of TemplatesByName.
+func (mr *MockApiClientInterfaceMockRecorder) TemplatesByName(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplatesByName", reflect.TypeOf((*MockApiClientInterface)(nil).TemplatesByName), name)
+}
+
 // UnassignConfigurationSets mocks base method.
 func (m *MockApiClientInterface) UnassignConfigurationSets(arg0, arg1 string, arg2 []string) error {
 	m.ctrl.T.Helper()

--- a/client/template.go
+++ b/client/template.go
@@ -299,6 +299,22 @@ func (client *ApiClient) Templates() ([]Template, error) {
 	return result, err
 }
 
+func (client *ApiClient) TemplatesByName(name string) ([]Template, error) {
+	organizationId, err := client.OrganizationId()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []Template
+
+	err = client.http.Get("/blueprints", map[string]string{"organizationId": organizationId, "name": name}, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (client *ApiClient) AssignTemplateToProject(id string, payload TemplateAssignmentToProjectPayload) (Template, error) {
 	var result Template
 	if payload.ProjectId == "" {

--- a/client/template_test.go
+++ b/client/template_test.go
@@ -90,6 +90,36 @@ var _ = Describe("Templates Client", func() {
 		})
 	})
 
+	Describe("TemplatesByName", func() {
+		var returnedTemplates []Template
+
+		mockTemplates := []Template{mockTemplate}
+
+		BeforeEach(func() {
+			mockOrganizationIdCall()
+
+			expectedPayload := map[string]string{"organizationId": organizationId, "name": mockTemplate.Name}
+			httpCall = mockHttpClient.EXPECT().
+				Get("/blueprints", expectedPayload, gomock.Any()).
+				Do(func(path string, request any, response *[]Template) {
+					*response = mockTemplates
+				})
+			returnedTemplates, _ = apiClient.TemplatesByName(mockTemplate.Name)
+		})
+
+		It("Should get organization id", func() {
+			organizationIdCall.Times(1)
+		})
+
+		It("Should send GET request with name filter", func() {
+			httpCall.Times(1)
+		})
+
+		It("Should return template", func() {
+			Expect(returnedTemplates).To(Equal(mockTemplates))
+		})
+	})
+
 	Describe("TemplateCreate", func() {
 		var (
 			createdTemplate Template

--- a/env0/data_template.go
+++ b/env0/data_template.go
@@ -183,7 +183,7 @@ func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 func getTemplateByName(name any, meta any) (client.Template, diag.Diagnostics) {
 	apiClient := meta.(client.ApiClientInterface)
 
-	templates, err := apiClient.Templates()
+	templates, err := apiClient.TemplatesByName(name.(string))
 	if err != nil {
 		return client.Template{}, diag.Errorf("Could not query templates: %v", err)
 	}

--- a/env0/data_template_test.go
+++ b/env0/data_template_test.go
@@ -94,7 +94,7 @@ func TestUnitTemplateData(t *testing.T) {
 		runUnitTest(t,
 			getValidTestCase(map[string]any{"name": template.Name}),
 			func(mock *client.MockApiClientInterface) {
-				mock.EXPECT().Templates().AnyTimes().Return([]client.Template{template, deletedTemplate}, nil)
+				mock.EXPECT().TemplatesByName(template.Name).AnyTimes().Return([]client.Template{template, deletedTemplate}, nil)
 			})
 	})
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

[APO-291](https://linear.app/env-zero/issue/APO-291) — concurrent Terraform plans return partial HTTP 500s from the templates API.

The `env0_template` data source resolves a template by name via `GET /blueprints?organizationId=…`, which returns the entire org template list and matches client-side. Under many concurrent plans these full-list reads overload the API and surface as partial 500s.

### Solution

- `client/template.go` — new `TemplatesByName(name)` calling `GET /blueprints?organizationId=…&name=…`, so the API returns only the matching template(s).
- `env0/data_template.go` — `getTemplateByName` uses `TemplatesByName`; the `!IsDeleted` filter and duplicate-name guard are unchanged.
- `client/api_client.go` / `client/api_client_mock.go` — interface method + mock entry.

**Compatibility:** backward compatible. Against an API without the `name` filter, the param is ignored and the full list is returned, so the existing client-side match still resolves correctly. The plural `env0_templates` data source is unchanged.

---
### How I _manually_ verified it works
<!-- Think about the flows and features that are affected by this PR -->

- [x] How did I verify this works

  Ran the provider against an API with the filter available: `data "env0_template" { name = "…" }` resolved the correct template id, and the outgoing request was `GET /blueprints?organizationId=…&name=…` returning only the matching template.

- [x] How did I verify I didn't break anything

  Resolution by `id` is untouched; `env0_templates` still calls `Templates()`; duplicate-name and deleted-template handling in `getTemplateByName` is unchanged; behavior is identical against an API that ignores the new param.
