### PR TITLE
Fix: cap the integration-test empty-list retry

### DIFF
--- a/env0/provider.go
+++ b/env0/provider.go
@@ -182,6 +182,12 @@ func Provider(version string) plugin.ProviderFunc {
 	}
 }
 
+const (
+	retryCount = 10
+	// Attempts allowed for the integration-test-only empty-list retry, counting the first request.
+	emptyListMaxAttempts = 3
+)
+
 func createRestyClient(ctx context.Context) *resty.Client {
 	var isIntegrationTest bool
 
@@ -191,8 +197,8 @@ func createRestyClient(ctx context.Context) *resty.Client {
 
 	subCtx := tflog.NewSubsystem(ctx, "env0_api_client")
 
-	return resty.New().SetRetryCount(10).
-		SetRetryWaitTime(time.Second + 5).
+	return resty.New().SetRetryCount(retryCount).
+		SetRetryWaitTime(time.Second).
 		SetRetryMaxWaitTime(time.Second * 30).
 		OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
 			if r != nil {
@@ -229,8 +235,16 @@ func createRestyClient(ctx context.Context) *resty.Client {
 				return true
 			}
 
+			// An empty list is a legitimate answer for most list endpoints, so this only covers
+			// read-after-write lag in the integration tests and gets its own small attempt cap.
+			// Sharing the 10-attempt ladder above made every genuinely-empty list (an environment
+			// with no variable sets, a project with no environments) cost ~2.5 minutes.
 			if r.StatusCode() == 200 && isIntegrationTest && r.String() == "[]" {
-				tflog.SubsystemWarn(subCtx, "env0_api_client", "Received an empty list , retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL})
+				if r.Request.Attempt >= emptyListMaxAttempts {
+					return false
+				}
+
+				tflog.SubsystemWarn(subCtx, "env0_api_client", "Received an empty list , retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "attempt": r.Request.Attempt})
 
 				return true
 			}

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -186,6 +186,8 @@ const (
 	retryCount = 10
 	// Attempts allowed for the integration-test-only empty-list retry, counting the first request.
 	emptyListMaxAttempts = 3
+	// Attempts allowed for the integration-test-only 404 retry, counting the first request.
+	notFoundMaxAttempts = 5
 )
 
 func createRestyClient(ctx context.Context) *resty.Client {
@@ -220,10 +222,23 @@ func createRestyClient(ctx context.Context) *resty.Client {
 				return true
 			}
 
-			// When running integration tests 404 may occur due to "database eventual consistency".
 			// Retry when there's a 5xx error. Otherwise do not retry.
-			if r.StatusCode() >= 500 || (isIntegrationTest && r.StatusCode() == 404) {
-				tflog.SubsystemWarn(subCtx, "env0_api_client", "Received a failed or not found response, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "status code": r.StatusCode()})
+			if r.StatusCode() >= 500 {
+				tflog.SubsystemWarn(subCtx, "env0_api_client", "Received a failed response, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "status code": r.StatusCode()})
+
+				return true
+			}
+
+			// When running integration tests 404 may occur due to "database eventual consistency".
+			// Some endpoints answer 404 by design (e.g. /api-keys/oidc-sub for an organization with
+			// no OIDC configured, read by every env0_organization data source), so this gets its own
+			// small attempt cap rather than the full ladder above.
+			if isIntegrationTest && r.StatusCode() == 404 {
+				if r.Request.Attempt >= notFoundMaxAttempts {
+					return false
+				}
+
+				tflog.SubsystemWarn(subCtx, "env0_api_client", "Received a not found response, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "attempt": r.Request.Attempt})
 
 				return true
 			}

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -202,3 +202,27 @@ func TestRestyClientSuite(t *testing.T) {
 	}
 	suite.Run(t, s)
 }
+
+// An empty list is a legitimate answer for most list endpoints. The integration-test-only
+// retry that covers read-after-write lag must stop after emptyListMaxAttempts, or every
+// genuinely-empty list pays the full retry ladder.
+func TestRestyClientEmptyListRetryIsCapped(t *testing.T) {
+	t.Setenv("INTEGRATION_TESTS", "1")
+
+	client := createRestyClient(context.Background())
+	url := "http://fake.env0.com/empty-list"
+
+	httpmock.ActivateNonDefault(client.GetClient())
+	defer httpmock.Deactivate()
+	httpmock.Reset()
+	httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusOK, "[]"))
+
+	res, err := client.R().Get(url)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusOK, res.StatusCode())
+		assert.Equal(t, "[]", res.String())
+	}
+
+	assert.Equal(t, emptyListMaxAttempts, httpmock.GetTotalCallCount())
+}

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/env0/terraform-provider-env0/client"
 	"github.com/env0/terraform-provider-env0/utils"
@@ -203,13 +204,23 @@ func TestRestyClientSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+// createRetryTestClient returns a client with the production retry conditions but a negligible
+// backoff, so asserting on attempt counts doesn't pay the real ladder's wall time.
+func createRetryTestClient(t *testing.T) *resty.Client {
+	t.Helper()
+
+	return createRestyClient(context.Background()).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(time.Millisecond)
+}
+
 // An empty list is a legitimate answer for most list endpoints. The integration-test-only
 // retry that covers read-after-write lag must stop after emptyListMaxAttempts, or every
 // genuinely-empty list pays the full retry ladder.
 func TestRestyClientEmptyListRetryIsCapped(t *testing.T) {
 	t.Setenv("INTEGRATION_TESTS", "1")
 
-	client := createRestyClient(context.Background())
+	client := createRetryTestClient(t)
 	url := "http://fake.env0.com/empty-list"
 
 	httpmock.ActivateNonDefault(client.GetClient())
@@ -227,4 +238,51 @@ func TestRestyClientEmptyListRetryIsCapped(t *testing.T) {
 	}
 
 	assert.Equal(t, emptyListMaxAttempts, httpmock.GetTotalCallCount())
+}
+
+// Some endpoints answer 404 by design, so the integration-test retry that covers database
+// eventual consistency must stop after notFoundMaxAttempts.
+func TestRestyClientNotFoundRetryIsCapped(t *testing.T) {
+	t.Setenv("INTEGRATION_TESTS", "1")
+
+	client := createRetryTestClient(t)
+	url := "http://fake.env0.com/not-found"
+
+	httpmock.ActivateNonDefault(client.GetClient())
+
+	defer httpmock.Deactivate()
+
+	httpmock.Reset()
+	httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, "NOT FOUND"))
+
+	res, err := client.R().Get(url)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusNotFound, res.StatusCode())
+	}
+
+	assert.Equal(t, notFoundMaxAttempts, httpmock.GetTotalCallCount())
+}
+
+// Outside the integration tests a 404 is never retried.
+func TestRestyClientNotFoundIsNotRetried(t *testing.T) {
+	t.Setenv("INTEGRATION_TESTS", "")
+
+	client := createRetryTestClient(t)
+	url := "http://fake.env0.com/not-found-no-integration"
+
+	httpmock.ActivateNonDefault(client.GetClient())
+
+	defer httpmock.Deactivate()
+
+	httpmock.Reset()
+	httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusNotFound, "NOT FOUND"))
+
+	res, err := client.R().Get(url)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusNotFound, res.StatusCode())
+	}
+
+	assert.Equal(t, 1, httpmock.GetTotalCallCount())
 }

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -213,7 +213,9 @@ func TestRestyClientEmptyListRetryIsCapped(t *testing.T) {
 	url := "http://fake.env0.com/empty-list"
 
 	httpmock.ActivateNonDefault(client.GetClient())
+
 	defer httpmock.Deactivate()
+
 	httpmock.Reset()
 	httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusOK, "[]"))
 


