### PR TITLE
Chore: summarize integration test failures with environment links

### DIFF
--- a/tests/harness.go
+++ b/tests/harness.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -18,6 +18,13 @@ import (
 const TESTS_FOLDER = "tests/integration"
 
 const initMaxAttempts = 3
+
+type testResult struct {
+	name         string
+	passed       bool
+	err          error
+	environments []string
+}
 
 func main() {
 	if err := compileProvider(); err != nil {
@@ -37,24 +44,185 @@ func main() {
 
 	var wg sync.WaitGroup
 
-	for _, testName := range testNames {
+	results := make([]testResult, len(testNames))
+
+	for i, testName := range testNames {
 		wg.Add(1)
 
-		go func(testName string) {
+		go func(i int, testName string) {
+			defer wg.Done()
+
 			if destroyMode == "DESTROY_ONLY" {
 				terraformDestroy(testName)
-			} else {
-				success, err := runTest(testName, destroyMode != "NO_DESTROY")
-				if !success {
-					log.Fatalf("Halting due to test '%s' failure: %s\n", testName, err)
-				}
+				results[i] = testResult{name: testName, passed: true}
+
+				return
 			}
 
-			wg.Done()
-		}(testName)
+			success, environments, err := runTest(testName, destroyMode != "NO_DESTROY")
+			if !success {
+				log.Printf("Test '%s' failed: %v\n", testName, err)
+			}
+
+			results[i] = testResult{name: testName, passed: success, err: err, environments: environments}
+		}(i, testName)
 	}
 
 	wg.Wait()
+
+	if destroyMode == "DESTROY_ONLY" {
+		return
+	}
+
+	failed := printSummary(results)
+
+	writeGithubStepSummary(results)
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func printSummary(results []testResult) int {
+	failed := 0
+
+	log.Println("==================== Integration tests summary ====================")
+
+	for _, result := range results {
+		if result.passed {
+			log.Printf("PASS  %s", result.name)
+		} else {
+			failed++
+
+			log.Printf("FAIL  %s", result.name)
+		}
+	}
+
+	for _, result := range results {
+		if result.passed {
+			continue
+		}
+
+		log.Printf("-------------------- failure details: %s --------------------", result.name)
+
+		for _, environment := range result.environments {
+			log.Println(environment)
+		}
+
+		for _, line := range errorHighlights(result.err) {
+			log.Println(line)
+		}
+	}
+
+	log.Printf("==================== %d/%d tests passed ====================", len(results)-failed, len(results))
+
+	return failed
+}
+
+// errorHighlights extracts the interesting lines from a test failure: terraform
+// diagnostic blocks (╷...╵) and any other lines mentioning an error, skipping the
+// verbose provider logs.
+func errorHighlights(err error) []string {
+	if err == nil {
+		return []string{"test failed without error details"}
+	}
+
+	var (
+		highlights   []string
+		inDiagnostic bool
+	)
+
+	for _, line := range strings.Split(err.Error(), "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		switch {
+		case strings.HasPrefix(trimmed, "╷"):
+			inDiagnostic = true
+
+			highlights = append(highlights, line)
+		case strings.HasPrefix(trimmed, "╵"):
+			inDiagnostic = false
+
+			highlights = append(highlights, line)
+		case inDiagnostic:
+			highlights = append(highlights, line)
+		case strings.Contains(trimmed, "Error") && !strings.Contains(trimmed, "[INFO]"):
+			highlights = append(highlights, line)
+		}
+
+		if len(highlights) >= 100 {
+			highlights = append(highlights, "... (truncated)")
+
+			break
+		}
+	}
+
+	if len(highlights) == 0 {
+		lines := strings.Split(err.Error(), "\n")
+		if len(lines) > 20 {
+			lines = lines[len(lines)-20:]
+		}
+
+		return lines
+	}
+
+	return highlights
+}
+
+// writeGithubStepSummary appends a markdown summary of the test results to the
+// GitHub Actions step summary (no-op outside of GitHub Actions).
+func writeGithubStepSummary(results []testResult) {
+	summaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryPath == "" {
+		return
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString("## Integration tests summary\n\n")
+	sb.WriteString("| Test | Result |\n|---|---|\n")
+
+	failuresExist := false
+
+	for _, result := range results {
+		status := "✅ Pass"
+		if !result.passed {
+			status = "❌ Fail"
+			failuresExist = true
+		}
+
+		sb.WriteString(fmt.Sprintf("| %s | %s |\n", result.name, status))
+	}
+
+	if failuresExist {
+		sb.WriteString("\n### Failures\n")
+
+		for _, result := range results {
+			if result.passed {
+				continue
+			}
+
+			sb.WriteString(fmt.Sprintf("\n#### ❌ %s\n\n", result.name))
+
+			for _, environment := range result.environments {
+				sb.WriteString(fmt.Sprintf("- %s\n", environment))
+			}
+
+			sb.WriteString(fmt.Sprintf("\n```\n%s\n```\n", strings.Join(errorHighlights(result.err), "\n")))
+		}
+	}
+
+	file, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Println("WARNING: unable to open GITHUB_STEP_SUMMARY file:", err)
+
+		return
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(sb.String()); err != nil {
+		log.Println("WARNING: unable to write GITHUB_STEP_SUMMARY:", err)
+	}
 }
 func compileProvider() error {
 	cmd := exec.Command("go", "build")
@@ -66,7 +234,7 @@ func compileProvider() error {
 
 	return nil
 }
-func runTest(testName string, destroy bool) (bool, error) {
+func runTest(testName string, destroy bool) (passed bool, environments []string, err error) {
 	testDir := TESTS_FOLDER + "/" + testName
 	toDelete := []string{
 		".terraform",
@@ -82,9 +250,9 @@ func runTest(testName string, destroy bool) (bool, error) {
 
 	log.Println("Running test ", testName)
 
-	_, err := terraformInit(testName)
+	_, err = terraformInit(testName)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	_, _ = terraformCommand(testName, "fmt")
@@ -93,29 +261,37 @@ func runTest(testName string, destroy bool) (bool, error) {
 		defer terraformDestroy(testName)
 	}
 
+	// Registered after the destroy cleanup so it runs before it (defers are LIFO):
+	// on failure, capture the env0 environments still in the state before they are cleaned up.
+	defer func() {
+		if !passed {
+			environments = environmentsInState(testName)
+		}
+	}()
+
 	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=0")
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	_, err = terraformCommand(testName, "apply", "-auto-approve", "-var", "second_run=1")
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	expectedOutputs, err := readExpectedOutputs(testName)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	outputsBytes, err := terraformCommand(testName, "output", "-json")
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	outputs, err := bytesOfJsonToStringMap(outputsBytes)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	for key, expectedValue := range expectedOutputs {
@@ -123,13 +299,13 @@ func runTest(testName string, destroy bool) (bool, error) {
 		if !ok {
 			log.Println("Error: Expected terraform output ", key, " but no such output was created")
 
-			return false, nil
+			return false, nil, fmt.Errorf("expected terraform output '%s' but no such output was created", key)
 		}
 
 		if value != expectedValue {
 			log.Printf("Error: Expected output of '%s' to be '%s' but found '%s'\n", key, expectedValue, value)
 
-			return false, nil
+			return false, nil, fmt.Errorf("expected output of '%s' to be '%s' but found '%s'", key, expectedValue, value)
 		}
 
 		log.Printf("Verified expected '%s'='%s' in %s", key, value, testName)
@@ -138,13 +314,97 @@ func runTest(testName string, destroy bool) (bool, error) {
 	if destroy {
 		_, err = terraformCommand(testName, "destroy", "-auto-approve", "-var", "second_run=0")
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
 	}
 
 	log.Println("Successfully finished running test ", testName)
 
-	return true, nil
+	return true, nil, nil
+}
+
+type stateModule struct {
+	Resources []struct {
+		Type   string `json:"type"`
+		Values struct {
+			Id        string `json:"id"`
+			Name      string `json:"name"`
+			ProjectId string `json:"project_id"`
+		} `json:"values"`
+	} `json:"resources"`
+	ChildModules []stateModule `json:"child_modules"`
+}
+
+// environmentsInState lists the env0 environments currently in the test's terraform state,
+// each with a direct link to the environment in the env0 UI - to make it easy to find the
+// environment a failed test was running against.
+func environmentsInState(testName string) []string {
+	stateBytes, err := terraformCommand(testName, "show", "-json")
+	if err != nil {
+		return nil
+	}
+
+	var state struct {
+		Values struct {
+			RootModule stateModule `json:"root_module"`
+		} `json:"values"`
+	}
+
+	if err := json.Unmarshal(stateBytes, &state); err != nil {
+		return nil
+	}
+
+	return collectEnvironments(state.Values.RootModule)
+}
+
+func collectEnvironments(module stateModule) []string {
+	var environments []string
+
+	for _, resource := range module.Resources {
+		if resource.Type != "env0_environment" {
+			continue
+		}
+
+		environment := fmt.Sprintf("environment '%s' (id: %s)", resource.Values.Name, resource.Values.Id)
+		if environmentUrl := environmentUiUrl(resource.Values.ProjectId, resource.Values.Id); environmentUrl != "" {
+			environment += " " + environmentUrl
+		}
+
+		environments = append(environments, environment)
+	}
+
+	for _, child := range module.ChildModules {
+		environments = append(environments, collectEnvironments(child)...)
+	}
+
+	return environments
+}
+
+// environmentUiUrl returns a link to the environment in the env0 UI, derived from the
+// API endpoint the tests run against (e.g. https://api.env0.com -> https://app.env0.com).
+func environmentUiUrl(projectId string, environmentId string) string {
+	apiEndpoint := os.Getenv("ENV0_API_ENDPOINT")
+	if apiEndpoint == "" {
+		apiEndpoint = "https://api.env0.com"
+	}
+
+	parsed, err := url.Parse(apiEndpoint)
+	if err != nil || parsed.Host == "" {
+		return ""
+	}
+
+	var host string
+
+	switch {
+	case strings.HasPrefix(parsed.Host, "api-"):
+		host = strings.TrimPrefix(parsed.Host, "api-")
+	case strings.HasPrefix(parsed.Host, "api."):
+		host = "app." + strings.TrimPrefix(parsed.Host, "api.")
+	default:
+		return ""
+	}
+
+	return fmt.Sprintf("https://%s/p/%s/environments/%s", host, projectId, environmentId)
 }
 
 func readExpectedOutputs(testName string) (map[string]string, error) {
@@ -234,8 +494,8 @@ func terraformCommand(testName string, arg ...string) ([]byte, error) {
 
 	var output, errOutput bytes.Buffer
 
-	cmd.Stderr = bufio.NewWriter(&errOutput)
-	cmd.Stdout = bufio.NewWriter(&output)
+	cmd.Stderr = &errOutput
+	cmd.Stdout = &output
 
 	log.Println("Running tofu ", arg, " in ", testName)
 
@@ -245,6 +505,8 @@ func terraformCommand(testName string, arg ...string) ([]byte, error) {
 
 	if err != nil {
 		log.Println("error running tofu ", arg, " in ", testName, " error: ", err)
+
+		err = fmt.Errorf("'tofu %s' failed in %s: %w\n%s", strings.Join(arg, " "), testName, err, errOutput.String())
 	} else {
 		log.Println("Completed successfully tofu", arg, "in", testName)
 	}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

When an integration test fails in CI, the harness halts on the first failure and the actual error is buried in thousands of interleaved provider log lines. For environment-related failures (e.g. `failed to wait for environment destroy to complete, deployment status is: INTERNAL_FAILURE`) there is no indication of *which* environment the test ran against, making failures hard to investigate.

### Solution

Improve the integration test harness (`tests/harness.go`) output — no provider code changes:

- **Run all tests to completion** instead of aborting on the first failure (which also killed other in-flight tests and skipped their cleanup destroys), then exit non-zero if any test failed
- **Print a pass/fail summary** at the end of the run, with only the terraform error diagnostics (`╷ Error ╵` blocks) extracted per failed test, filtering out the verbose provider logs
- **Link failed tests to their env0 environments**: before cleanup, capture the `env0_environment` resources still in the failed test's terraform state (`tofu show -json`, including child modules) and print each environment's name, id, and a direct link to it in the env0 UI, derived from the configured `ENV0_API_ENDPOINT`
- **Write the summary as markdown to `GITHUB_STEP_SUMMARY`** so it renders on the workflow run's summary page (pass/fail table + per-failure environment links and error excerpt)
- Fix output capture: include stderr in returned command errors, and capture process output directly instead of via unflushed buffered writers whose tail could be lost

### Output before / after

**Before** — the run ends mid-flight on the first failure, with no summary and no hint of which environment failed:

```
2026-07-23T09:08:32 [ERROR] provider.terraform-provider-env0: Response contains error diagnostic: ... diagnostic_summary="failed to wait for environment destroy to complete, deployment status is: INTERNAL_FAILURE" ...
╷
│ Error: failed to wait for environment destroy to complete, deployment status is: INTERNAL_FAILURE
│
╵
2026/07/23 09:08:32 error running tofu [destroy -auto-approve -var second_run=0] in 014_environment error: exit status 1
2026/07/23 09:08:32 Halting due to test '014_environment' failure: ...
```

**After** — the full run completes and ends with a summary (the verbose per-test log stream above it is unchanged):

```
==================== Integration tests summary ====================
PASS  003_full_environment
PASS  009_project
FAIL  014_environment
-------------------- failure details: 014_environment --------------------
environment 'my-env-14' (id: 4f2a1c9e-...) https://app.env0.com/p/<project-id>/environments/4f2a1c9e-...
╷
│ Error: failed to wait for environment destroy to complete, deployment status is: INTERNAL_FAILURE
│
╵
==================== 24/25 tests passed ====================
```

And the same summary is rendered on the workflow run's **Summary** page via `GITHUB_STEP_SUMMARY`:

> ## Integration tests summary
>
> | Test | Result |
> |---|---|
> | 003_full_environment | ✅ Pass |
> | 014_environment | ❌ Fail |
>
> ### Failures
>
> #### ❌ 014_environment
>
> - environment 'my-env-14' (id: 4f2a1c9e-...) https://app.env0.com/p/&lt;project-id&gt;/environments/4f2a1c9e-...
>
> ```
> ╷
> │ Error: failed to wait for environment destroy to complete, deployment status is: INTERNAL_FAILURE
> │
> ╵
> ```

### Validation

Validated end-to-end with a stubbed `tofu` binary: verified the console summary, environment link construction, state parsing (environments only, child modules included), the `GITHUB_STEP_SUMMARY` markdown, and exit codes for passing/failing/`DESTROY_ONLY` runs.
