### PR TITLE
[APO-551] Fix: reject tag values padded around the comma separator

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -27,6 +27,19 @@ resource "env0_environment" "example" {
   template_id = data.env0_template.example.id
 }
 
+resource "env0_environment" "example_with_tags" {
+  name        = "environment with tags"
+  project_id  = data.env0_project.default_project.id
+  template_id = data.env0_template.example.id
+
+  tags = {
+    owner         = "alice"
+    "cost-center" = "1234"
+    # a key may hold several values - join them with a comma and no space
+    team = "eng,payments"
+  }
+}
+
 resource "env0_environment" "example_with_hcl_configuration" {
   name        = "environment with hcl"
   project_id  = data.env0_project.default_project.id
@@ -80,7 +93,7 @@ If true must specify one of the following - 'github_installation_id' if using Gi
 If true must specify one of the following - 'github_installation_id' if using GitHub, 'gitlab_project_id' and 'token_id' if using GitLab, or 'bitbucket_client_key' if using BitBucket.
 - `sub_environment_configuration` (Block List) the subenvironments for a workflow environment. Template type must be 'workflow'. Must match the configuration as defined in 'env0.workflow.yml' (see [below for nested schema](#nestedblock--sub_environment_configuration))
 - `tags` (Map of String) the environment's tags. Keys and values may contain letters, digits, spaces and the characters _ . : / + - @ (up to 50 key-value pairs).
-A key may hold several values - join them with a comma (for example: "eng,payments").
+A key may hold several values - join them with a comma and no space (for example: "eng,payments").
 - `template_id` (String) the template id the environment is to be created from.
 Important note: the template must first be assigned to the same project as the environment (project_id). Use 'env0_template_project_assignment' to assign the template to the project. In addition, be sure to leverage 'depends_on' if applicable. Please note that changing this attribute will require environment redeploy
 - `terragrunt_working_directory` (String) The working directory path to be used by a Terragrunt template. If left empty '/' is used. Note: modifying this field destroys the current environment and creates a new one

--- a/env0/resource_environment.go
+++ b/env0/resource_environment.go
@@ -240,11 +240,12 @@ func resourceEnvironment() *schema.Resource {
 			},
 			"tags": {
 				Type:        schema.TypeMap,
-				Description: "the environment's tags. Keys and values may contain letters, digits, spaces and the characters _ . : / + - @ (up to 50 key-value pairs).\nA key may hold several values - join them with a comma (for example: \"eng,payments\").",
+				Description: "the environment's tags. Keys and values may contain letters, digits, spaces and the characters _ . : / + - @ (up to 50 key-value pairs).\nA key may hold several values - join them with a comma and no space (for example: \"eng,payments\").",
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				ValidateDiagFunc: ValidateTags,
 			},
 			"output": {
 				Type:        schema.TypeString,

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -150,8 +150,16 @@ func ValidateTags(i any, path cty.Path) diag.Diagnostics {
 
 	for key, value := range i.(map[string]any) {
 		for _, v := range strings.Split(value.(string), ",") {
-			if v == "" || v != strings.TrimSpace(v) {
-				diags = append(diags, diag.Errorf("tag %q: a value may not be empty or padded with spaces - join a key's values with a comma and no space (for example: \"eng,payments\"), got: %q", key, value)...)
+			if v == "" {
+				diags = append(diags, diag.Errorf("tag %q: value %q has an empty entry - a key's values are joined with a comma and no spaces (for example: \"eng,payments\")", key, value)...)
+
+				break
+			}
+
+			// A padded value is stored verbatim by the API, and then no longer matches an unpadded tag filter.
+			// The environment itself imports fine - it is only the configuration that has to drop the padding.
+			if v != strings.TrimSpace(v) {
+				diags = append(diags, diag.Errorf("tag %q: value %q has a leading or trailing space - a key's values are joined with a comma and no spaces (for example: \"eng,payments\"). If this tag was created outside terraform, drop the padding here and apply to normalize it", key, value)...)
 
 				break
 			}

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -145,10 +145,18 @@ func NewRoleValidator(supportedBuiltInRoles []string) schema.SchemaValidateDiagF
 // A tag value is a comma-joined list of the key's values. A space is legal inside a value, so padding around the
 // separator would otherwise be stored verbatim ("eng, payments" -> ["eng", " payments"]) and the environment would
 // silently stop matching a filter on "payments". Trimming instead would leave config and state permanently unequal.
+// A padded key fails the same way, so it is rejected too.
 func ValidateTags(i any, path cty.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	for key, value := range i.(map[string]any) {
+		// A padded key has the same silent failure as a padded value: it is stored verbatim and stops matching an unpadded tag filter.
+		if key != strings.TrimSpace(key) {
+			diags = append(diags, diag.Errorf("tag %q: the key has a leading or trailing space - a space inside a key is legal, but padding is not. If this tag was created outside terraform, drop the padding here and apply to normalize it", key)...)
+
+			continue
+		}
+
 		for _, v := range strings.Split(value.(string), ",") {
 			if v == "" {
 				diags = append(diags, diag.Errorf("tag %q: value %q has an empty entry - a key's values are joined with a comma and no spaces (for example: \"eng,payments\")", key, value)...)

--- a/env0/validators.go
+++ b/env0/validators.go
@@ -142,6 +142,25 @@ func NewRoleValidator(supportedBuiltInRoles []string) schema.SchemaValidateDiagF
 	}
 }
 
+// A tag value is a comma-joined list of the key's values. A space is legal inside a value, so padding around the
+// separator would otherwise be stored verbatim ("eng, payments" -> ["eng", " payments"]) and the environment would
+// silently stop matching a filter on "payments". Trimming instead would leave config and state permanently unequal.
+func ValidateTags(i any, path cty.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for key, value := range i.(map[string]any) {
+		for _, v := range strings.Split(value.(string), ",") {
+			if v == "" || v != strings.TrimSpace(v) {
+				diags = append(diags, diag.Errorf("tag %q: a value may not be empty or padded with spaces - join a key's values with a comma and no space (for example: \"eng,payments\"), got: %q", key, value)...)
+
+				break
+			}
+		}
+	}
+
+	return diags
+}
+
 func ValidateUrl(i any, path cty.Path) diag.Diagnostics {
 	v := i.(string)
 

--- a/env0/validators_test.go
+++ b/env0/validators_test.go
@@ -179,6 +179,22 @@ func TestValidateTags(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "space inside a key is legal",
+			tags:        map[string]any{"cost center": "platform"},
+			expectError: false,
+		},
+		{
+			// legal server-side, so it can arrive by import - but the key silently stops matching a filter on "owner"
+			name:        "padded key",
+			tags:        map[string]any{" owner": "alice"},
+			expectError: true,
+		},
+		{
+			name:        "trailing space on a key",
+			tags:        map[string]any{"owner ": "alice"},
+			expectError: true,
+		},
+		{
 			name:        "no tags",
 			tags:        map[string]any{},
 			expectError: false,

--- a/env0/validators_test.go
+++ b/env0/validators_test.go
@@ -126,6 +126,62 @@ func TestValidateNotEmptyString(t *testing.T) {
 	}
 }
 
+func TestValidateTags(t *testing.T) {
+	tests := []struct {
+		name        string
+		tags        map[string]any
+		expectError bool
+	}{
+		{
+			name:        "single value",
+			tags:        map[string]any{"owner": "alice"},
+			expectError: false,
+		},
+		{
+			name:        "multi value joined with no space",
+			tags:        map[string]any{"team": "eng,payments"},
+			expectError: false,
+		},
+		{
+			name:        "space inside a value is legal",
+			tags:        map[string]any{"team": "platform eng,payments"},
+			expectError: false,
+		},
+		{
+			name:        "space after the separator",
+			tags:        map[string]any{"team": "eng, payments"},
+			expectError: true,
+		},
+		{
+			name:        "space before the separator",
+			tags:        map[string]any{"team": "eng ,payments"},
+			expectError: true,
+		},
+		{
+			name:        "empty value",
+			tags:        map[string]any{"team": ""},
+			expectError: true,
+		},
+		{
+			name:        "empty segment",
+			tags:        map[string]any{"team": "eng,,payments"},
+			expectError: true,
+		},
+		{
+			name:        "no tags",
+			tags:        map[string]any{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := ValidateTags(tt.tags, cty.Path{})
+			assert.Equal(t, tt.expectError, diags.HasError())
+		})
+	}
+}
+
 func TestValidateRetries(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/env0/validators_test.go
+++ b/env0/validators_test.go
@@ -163,6 +163,17 @@ func TestValidateTags(t *testing.T) {
 			expectError: true,
 		},
 		{
+			// legal server-side, so it can arrive by import - but it silently stops matching a filter on "alice"
+			name:        "padded single value",
+			tags:        map[string]any{"owner": " alice"},
+			expectError: true,
+		},
+		{
+			name:        "trailing space on a single value",
+			tags:        map[string]any{"owner": "alice "},
+			expectError: true,
+		},
+		{
 			name:        "empty segment",
 			tags:        map[string]any{"team": "eng,,payments"},
 			expectError: true,

--- a/examples/resources/env0_environment/resource.tf
+++ b/examples/resources/env0_environment/resource.tf
@@ -12,6 +12,19 @@ resource "env0_environment" "example" {
   template_id = data.env0_template.example.id
 }
 
+resource "env0_environment" "example_with_tags" {
+  name        = "environment with tags"
+  project_id  = data.env0_project.default_project.id
+  template_id = data.env0_template.example.id
+
+  tags = {
+    owner         = "alice"
+    "cost-center" = "1234"
+    # a key may hold several values - join them with a comma and no space
+    team = "eng,payments"
+  }
+}
+
 resource "env0_environment" "example_with_hcl_configuration" {
   name        = "environment with hcl"
   project_id  = data.env0_project.default_project.id


### PR DESCRIPTION
Closes APO-551. Found during the APO-495 Terraform-provider QA.

`env0_environment` `tags` values are comma-joined lists of a key's values. A space is legal *inside* a tag value, so `team = "eng, payments"` was stored verbatim as `["eng", " payments"]` — the apply succeeded, the re-plan was empty, and no error ever appeared, but the environment silently stopped matching a filter on `payments`, in both the env0 API and CloudQuery.

Trimming on the write path alone would swap one bug for another: the server returns the trimmed values, read writes them back to state, and config never matches state again. So this rejects the input at plan time instead — along with empty entries (`"a,,b"`), which until now failed as a raw 400 at apply time. A space *inside* a value stays legal.

Also adds the missing `tags` example to the resource docs, which had none.

## Tags created outside terraform

Padding is legal server-side, so a tag created in the UI or via the API can already have it. Worth being explicit about what this validator does and does not change there, since it is the one behaviour reviewers are most likely to ask about:

- **Import still works.** `terraform import` does not run config validation, so the environment imports and the padded value lands in state verbatim.
- **Config cannot restate the padding.** Writing `owner = " alice"` to match the imported state is rejected. This is deliberate: that value is invisible to `?tags=owner=alice`, so allowing it would keep the silent-filter-miss bug alive for single values.
- **The escape hatch is one apply.** Drop the padding in config and apply — the tag normalizes server-side and the re-plan is empty. Verified end to end.
- The error message says so, rather than talking about comma-joining when the value holds no comma.

The tradeoff: a user who genuinely wants a padded tag value cannot express it through this provider. That seems clearly right — a leading space in a tag value is not something anyone means, and the failure mode of allowing it is silent.

## Manual QA

Built from this branch and run with real Terraform against the dev stage.

Config authoring:

| `tags` in config | Before | After |
| --- | --- | --- |
| `team = "eng,payments"` | applies | applies (unchanged) |
| `note = "platform eng"` | applies | applies (space inside a value still legal) |
| `team = "eng, payments"` | applies, stores `" payments"` | rejected at plan |
| `team = "eng ,payments"` | applies, stores `"eng "` | rejected at plan |
| `owner = " alice"` | applies, stores `" alice"` | rejected at plan |
| `team = ""` | 400 at apply | rejected at plan |
| `team = "eng,,payments"` | 400 at apply | rejected at plan |

Import of an environment whose tags were set out-of-band to `{"squad":["eng"," payments"],"owner":[" alice"]}`:

| Step | Result |
| --- | --- |
| `terraform import` | succeeds; state holds `squad = "eng, payments"`, `owner = " alice"` |
| plan with config matching state | rejected, with the message pointing at normalization |
| plan with padding dropped | `~ "owner" = " alice" -> "alice"`, `~ "squad" = "eng, payments" -> "eng,payments"` |
| apply, then re-plan | converges in one apply; server holds `{"owner":["alice"],"squad":["eng","payments"]}`; re-plan empty |

Confirmed the original impact on the dev stage before fixing: with `["eng", " payments"]` stored, `GET /environments?tags=squad=payments` returned no match while `tags=squad=%20payments` matched.

Full suite green (`go test ./...`). Docs regenerated with `tfplugindocs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)