### PR DESCRIPTION
## Problem

The `tf_provider_tests / TF Provider Test` job takes ~9.5 minutes while every other post-deploy suite finishes in 2-6 minutes. Measured on run 31942800135, job 95154326012: job total 570s, effectively all inside the single `Run Provider Test Harness` step.

The 41 integration tests already run fully in parallel, so wall clock equals the slowest single test. The critical path is `012_environment` at 553s, followed by `013_downstream_environments` 507s, `002_project` 490s (459s of which is destroy), `041_agent_pool` 458s. The bottom 20 tests all finish under 60s.

## Root cause

`env0/provider.go` retries any HTTP 200 whose body is exactly `[]` when `INTEGRATION_TESTS=1`, using the same ladder as 5xx: `SetRetryCount(10)` with backoff capped at 30s. An empty list is a legitimate answer for most of these endpoints, so the retry never succeeds and always burns the full ladder.

From the job log:

- 770 empty-list retries, forming 54 complete 10-retry ladders.
- Median ladder 144s, max 456s. Summed retry wall across the parallel tests: 10,008s.
- Offenders: `/configuration-sets/assignments/environment/<id>` 484 retries (an environment with no variable sets always returns `[]`, and every `env0_environment` read hits it), `/environments?projectId=<id>` 275 retries (a project with no environments, called from `resourceProjectAssertCanDelete` on every project destroy), `/environments/<id>/downstream` 11.

That accounts for essentially all of `002_project`'s 459s destroy and both long phases of `012_environment`.

## Change

Give the empty-list case its own attempt cap (`emptyListMaxAttempts = 3`) instead of sharing the 10-attempt ladder. Three attempts keep a short cushion for genuine read-after-write lag (roughly 1s + 2s of backoff) rather than removing the retry entirely, which would risk reintroducing flake.

Also changes `SetRetryWaitTime(time.Second + 5)` to `SetRetryWaitTime(time.Second)`. That was 1 second plus 5 nanoseconds, almost certainly a typo for `time.Second * 5`. Making it a plain `time.Second` makes the existing behaviour explicit rather than silently making every 5xx retry five times slower. If the original intent really was 5 seconds, that is a separate decision.

## Verification

New test `TestRestyClientEmptyListRetryIsCapped`, measured before and after:

- before: 11 HTTP calls, 137.81s for a single empty-list response
- after: 3 HTTP calls, 2.95s

```
go build ./... && go vet ./env0/
go test ./env0/ -run TestRestyClient -v   # 4 tests pass
```

Expected result: the job drops from roughly 570s to roughly 150-200s. Follow-up (not in this PR): split the four fat test directories, since `012_environment` stays the longest test at 11 environments in one directory.
