### PR TITLE
[APO-382] Fix: update PolicyUpdatePayload to handle infinite TTLs and adjust API interactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     # 8-vCPU runner: Go Test runs with -race (CPU-bound), so more cores + RAM cut wall time.
     # Integration tests stay on the standard runner — they're backend-bound, not runner-bound.
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ vars.LARGE_RUNNER_LABEL }}
     steps:
       - name: Install Go
         uses: actions/setup-go@v5

--- a/client/project_policy.go
+++ b/client/project_policy.go
@@ -24,24 +24,24 @@ type Policy struct {
 }
 
 type PolicyUpdatePayload struct {
-	ProjectId                   string `json:"projectId"`
-	NumberOfEnvironments        int    `json:"numberOfEnvironments,omitempty"`
-	NumberOfEnvironmentsTotal   int    `json:"numberOfEnvironmentsTotal,omitempty"`
-	RequiresApprovalDefault     bool   `json:"requiresApprovalDefault"`
-	IncludeCostEstimation       bool   `json:"includeCostEstimation"`
-	SkipApplyWhenPlanIsEmpty    bool   `json:"skipApplyWhenPlanIsEmpty"`
-	DisableDestroyEnvironments  bool   `json:"disableDestroyEnvironments"`
-	SkipRedundantDeployments    bool   `json:"skipRedundantDeployments"`
-	RunPullRequestPlanDefault   bool   `json:"runPullRequestPlanDefault"`
-	ContinuousDeploymentDefault bool   `json:"continuousDeploymentDefault"`
-	MaxTtl                      string `json:"maxTtl,omitempty"`
-	DefaultTtl                  string `json:"defaultTtl,omitempty"`
-	ForceRemoteBackend          bool   `json:"forceRemoteBackend"`
-	DriftDetectionCron          string `json:"driftDetectionCron"`
-	DriftDetectionEnabled       bool   `json:"driftDetectionEnabled"`
-	AutoDriftRemediation        string `json:"autoDriftRemediation,omitempty"`
-	VcsPrCommentsEnabledDefault bool   `json:"vcsPrCommentsEnabledDefault"`
-	OutputsAsInputsEnabled      bool   `json:"outputsAsInputsEnabled"`
+	ProjectId                   string  `json:"projectId"`
+	NumberOfEnvironments        int     `json:"numberOfEnvironments,omitempty"`
+	NumberOfEnvironmentsTotal   int     `json:"numberOfEnvironmentsTotal,omitempty"`
+	RequiresApprovalDefault     bool    `json:"requiresApprovalDefault"`
+	IncludeCostEstimation       bool    `json:"includeCostEstimation"`
+	SkipApplyWhenPlanIsEmpty    bool    `json:"skipApplyWhenPlanIsEmpty"`
+	DisableDestroyEnvironments  bool    `json:"disableDestroyEnvironments"`
+	SkipRedundantDeployments    bool    `json:"skipRedundantDeployments"`
+	RunPullRequestPlanDefault   bool    `json:"runPullRequestPlanDefault"`
+	ContinuousDeploymentDefault bool    `json:"continuousDeploymentDefault"`
+	MaxTtl                      *string `json:"maxTtl"`
+	DefaultTtl                  *string `json:"defaultTtl"`
+	ForceRemoteBackend          bool    `json:"forceRemoteBackend"`
+	DriftDetectionCron          string  `json:"driftDetectionCron"`
+	DriftDetectionEnabled       bool    `json:"driftDetectionEnabled"`
+	AutoDriftRemediation        string  `json:"autoDriftRemediation,omitempty"`
+	VcsPrCommentsEnabledDefault bool    `json:"vcsPrCommentsEnabledDefault"`
+	OutputsAsInputsEnabled      bool    `json:"outputsAsInputsEnabled"`
 }
 
 // Policy retrieves a policy from the API

--- a/client/project_policy_test.go
+++ b/client/project_policy_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"encoding/json"
 	"errors"
 
 	. "github.com/env0/terraform-provider-env0/client"
