### PR TITLE
Chore: route PRs to a single AI reviewer

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,44 @@
+# Routes each PR to exactly one AI reviewer, to cut Greptile spend:
+#
+#   small and simple  -> Copilot   (cheap)
+#   everything else   -> Greptile  (expensive, deeper)
+#   draft or bot      -> neither
+#
+# Logic lives in env0/gh-workflows and tracks its main branch.
+#
+# This repo is PUBLIC: PRs from forks get a read-only token, so the router skips
+# them. External contributions therefore get no AI review.
+#
+# Greptile is stopped from reviewing the PRs Copilot now covers by greptile.json
+# in this repo root ("skipReview": "AUTOMATIC"). Both parts are required — the
+# workflow alone does not reduce Greptile usage.
+#
+# Escape hatches: label a PR ai-review/force-greptile or ai-review/force-copilot
+# to override the size decision.
+
+name: AI review
+
+on:
+  pull_request:
+    types:
+      - opened            # route new PRs
+      - ready_for_review  # route drafts once they go ready
+      - reopened
+      - labeled           # honour ai-review/force-* overrides
+      - synchronize       # escalate copilot -> greptile if a PR outgrows the
+                          # thresholds; never downgrades
+
+jobs:
+  route:
+    uses: env0/gh-workflows/.github/workflows/ai-review-router.yml@main
+    # Required: a reusable workflow cannot grant itself more than the calling
+    # job already has.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    with:
+      dry_run: false
+      max_churn: 100
+      max_files: 5
+      greptile_trigger: comment

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,11 @@
+{
+  "skipReview": "AUTOMATIC",
+
+  "labels": [
+    "ai-review/greptile",
+    "ai-review/force-greptile"
+  ],
+
+  "triggerOnDrafts": false,
+  "triggerOnUpdates": false
+}


### PR DESCRIPTION
Routes each PR to **exactly one** AI reviewer instead of Greptile on everything.

| PR | Today | After |
| --- | --- | --- |
| small **and** simple | no AI review | **Copilot** (cheap) |
| large / complex | no AI review | Greptile |
| draft or bot-authored | no AI review | neither |

Greptile was only just enabled on this repo, so this is additive rather than a cost reduction here. At the current `100` lines / `5` files thresholds, about **46%** of this repo's PRs route to Copilot.

## This repo is public — fork PRs are skipped

PRs from forks get a read-only `GITHUB_TOKEN`, so the router cannot label them or request reviewers. It now detects a fork and skips cleanly rather than failing with a red workflow on every external contribution.

**External contributions therefore get no AI review** — about 2 of the last 60 PRs here. The only way around it is `pull_request_target`, which runs workflow code with write access against untrusted PRs; not worth it for 3% coverage.

Default `risk_paths` are left as-is: this repo has no migrations, SQL or auth directories, so the pattern never fires.

## Both files are required

- `.github/workflows/ai-review.yml` — decides and applies an `ai-review/*` label
- `greptile.json` — `"skipReview": "AUTOMATIC"` stops Greptile auto-reviewing everything; the router posts `@greptileai` for PRs that should get a deep review

The workflow alone saves nothing.

## How the decision is made (no LLM)

Sizing comes from the webhook payload, so the common path costs zero API calls. First match wins:

1. PR from a fork → skip (read-only token cannot label or request reviews)
2. draft → skip (`force-*` labels do not override this)
3. `ai-review/force-copilot` / `ai-review/force-greptile` → honour it
4. author type `Bot`, or a known PAT-based bot login → skip
5. `> 5` files or `> 100` changed lines → Greptile
6. touches migrations / auth,rbac,secrets dirs → Greptile (small ≠ simple)
7. otherwise → Copilot

Re-evaluated on every push, escalate-only: a PR that grows past the thresholds moves to Greptile, but a push never downgrades it back to Copilot.

## Rolled out and proven elsewhere first

Live in `env0/env0`, `cloudquery/platform`, `cloudquery/frontend` and `cloudquery/cloud-infrastructure`. `GITHUB_TOKEN` is sufficient to request Copilot, and `@greptileai` posted by `github-actions[bot]` triggers a real Greptile review — no PAT needed.

`greptile_trigger: comment` is deliberate. The `label` mode does **not** work: a label does not re-trigger a review while `skipReview` is `"AUTOMATIC"`, and it fails silently.

Escape hatches: label any PR `ai-review/force-greptile` or `ai-review/force-copilot`.