### PR TITLE
[APO-556] Fix: stop VCS drift suppression from mutating the API response

### DIFF
--- a/env0/resource_custom_flow.go
+++ b/env0/resource_custom_flow.go
@@ -54,16 +54,19 @@ func resourceCustomFlowRead(ctx context.Context, d *schema.ResourceData, meta an
 		return ResourceGetFailure(ctx, "custom flow", d, err)
 	}
 
+	// suppressVcsFieldDrift writes through these pointers, so it gets a copy - the object the client returned is not ours to mutate.
+	flow := *customFlow
+
 	suppressVcsFieldDrift("", VcsFields{
-		GithubInstallationId: &customFlow.GithubInstallationId,
-		VcsConnectionId:      &customFlow.VcsConnectionId,
-		BitbucketClientKey:   &customFlow.BitbucketClientKey,
-		TokenId:              &customFlow.TokenId,
-		IsAzureDevOps:        &customFlow.IsAzureDevOps,
-		IsGitlab:             &customFlow.IsGitLab,
+		GithubInstallationId: &flow.GithubInstallationId,
+		VcsConnectionId:      &flow.VcsConnectionId,
+		BitbucketClientKey:   &flow.BitbucketClientKey,
+		TokenId:              &flow.TokenId,
+		IsAzureDevOps:        &flow.IsAzureDevOps,
+		IsGitlab:             &flow.IsGitLab,
 	}, d)
 