@@ -122,6 +123,52 @@ var _ = Describe("Policy", func() {
 				_, err := apiClient.PolicyUpdate(updatePolicyPayload)
 				Expect(expectedErr).Should(Equal(err))
 			})
+		})
+	})
+
+	Describe("PolicyUpdatePayload ttl serialization", func() {
+		marshalToMap := func(payload PolicyUpdatePayload) map[string]any {
+			serialized, err := json.Marshal(payload)
+			Expect(err).To(BeNil())
+
+			var body map[string]any
+			Expect(json.Unmarshal(serialized, &body)).To(Succeed())
+
+			return body
+		}
+
+		It("Should serialize an unset ttl as an explicit null rather than omitting it", func() {
+			body := marshalToMap(PolicyUpdatePayload{ProjectId: "project0"})
+
+			Expect(body).To(HaveKey("maxTtl"))
+			Expect(body).To(HaveKey("defaultTtl"))
+			Expect(body["maxTtl"]).To(BeNil())
+			Expect(body["defaultTtl"]).To(BeNil())
+		})
+
+		It("Should serialize an infinite max ttl as null alongside a finite default ttl", func() {
+			defaultTtl := "7-h"
+			body := marshalToMap(PolicyUpdatePayload{ProjectId: "project0", DefaultTtl: &defaultTtl})
+
+			Expect(body).To(HaveKey("maxTtl"))
+			Expect(body["maxTtl"]).To(BeNil())
+			Expect(body["defaultTtl"]).To(Equal("7-h"))
+		})
+
+		It("Should serialize finite ttls as their string values", func() {
+			maxTtl, defaultTtl := "1-M", "7-h"
+			body := marshalToMap(PolicyUpdatePayload{ProjectId: "project0", MaxTtl: &maxTtl, DefaultTtl: &defaultTtl})
+
+			Expect(body["maxTtl"]).To(Equal("1-M"))
+			Expect(body["defaultTtl"]).To(Equal("7-h"))
+		})
+
+		It("Should serialize inherited ttls as their string values", func() {
+			maxTtl, defaultTtl := "inherit", "inherit"
+			body := marshalToMap(PolicyUpdatePayload{ProjectId: "project0", MaxTtl: &maxTtl, DefaultTtl: &defaultTtl})
+
+			Expect(body["maxTtl"]).To(Equal("inherit"))
+			Expect(body["defaultTtl"]).To(Equal("inherit"))
 		})
 	})
 })

--- a/docs/resources/project_policy.md
+++ b/docs/resources/project_policy.md
@@ -42,12 +42,12 @@ resource "env0_project_policy" "example" {
 
 - `auto_drift_remediation` (String) Auto drift remediation strategy (DISABLED, CODE_TO_CLOUD, CLOUD_TO_CODE, SMART_REMEDIATION). Defaults to DISABLED
 - `continuous_deployment_default` (Boolean) Redeploy on every push to the git branch default value
-- `default_ttl` (String) the default environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Default value is 'inherit' which inherits the organization policy. must be equal or shorter than max_ttl
+- `default_ttl` (String) the default environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Set to 'Infinite' for environments that never expire (requires max_ttl to be 'Infinite' as well). Default value is 'inherit' which inherits the organization policy. must be equal or shorter than max_ttl
 - `disable_destroy_environments` (Boolean) Disallow destroying environment in the project
 - `drift_detection_cron` (String) default cron expression for new environments
 - `force_remote_backend` (Boolean) if 'true' all environments created in this project will be forced to use env0 remote backend. Default is 'false'
 - `include_cost_estimation` (Boolean) Enable cost estimation for the project
-- `max_ttl` (String) the maximum environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Default value is 'inherit' which inherits the organization policy. must be equal or longer than default_ttl
+- `max_ttl` (String) the maximum environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Set to 'Infinite' for environments that never expire. Default value is 'inherit' which inherits the organization policy. must be equal or longer than default_ttl
 - `number_of_environments` (Number) Max number of environments a single user can have in this project.
 Omitting removes the restriction.
 - `number_of_environments_total` (Number) Max number of environments in this project.

--- a/env0/resource_project_policy.go
+++ b/env0/resource_project_policy.go
@@ -90,14 +90,14 @@ func resourceProjectPolicy() *schema.Resource {
 			},
 			"max_ttl": {
 				Type:             schema.TypeString,
-				Description:      "the maximum environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Default value is 'inherit' which inherits the organization policy. must be equal or longer than default_ttl",
+				Description:      "the maximum environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Set to 'Infinite' for environments that never expire. Default value is 'inherit' which inherits the organization policy. must be equal or longer than default_ttl",
 				Optional:         true,
 				Default:          INHERIT,
 				ValidateDiagFunc: ValidateTtl,
 			},
 			"default_ttl": {
 				Type:             schema.TypeString,
-				Description:      "the default environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Default value is 'inherit' which inherits the organization policy. must be equal or shorter than max_ttl",
+				Description:      "the default environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Set to 'Infinite' for environments that never expire (requires max_ttl to be 'Infinite' as well). Default value is 'inherit' which inherits the organization policy. must be equal or shorter than max_ttl",
 				Optional:         true,
 				Default:          INHERIT,
 				ValidateDiagFunc: ValidateTtl,
@@ -167,7 +167,27 @@ func resourceProjectPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 
+	if err := writePolicyInfiniteTtls(&policy, d); err != nil {
+		return diag.Errorf("schema resource data serialization failed: %v", err)
+	}
+
 	d.SetId(projectId)
+
+	return nil
+}
+
+func writePolicyInfiniteTtls(policy *client.Policy, d *schema.ResourceData) error {
+	if policy.MaxTtl == nil {
+		if err := d.Set("max_ttl", INFINITE); err != nil {
+			return err
+		}
+	}
+
+	if policy.DefaultTtl == nil {
+		if err := d.Set("default_ttl", INFINITE); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -181,21 +201,31 @@ func resourceProjectPolicyUpdate(ctx context.Context, d *schema.ResourceData, me
 		return diag.Errorf("schema resource data deserialization failed: %v", err)
 	}
 
-	// Validate if one is "inherit", the other must be too.
-	if (payload.MaxTtl == INHERIT || payload.DefaultTtl == INHERIT) && payload.MaxTtl != payload.DefaultTtl {
+	maxTtl, defaultTtl := INHERIT, INHERIT
+	if payload.MaxTtl != nil {
+		maxTtl = *payload.MaxTtl
+	}
+
+	if payload.DefaultTtl != nil {
+		defaultTtl = *payload.DefaultTtl
+	}
+
+	payload.MaxTtl, payload.DefaultTtl = &maxTtl, &defaultTtl
+
+	if (maxTtl == INHERIT || defaultTtl == INHERIT) && maxTtl != defaultTtl {
 		return diag.Errorf("max_ttl and default_ttl must both inherit organization settings or override them")
 	}
 
-	if err := validateTtl(&payload.DefaultTtl, &payload.MaxTtl); err != nil {
+	if err := validateTtl(payload.DefaultTtl, payload.MaxTtl); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if payload.DefaultTtl == INFINITE {
-		payload.DefaultTtl = ""
+	if defaultTtl == INFINITE {
+		payload.DefaultTtl = nil
 	}
 
-	if payload.MaxTtl == INFINITE {
-		payload.MaxTtl = ""
+	if maxTtl == INFINITE {
+		payload.MaxTtl = nil
 	}
 
 	if payload.DriftDetectionCron != "" {
@@ -214,9 +244,13 @@ func resourceProjectPolicyDelete(ctx context.Context, d *schema.ResourceData, me
 
 	projectId := d.Id()
 
+	inheritMaxTtl, inheritDefaultTtl := INHERIT, INHERIT
+
 	payload := client.PolicyUpdatePayload{
 		ProjectId:               projectId,
 		RequiresApprovalDefault: true,
+		MaxTtl:                  &inheritMaxTtl,
+		DefaultTtl:              &inheritDefaultTtl,
 	}
 
 	policy, err := apiClient.PolicyUpdate(payload)
@@ -244,6 +278,10 @@ func resourceProjectPolicyImport(ctx context.Context, d *schema.ResourceData, me
 	d.SetId(projectId)
 
 	if err := writeResourceData(&policy, d); err != nil {
+		return nil, fmt.Errorf("schema resource data serialization failed: %w", err)
+	}
+
+	if err := writePolicyInfiniteTtls(&policy, d); err != nil {
 		return nil, fmt.Errorf("schema resource data serialization failed: %w", err)
 	}
 

--- a/env0/resource_project_policy_test.go
+++ b/env0/resource_project_policy_test.go
@@ -147,8 +147,8 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 					SkipApplyWhenPlanIsEmpty:    policy.SkipApplyWhenPlanIsEmpty,
 					DisableDestroyEnvironments:  policy.DisableDestroyEnvironments,
 					SkipRedundantDeployments:    policy.SkipRedundantDeployments,
-					MaxTtl:                      "inherit",
-					DefaultTtl:                  "inherit",
+					MaxTtl:                      new("inherit"),
+					DefaultTtl:                  new("inherit"),
 					ForceRemoteBackend:          true,
 					DriftDetectionEnabled:       true,
 					DriftDetectionCron:          policy.DriftDetectionCron,
@@ -167,8 +167,8 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 					SkipApplyWhenPlanIsEmpty:   updatedPolicy.SkipApplyWhenPlanIsEmpty,
 					DisableDestroyEnvironments: updatedPolicy.DisableDestroyEnvironments,
 					SkipRedundantDeployments:   updatedPolicy.SkipRedundantDeployments,
-					MaxTtl:                     "",
-					DefaultTtl:                 *updatedPolicy.DefaultTtl,
+					MaxTtl:                     nil,
+					DefaultTtl:                 updatedPolicy.DefaultTtl,
 					ForceRemoteBackend:         updatedPolicy.ForceRemoteBackend,
 					DriftDetectionEnabled:      updatedPolicy.DriftDetectionEnabled,
 					DriftDetectionCron:         updatedPolicy.DriftDetectionCron,
@@ -186,6 +186,8 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 					DisableDestroyEnvironments: resetPolicy.DisableDestroyEnvironments,
 					SkipRedundantDeployments:   resetPolicy.SkipRedundantDeployments,
 					ForceRemoteBackend:         resetPolicy.ForceRemoteBackend,
+					MaxTtl:                     new("inherit"),
+					DefaultTtl:                 new("inherit"),
 				}).Times(1).Return(resetPolicy, nil),
 			)
 		})
@@ -204,6 +206,8 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 			SkipRedundantDeployments:   true,
 			UpdatedBy:                  "updater0",
 			AutoDriftRemediation:       "DISABLED",
+			MaxTtl:                     new("inherit"),
+			DefaultTtl:                 new("inherit"),
 		}
 
 		testCaseForDefault := resource.TestCase{
@@ -246,8 +250,8 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 				SkipApplyWhenPlanIsEmpty:   policy.SkipApplyWhenPlanIsEmpty,
 				DisableDestroyEnvironments: policy.DisableDestroyEnvironments,
 				SkipRedundantDeployments:   policy.SkipRedundantDeployments,
-				DefaultTtl:                 "inherit",
-				MaxTtl:                     "inherit",
+				DefaultTtl:                 new("inherit"),
+				MaxTtl:                     new("inherit"),
 				AutoDriftRemediation:       "DISABLED",
 			}).Times(1).Return(policy, nil)
 
@@ -262,6 +266,107 @@ func TestUnitProjectPolicyResource(t *testing.T) {
 				SkipApplyWhenPlanIsEmpty:   resetPolicy.SkipApplyWhenPlanIsEmpty,
 				DisableDestroyEnvironments: resetPolicy.DisableDestroyEnvironments,
 				SkipRedundantDeployments:   resetPolicy.SkipRedundantDeployments,
+				MaxTtl:                     new("inherit"),
+				DefaultTtl:                 new("inherit"),
+			}).Times(1).Return(resetPolicy, nil)
+		})
+	})
+
+	t.Run("both ttls infinite", func(t *testing.T) {
+		infinitePolicy := client.Policy{
+			Id:                      "id0",
+			ProjectId:               "project0",
+			RequiresApprovalDefault: true,
+			UpdatedBy:               "updater0",
+			AutoDriftRemediation:    "DISABLED",
+			// An infinite ttl comes back from the API as a null.
+			MaxTtl:     nil,
+			DefaultTtl: nil,
+		}
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]any{
+						"project_id":  infinitePolicy.ProjectId,
+						"max_ttl":     "Infinite",
+						"default_ttl": "Infinite",
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "project_id", infinitePolicy.ProjectId),
+						resource.TestCheckResourceAttr(accessor, "max_ttl", "Infinite"),
+						resource.TestCheckResourceAttr(accessor, "default_ttl", "Infinite"),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			gomock.InOrder(
+				// Both ttls must reach the API as explicit nulls. Omitting them would
+				// leave the project on the inherited organization policy.
+				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+					ProjectId:               infinitePolicy.ProjectId,
+					RequiresApprovalDefault: true,
+					AutoDriftRemediation:    "DISABLED",
+					MaxTtl:                  nil,
+					DefaultTtl:              nil,
+				}).Times(1).Return(infinitePolicy, nil),
+				// Reading the nulls back must restore "Infinite", otherwise the
+				// post-apply plan would not be empty.
+				mock.EXPECT().Policy(gomock.Any()).Times(1).Return(infinitePolicy, nil),
+				mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+					ProjectId:               infinitePolicy.ProjectId,
+					RequiresApprovalDefault: true,
+					MaxTtl:                  new("inherit"),
+					DefaultTtl:              new("inherit"),
+				}).Times(1).Return(resetPolicy, nil),
+			)
+		})
+	})
+
+	t.Run("empty ttl is treated as inherit, not infinite", func(t *testing.T) {
+		inheritPolicy := client.Policy{
+			Id:                      "id0",
+			ProjectId:               "project0",
+			RequiresApprovalDefault: true,
+			UpdatedBy:               "updater0",
+			AutoDriftRemediation:    "DISABLED",
+			MaxTtl:                  new("inherit"),
+			DefaultTtl:              new("inherit"),
+		}
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]any{
+						"project_id": inheritPolicy.ProjectId,
+						"max_ttl":    "",
+					}),
+					// An empty max_ttl is read back from the API as "inherit", so it never
+					// matches the configured "" - a pre-existing perpetual diff, unrelated
+					// to this fix. What matters here is the payload asserted below.
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			// An empty ttl must not become a null - that would silently grant the
+			// project an infinite ttl.
+			mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+				ProjectId:               inheritPolicy.ProjectId,
+				RequiresApprovalDefault: true,
+				AutoDriftRemediation:    "DISABLED",
+				MaxTtl:                  new("inherit"),
+				DefaultTtl:              new("inherit"),
+			}).Times(1).Return(inheritPolicy, nil)
+			mock.EXPECT().Policy(gomock.Any()).AnyTimes().Return(inheritPolicy, nil)
+			mock.EXPECT().PolicyUpdate(client.PolicyUpdatePayload{
+				ProjectId:               inheritPolicy.ProjectId,
+				RequiresApprovalDefault: true,
+				MaxTtl:                  new("inherit"),
+				DefaultTtl:              new("inherit"),
 			}).Times(1).Return(resetPolicy, nil)
 		})
 	})