-	if err := writeResourceData(customFlow, d); err != nil {
+	if err := writeResourceData(&flow, d); err != nil {
 		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 

--- a/env0/resource_environment_discovery_configuration.go
+++ b/env0/resource_environment_discovery_configuration.go
@@ -337,15 +337,18 @@ func resourceEnvironmentDiscoveryConfigurationPut(ctx context.Context, d *schema
 		return diag.Errorf("enable/update environment discovery configuration request failed: %s", err.Error())
 	}
 
+	// suppressVcsFieldDrift writes through these pointers, so it gets a copy - the object the client returned is not ours to mutate.
+	payload := *res
+
 	suppressVcsFieldDrift("", VcsFields{
-		GithubInstallationId: &res.GithubInstallationId,
-		VcsConnectionId:      &res.VcsConnectionId,
-		BitbucketClientKey:   &res.BitbucketClientKey,
-		TokenId:              &res.TokenId,
-		IsAzureDevOps:        &res.IsAzureDevops,
+		GithubInstallationId: &payload.GithubInstallationId,
+		VcsConnectionId:      &payload.VcsConnectionId,
+		BitbucketClientKey:   &payload.BitbucketClientKey,
+		TokenId:              &payload.TokenId,
+		IsAzureDevOps:        &payload.IsAzureDevops,
 	}, d)
 
-	if err := setResourceEnvironmentDiscoveryConfiguration(d, res); err != nil {
+	if err := setResourceEnvironmentDiscoveryConfiguration(d, &payload); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -417,15 +420,18 @@ func resourceEnvironmentDiscoveryConfigurationGet(ctx context.Context, d *schema
 		return ResourceGetFailure(ctx, "environment_discovery_configuration", d, err)
 	}
 
+	// suppressVcsFieldDrift writes through these pointers, so it gets a copy - the object the client returned is not ours to mutate.
+	payload := *getPayload
+
 	suppressVcsFieldDrift("", VcsFields{
-		GithubInstallationId: &getPayload.GithubInstallationId,
-		VcsConnectionId:      &getPayload.VcsConnectionId,
-		BitbucketClientKey:   &getPayload.BitbucketClientKey,
-		TokenId:              &getPayload.TokenId,
-		IsAzureDevOps:        &getPayload.IsAzureDevops,
+		GithubInstallationId: &payload.GithubInstallationId,
+		VcsConnectionId:      &payload.VcsConnectionId,
+		BitbucketClientKey:   &payload.BitbucketClientKey,
+		TokenId:              &payload.TokenId,
+		IsAzureDevOps:        &payload.IsAzureDevops,
 	}, d)
 
-	if err := setResourceEnvironmentDiscoveryConfiguration(d, getPayload); err != nil {
+	if err := setResourceEnvironmentDiscoveryConfiguration(d, &payload); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/env0/resource_module.go
+++ b/env0/resource_module.go
@@ -218,16 +218,23 @@ func resourceModuleRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	// Avoid drifts: the backend automatically populates VCS fields from one another.
+	// suppressVcsFieldDrift writes through these pointers, so it gets a copy - the object the client returned is not
+	// ours to mutate. These three fields are pointers, so they need copies of their own.
+	m := *module
+	m.GithubInstallationId = copyPtr(module.GithubInstallationId)
+	m.VcsConnectionId = copyPtr(module.VcsConnectionId)
+	m.BitbucketClientKey = copyPtr(module.BitbucketClientKey)
+
 	suppressVcsFieldDrift("", VcsFields{
-		GithubInstallationId: module.GithubInstallationId,
-		VcsConnectionId:      module.VcsConnectionId,
-		BitbucketClientKey:   module.BitbucketClientKey,
-		TokenId:              &module.TokenId,
-		IsAzureDevOps:        &module.IsAzureDevOps,
-		IsGitlab:             &module.IsGitlab,
+		GithubInstallationId: m.GithubInstallationId,
+		VcsConnectionId:      m.VcsConnectionId,
+		BitbucketClientKey:   m.BitbucketClientKey,
+		TokenId:              &m.TokenId,
+		IsAzureDevOps:        &m.IsAzureDevOps,
+		IsGitlab:             &m.IsGitlab,
 	}, d)
 
-	if err := writeResourceData(module, d); err != nil {
+	if err := writeResourceData(&m, d); err != nil {
 		return diag.Errorf("schema resource data serialization failed: %v", err)
 	}
 

--- a/env0/utils.go
+++ b/env0/utils.go
@@ -523,12 +523,23 @@ type VcsFields struct {
 	IsGitlab             *bool
 }
 
+// copyPtr returns a pointer to a copy of the pointee, so writing through the result leaves the original untouched.
+func copyPtr[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+
+	return new(*p)
+}
+
 // suppressVcsFieldDrift zeroes out VCS fields that the user did NOT specify,
 // preventing false drift when the backend auto-populates fields.
 // When vcs_connection_id is set, all legacy fields are zeroed.
 // When any legacy field is set, vcs_connection_id is zeroed.
 // When both sides are set (e.g., after import), neither is zeroed.
 // The prefix parameter supports nested schemas (e.g., "without_template_settings").
+// It writes through the pointers in fields, so callers pass pointers into a copy rather than into an object they do
+// not own - mutating an API response in place races with any other goroutine still reading it.
 func suppressVcsFieldDrift(prefix string, fields VcsFields, d *schema.ResourceData) {
 	key := func(name string) string {
 		if prefix != "" {

--- a/env0/utils_test.go
+++ b/env0/utils_test.go
@@ -1,6 +1,7 @@
 package env0
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestReadResourceDataModule(t *testing.T) {
@@ -468,4 +470,54 @@ func TestLastSplit(t *testing.T) {
 	assert.Equal(t, []string{"a_", ""}, lastUnderscoreSplit("a__"))
 
 	assert.Equal(t, []string{"abc"}, lastUnderscoreSplit("abc"))
+}
+
+// The unit-test mocks hand the same fixture pointer to every call, so a read that zeroes VCS fields in place both
+// races with concurrent reads of that fixture and blanks the fields the next step expects to see.
+func TestVcsDriftSuppressionLeavesTheApiObjectAlone(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("custom flow", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		customFlow := client.CustomFlow{Id: "id", Name: "name", Repository: "repo", TokenId: "token", VcsConnectionId: "vcs-id"}
+
+		mock := client.NewMockApiClientInterface(ctrl)
+		mock.EXPECT().CustomFlow("id").Times(1).Return(&customFlow, nil)
+
+		d := schema.TestResourceDataRaw(t, resourceCustomFlow().Schema, map[string]any{
+			"name":              "name",
+			"repository":        "repo",
+			"vcs_connection_id": "vcs-id",
+		})
+		d.SetId("id")
+
+		require.False(t, resourceCustomFlowRead(ctx, d, mock).HasError())
+		assert.Equal(t, "token", customFlow.TokenId, "read zeroed a field on the object the client returned")
+	})
+
+	t.Run("module", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// vcs_connection_id is the field zeroed here, and on a module it is a pointer - a shallow copy still shares it.
+		module := client.Module{Id: "id", ModuleName: "name", ModuleProvider: "provider", Repository: "repo",
+			GithubInstallationId: new(1000), VcsConnectionId: new("vcs-id")}
+
+		mock := client.NewMockApiClientInterface(ctrl)
+		mock.EXPECT().Module("id").Times(1).Return(&module, nil)
+
+		d := schema.TestResourceDataRaw(t, resourceModule().Schema, map[string]any{
+			"module_name":            "name",
+			"module_provider":        "provider",
+			"repository":             "repo",
+			"github_installation_id": 1000,
+		})
+		d.SetId("id")
+
+		require.False(t, resourceModuleRead(ctx, d, mock).HasError())
+		require.NotNil(t, module.VcsConnectionId)
+		assert.Equal(t, "vcs-id", *module.VcsConnectionId, "read zeroed a field on the object the client returned")
+	})
 }


### PR DESCRIPTION
Closes APO-556. Found while looking into a red `Unit Tests` check on #1125, whose diff only touches tag validators.

`suppressVcsFieldDrift` zeroes VCS fields by writing through the pointers it is handed, and the read paths handed it pointers straight into the struct the API client returned. In production that is harmless — every call decodes a fresh struct — but the unit-test mocks hand the same fixture pointer to every call (`Times(2).Return(&customFlow, nil)`), so Read and Import touch that one object from separate gRPC goroutines and the race detector fires under `-parallel 16`. It also means a step-2 read receives a fixture whose legacy fields step 1 already blanked, so those steps assert less than they look like they do.

The four affected read paths now pass pointers into a copy. `client.Module` holds `GithubInstallationId`, `VcsConnectionId` and `BitbucketClientKey` as pointers, so a shallow copy still shares them — those get copies of their own via a small `copyPtr` helper. The approval-policy and template call sites already took their struct by value and are unchanged.

Fixing the mocks instead would have meant rewriting ~40 `EXPECT` lines across three test files, and would regress the next time someone writes `Return(&fixture)`.

## Manual QA

`TestVcsDriftSuppressionLeavesTheApiObjectAlone` covers both shapes — value fields (custom flow) and pointer fields (module):

| | custom flow subtest | module subtest |
| --- | --- | --- |
| before the fix | fails: `TokenId` `"token"` -> `""` | fails: `*VcsConnectionId` `"vcs-id"` -> `""` |
| after the fix | passes | passes |

Verified by stashing only the three resource files and re-running, so the test is known to fail against `main`.

Full suite green (`go test ./...`). The original race reproduces only under CI's `-race -parallel 16`; local `-race` runs are not usable on my machine (the `terraform` CLI subprocess segfaults), so the CI check on this PR is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)