--- a/tests/integration/011_policy/expected_outputs.json
+++ b/tests/integration/011_policy/expected_outputs.json
@@ -1,1 +1,4 @@
-{}
+{
+  "infinite_policy_max_ttl": "Infinite",
+  "infinite_policy_default_ttl": "4-d"
+}

--- a/tests/integration/011_policy/main.tf
+++ b/tests/integration/011_policy/main.tf
@@ -89,3 +89,13 @@ resource "env0_project_policy" "test_policy_smart_remediation" {
   drift_detection_cron          = "0 7 * * *"
   auto_drift_remediation        = "SMART_REMEDIATION"
 }
+
+# Reading these back asserts that "Infinite" survives the round-trip to the API.
+# Before the explicit-null fix the provider dropped the field and these read "inherit".
+output "infinite_policy_max_ttl" {
+  value = env0_project_policy.test_policy_infinite.max_ttl
+}
+
+output "infinite_policy_default_ttl" {
+  value = env0_project_policy.test_policy_infinite.default_ttl
+}


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Fixes #1110. Linear: [APO-382](https://linear.app/env-zero/issue/APO-382/env0-project-policy-infinite-ttl-infinite-is-silently-dropped-falls)

`max_ttl = "Infinite"` and `default_ttl = "Infinite"` on `env0_project_policy` apply cleanly and do nothing. Environments keep the organization TTL and are still destroyed.

`resourceProjectPolicyUpdate` maps `Infinite` to `""`, then `omitempty` on the two `string` fields drops the key from the request body. `PUT /policies` reads an absent field as "keep the stored value" and needs an explicit `null` for infinite. The policy stays `inherit` and resolves to the org policy.

A single `Infinite` breaks the same way. `terraform plan` also never converges.

### Solution

- `client/project_policy.go`: `MaxTtl` and `DefaultTtl` become `*string` and lose `omitempty`, so nil serializes as `null`. `OrganizationPolicyUpdatePayload` already does this.
- Update maps `Infinite` to nil. An absent or empty ttl normalizes to `inherit`, keeping nil reserved for infinite.
- Delete sends `inherit` explicitly. Without it nil would serialize as `null`, so `terraform destroy` would set an infinite ttl instead of resetting the policy.
- Read and import map a `null` ttl back to `Infinite`, fixing import and the perpetual diff.
- `Infinite` documented in both schema descriptions, `docs/` regenerated.

**Behaviour changes to note when reviewing:** `terraform destroy` now resets the ttls to `inherit` instead of leaving them untouched. A policy stored as `null` now reads back as `Infinite`, so a project whose stored ttl is `null` while the config says `inherit` will show a one-time diff. That diff is accurate: such a project really is on an infinite ttl.

---
### How I _manually_ verified it works
<!-- Think about the flows and features that are affected by this PR -->

- [x] How did I verify this works

  Built the provider and ran `terraform apply`, `plan` and `destroy` against a local mock of `PUT /policies` that reproduces the `{ ...policies, ...body }` merge from `update-policies.ts`, with the organization policy set to `4-w`.

  Before the fix: the request body contained no `maxTtl` or `defaultTtl` key, the stored policy stayed `inherit`, and the second `plan` exited 2 with `max_ttl = "inherit" -> "Infinite"`.

  After the fix: the body contained `"maxTtl": null` and `"defaultTtl": null`, the stored policy became `null`, and the second `plan` exited 0.

  Not verified against a live env0 organization. I had no API credentials, so the env0 UI and real environment expiry are unchecked.

- [x] How did I verify I didn't break anything

  `terraform destroy` sends `"maxTtl": "inherit"` and the stored policy is `inherit` afterwards, not `null`, so destroying the resource does not disable ttl enforcement.

  Two mutations to confirm the specs have teeth: re-adding `omitempty` fails the new serialization spec, and reverting the delete change fails the resource specs.

  `inherit` and finite-ttl configurations are unchanged, and the existing `Create Failure` specs for mismatched ttls still pass.