### PR TITLE
[ATL-305] Fix: back off properly on 429 responses

### DIFF
--- a/client/http/client.go
+++ b/client/http/client.go
@@ -11,11 +11,12 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-// How long the rate limiter holds back every request after a 429 that carries no Retry-After
-// header. The limit is enforced server side (API gateway and WAF), so the whole client has to
-// idle: retrying only the blocked request while its siblings keep firing is what turns a single
-// 429 into thousands of blocked requests.
-const defaultRateLimitPause = 5 * time.Second
+// DefaultRateLimitPause is how long the rate limiter holds back every request after a 429 that
+// carries no Retry-After header. The limit is enforced server side (API gateway and WAF), so the
+// whole client has to idle: retrying only the blocked request while its siblings keep firing is
+// what turns a single 429 into thousands of blocked requests. The provider's 429 backoff starts
+// from the same value, so the two can't drift apart.
+const DefaultRateLimitPause = 5 * time.Second
 
 type HttpClientInterface interface {
 	Get(path string, params map[string]string, response any) error
@@ -60,6 +61,9 @@ func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
 // applyRateLimiter wires the limiter into the resty middleware rather than into HttpClient's
 // request builder, so that retried attempts count against the limit as well. Otherwise a run
 // that starts getting 429s or 5xx answers sends the retries on top of the allowed rate.
+//
+// The hooks are appended to the resty client, so it must not be handed to NewHttpClient twice:
+// a second call would register a second Wait and halve the effective rate.
 func applyRateLimiter(client *resty.Client, rateLimiter ratelimiter.RateLimiter) {
 	client.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
 		return rateLimiter.Wait(r.Context())
@@ -72,7 +76,7 @@ func applyRateLimiter(client *resty.Client, rateLimiter ratelimiter.RateLimiter)
 
 		pause, ok := ParseRetryAfter(r.Header().Get("Retry-After"))
 		if !ok {
-			pause = defaultRateLimitPause
+			pause = DefaultRateLimitPause
 		}
 
 		rateLimiter.Pause(pause)

--- a/client/http/client.go
+++ b/client/http/client.go
@@ -3,12 +3,19 @@ package http
 //go:generate mockgen -destination=client_mock.go -package=http . HttpClientInterface
 
 import (
-	"context"
+	"net/http"
 	"reflect"
+	"time"
 
 	"github.com/env0/terraform-provider-env0/client/http/ratelimiter"
 	"github.com/go-resty/resty/v2"
 )
+
+// How long the rate limiter holds back every request after a 429 that carries no Retry-After
+// header. The limit is enforced server side (API gateway and WAF), so the whole client has to
+// idle: retrying only the blocked request while its siblings keep firing is what turns a single
+// 429 into thousands of blocked requests.
+const defaultRateLimitPause = 5 * time.Second
 
 type HttpClientInterface interface {
 	Get(path string, params map[string]string, response any) error
@@ -19,11 +26,10 @@ type HttpClientInterface interface {
 }
 
 type HttpClient struct {
-	ApiKey      string
-	ApiSecret   string
-	Endpoint    string
-	client      *resty.Client
-	rateLimiter *ratelimiter.RateLimiter
+	ApiKey    string
+	ApiSecret string
+	Endpoint  string
+	client    *resty.Client
 }
 
 type HttpClientConfig struct {
@@ -36,26 +42,46 @@ type HttpClientConfig struct {
 }
 
 func NewHttpClient(config HttpClientConfig) (*HttpClient, error) {
+	restClient := config.RestClient.SetBaseURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent)
+
+	if config.RateLimiter != nil {
+		applyRateLimiter(restClient, config.RateLimiter)
+	}
+
 	httpClient := &HttpClient{
-		ApiKey:      config.ApiKey,
-		ApiSecret:   config.ApiSecret,
-		client:      config.RestClient.SetBaseURL(config.ApiEndpoint).SetHeader("User-Agent", config.UserAgent),
-		rateLimiter: &config.RateLimiter,
+		ApiKey:    config.ApiKey,
+		ApiSecret: config.ApiSecret,
+		client:    restClient,
 	}
 
 	return httpClient, nil
 }
 
-func (client *HttpClient) request() *resty.Request {
-	if *client.rateLimiter != nil {
-		ctx := context.Background()
+// applyRateLimiter wires the limiter into the resty middleware rather than into HttpClient's
+// request builder, so that retried attempts count against the limit as well. Otherwise a run
+// that starts getting 429s or 5xx answers sends the retries on top of the allowed rate.
+func applyRateLimiter(client *resty.Client, rateLimiter ratelimiter.RateLimiter) {
+	client.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
+		return rateLimiter.Wait(r.Context())
+	})
 
-		err := (*client.rateLimiter).Wait(ctx)
-		if err != nil {
-			return client.client.R().SetError(err)
+	client.OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
+		if r.StatusCode() != http.StatusTooManyRequests {
+			return nil
 		}
-	}
 
+		pause, ok := ParseRetryAfter(r.Header().Get("Retry-After"))
+		if !ok {
+			pause = defaultRateLimitPause
+		}
+
+		rateLimiter.Pause(pause)
+
+		return nil
+	})
+}
+
+func (client *HttpClient) request() *resty.Request {
 	return client.client.R().SetBasicAuth(client.ApiKey, client.ApiSecret)
 }
 

--- a/client/http/rate_limiter_test.go
+++ b/client/http/rate_limiter_test.go
@@ -82,9 +82,13 @@ var _ = Describe("SlidingWindow Rate Limiter", func() {
 
 			httpClient = createClient(2, 200*time.Millisecond)
 
-			var response string
+			done := make(chan struct{})
 
 			go func() {
+				defer close(done)
+
+				var response string
+
 				_ = httpClient.Get(path, nil, &response)
 			}()
 
@@ -94,7 +98,7 @@ var _ = Describe("SlidingWindow Rate Limiter", func() {
 			callCount := httpmock.GetCallCountInfo()
 			Expect(callCount["GET "+BaseUrl+path]).To(Equal(2))
 
-			time.Sleep(300 * time.Millisecond)
+			Eventually(done, 3*time.Second).Should(BeClosed())
 
 			callCount = httpmock.GetCallCountInfo()
 			Expect(callCount["GET "+BaseUrl+path]).To(Equal(4))
@@ -115,21 +119,29 @@ var _ = Describe("SlidingWindow Rate Limiter", func() {
 
 			httpClient = createClient(10, time.Minute)
 
-			var response string
+			var rateLimitedResponse string
 
-			Expect(httpClient.Get(path, nil, &response)).ToNot(BeNil())
+			Expect(httpClient.Get(path, nil, &rateLimitedResponse)).To(HaveOccurred())
+
+			done := make(chan struct{})
 
 			go func() {
+				defer close(done)
+
+				var response string
+
 				_ = httpClient.Get(TestEndpoint, nil, &response)
 			}()
 
+			// The 429 holds back a request to an endpoint that never answered 429 itself.
 			time.Sleep(100 * time.Millisecond)
 
 			callCount := httpmock.GetCallCountInfo()
 			Expect(callCount["GET "+BaseUrl+TestEndpoint]).To(Equal(0))
 
-			// Retry-After said one second, after which the held back request goes out.
-			time.Sleep(time.Second)
+			// Retry-After said one second, after which the held back request goes out (plus the
+			// limiter's wake-up spread).
+			Eventually(done, 3*time.Second).Should(BeClosed())
 
 			callCount = httpmock.GetCallCountInfo()
 			Expect(callCount["GET "+BaseUrl+TestEndpoint]).To(Equal(1))

--- a/client/http/rate_limiter_test.go
+++ b/client/http/rate_limiter_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"net/http"
 	"time"
 
 	httpModule "github.com/env0/terraform-provider-env0/client/http"
@@ -62,6 +63,78 @@ var _ = Describe("SlidingWindow Rate Limiter", func() {
 		Expect(err).To(BeNil())
 		Expect(response).To(Equal(SuccessResponse))
 	}
+
+	Context("with rate limiting applied to retries", func() {
+		// Retried attempts used to bypass the limiter, so a run that started failing sent its
+		// retries on top of the allowed rate - which is what kept the WAF blocking requests.
+		It("should count retried attempts against the limit", func() {
+			const path = "/server-error"
+
+			httpmock.RegisterResponder("GET", BaseUrl+path,
+				httpmock.NewStringResponder(http.StatusInternalServerError, "BAD"))
+
+			restClient.SetRetryCount(3).
+				SetRetryWaitTime(time.Millisecond).
+				SetRetryMaxWaitTime(time.Millisecond).
+				AddRetryCondition(func(r *resty.Response, err error) bool {
+					return r.StatusCode() >= http.StatusInternalServerError
+				})
+
+			httpClient = createClient(2, 200*time.Millisecond)
+
+			var response string
+
+			go func() {
+				_ = httpClient.Get(path, nil, &response)
+			}()
+
+			// Only the window's budget goes out immediately, the retries wait for a free slot.
+			time.Sleep(20 * time.Millisecond)
+
+			callCount := httpmock.GetCallCountInfo()
+			Expect(callCount["GET "+BaseUrl+path]).To(Equal(2))
+
+			time.Sleep(300 * time.Millisecond)
+
+			callCount = httpmock.GetCallCountInfo()
+			Expect(callCount["GET "+BaseUrl+path]).To(Equal(4))
+		})
+
+		// A 429 is a server side limit, so the entire client has to back off. Retrying only the
+		// blocked request while its siblings keep firing is what turns one 429 into thousands.
+		It("should pause every request after a 429", func() {
+			const path = "/rate-limited"
+
+			httpmock.RegisterResponder("GET", BaseUrl+path,
+				func(*http.Request) (*http.Response, error) {
+					res := httpmock.NewStringResponse(http.StatusTooManyRequests, "TOO MANY REQUESTS")
+					res.Header.Set("Retry-After", "1")
+
+					return res, nil
+				})
+
+			httpClient = createClient(10, time.Minute)
+
+			var response string
+
+			Expect(httpClient.Get(path, nil, &response)).ToNot(BeNil())
+
+			go func() {
+				_ = httpClient.Get(TestEndpoint, nil, &response)
+			}()
+
+			time.Sleep(100 * time.Millisecond)
+
+			callCount := httpmock.GetCallCountInfo()
+			Expect(callCount["GET "+BaseUrl+TestEndpoint]).To(Equal(0))
+
+			// Retry-After said one second, after which the held back request goes out.
+			time.Sleep(time.Second)
+
+			callCount = httpmock.GetCallCountInfo()
+			Expect(callCount["GET "+BaseUrl+TestEndpoint]).To(Equal(1))
+		})
+	})
 
 	Context("with client rate limiting tests", func() {
 		// These tests verify our HTTP client's rate limiting behavior

--- a/client/http/ratelimiter/rate_limiter.go
+++ b/client/http/ratelimiter/rate_limiter.go
@@ -1,8 +1,15 @@
 package ratelimiter
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type RateLimiter interface {
 	Allow() bool
 	Wait(ctx context.Context) error
+	// Pause holds back every request, not just the one that triggered it, for at least d.
+	// Used when the server answers 429: the limit is server side, so sibling requests must
+	// back off too instead of spending the rest of the window on responses that get blocked.
+	Pause(d time.Duration)
 }

--- a/client/http/ratelimiter/sliding_window_limiter.go
+++ b/client/http/ratelimiter/sliding_window_limiter.go
@@ -12,6 +12,9 @@ type SlidingWindowLimiter struct {
 	maxRequests int
 	window      time.Duration
 	requests    []time.Time
+	// No request is allowed before this point in time, regardless of the window budget.
+	// Set by Pause when the server pushes back (429).
+	pausedUntil time.Time
 	mu          sync.Mutex
 }
 
@@ -38,6 +41,10 @@ func (l *SlidingWindowLimiter) Allow() bool {
 	now := time.Now()
 	l.cleanup(now)
 
+	if now.Before(l.pausedUntil) {
+		return false
+	}
+
 	if len(l.requests) < l.maxRequests {
 		l.requests = append(l.requests, now)
 
@@ -45,6 +52,22 @@ func (l *SlidingWindowLimiter) Allow() bool {
 	}
 
 	return false
+}
+
+// Pause blocks all requests for at least d, extending an existing pause but never shortening it.
+// A paused limiter keeps its window budget: requests resume as soon as the pause expires.
+func (l *SlidingWindowLimiter) Pause(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	until := time.Now().Add(d)
+	if until.After(l.pausedUntil) {
+		l.pausedUntil = until
+	}
 }
 
 // Wait blocks until a request can be made, then records it.
@@ -101,12 +124,17 @@ func (l *SlidingWindowLimiter) nextAvailable() time.Duration {
 	now := time.Now()
 	l.cleanup(now)
 
-	if len(l.requests) < l.maxRequests {
-		return 0
+	delay := time.Duration(0)
+
+	if len(l.requests) >= l.maxRequests {
+		// Wait for the oldest request to expire
+		oldest := l.requests[0]
+		delay = oldest.Add(l.window).Sub(now)
 	}
 
-	// Wait for the oldest request to expire
-	oldest := l.requests[0]
+	if pause := l.pausedUntil.Sub(now); pause > delay {
+		delay = pause
+	}
 
-	return oldest.Add(l.window).Sub(now)
+	return delay
 }

--- a/client/http/ratelimiter/sliding_window_limiter.go
+++ b/client/http/ratelimiter/sliding_window_limiter.go
@@ -2,8 +2,17 @@ package ratelimiter
 
 import (
 	"context"
+	"math/rand/v2"
 	"sync"
 	"time"
+)
+
+// Spread applied to the wake-up of requests waiting out a pause. A pause is one shared deadline,
+// so without it every waiter resumes in the same instant and hits the server as one burst - the
+// behaviour the caller's jittered backoff is trying to avoid. Capped so a short pause stays short.
+const (
+	pauseWakeupSpread    = 0.25
+	pauseWakeupSpreadMax = time.Second
 )
 
 // SlidingWindowLimiter implements sliding window rate limiting.
@@ -133,8 +142,18 @@ func (l *SlidingWindowLimiter) nextAvailable() time.Duration {
 	}
 
 	if pause := l.pausedUntil.Sub(now); pause > delay {
-		delay = pause
+		delay = pause + pauseWakeupJitter(pause)
 	}
 
 	return delay
+}
+
+// pauseWakeupJitter returns a random extra wait in [0, min(pause*pauseWakeupSpread, pauseWakeupSpreadMax)).
+func pauseWakeupJitter(pause time.Duration) time.Duration {
+	spread := min(time.Duration(float64(pause)*pauseWakeupSpread), pauseWakeupSpreadMax)
+	if spread <= 0 {
+		return 0
+	}
+
+	return rand.N(spread)
 }

--- a/client/http/ratelimiter/sliding_window_limiter_test.go
+++ b/client/http/ratelimiter/sliding_window_limiter_test.go
@@ -158,6 +158,52 @@ var _ = Describe("SlidingWindowLimiter", func() {
 			Expect(time.Since(start)).To(BeNumerically(">=", 90*time.Millisecond))
 		})
 
+		// A pause is one shared deadline, so without a spread every waiter resumes in the same
+		// instant and the burst the caller's jittered backoff avoided happens anyway.
+		It("should spread the wake-up of requests waiting out a pause", func() {
+			const waiters = 10
+
+			limiter = NewSlidingWindowLimiter(waiters, time.Minute)
+			limiter.Pause(200 * time.Millisecond)
+
+			var (
+				mu        sync.Mutex
+				wakeTimes []time.Time
+				wg        sync.WaitGroup
+			)
+
+			for range waiters {
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					Expect(limiter.Wait(context.Background())).To(BeNil())
+
+					mu.Lock()
+					defer mu.Unlock()
+
+					wakeTimes = append(wakeTimes, time.Now())
+				}()
+			}
+
+			wg.Wait()
+
+			earliest, latest := wakeTimes[0], wakeTimes[0]
+
+			for _, wakeTime := range wakeTimes {
+				if wakeTime.Before(earliest) {
+					earliest = wakeTime
+				}
+
+				if wakeTime.After(latest) {
+					latest = wakeTime
+				}
+			}
+
+			Expect(latest.Sub(earliest)).To(BeNumerically(">", 5*time.Millisecond))
+		})
+
 		It("should respect context cancellation while paused", func() {
 			limiter = NewSlidingWindowLimiter(10, time.Minute)
 

--- a/client/http/ratelimiter/sliding_window_limiter_test.go
+++ b/client/http/ratelimiter/sliding_window_limiter_test.go
@@ -96,6 +96,80 @@ var _ = Describe("SlidingWindowLimiter", func() {
 		})
 	})
 
+	Describe("Pause", func() {
+		It("should block requests that the window would have allowed", func() {
+			limiter = NewSlidingWindowLimiter(10, time.Minute)
+
+			limiter.Pause(100 * time.Millisecond)
+			Expect(limiter.Allow()).To(BeFalse())
+
+			time.Sleep(150 * time.Millisecond)
+
+			Expect(limiter.Allow()).To(BeTrue())
+		})
+
+		It("should not consume the window budget while paused", func() {
+			limiter = NewSlidingWindowLimiter(2, time.Minute)
+
+			limiter.Pause(50 * time.Millisecond)
+			Expect(limiter.Allow()).To(BeFalse())
+			Expect(limiter.Allow()).To(BeFalse())
+
+			time.Sleep(100 * time.Millisecond)
+
+			Expect(limiter.Allow()).To(BeTrue())
+			Expect(limiter.Allow()).To(BeTrue())
+			Expect(limiter.Allow()).To(BeFalse())
+		})
+
+		It("should extend an existing pause but never shorten it", func() {
+			limiter = NewSlidingWindowLimiter(10, time.Minute)
+
+			limiter.Pause(200 * time.Millisecond)
+			limiter.Pause(10 * time.Millisecond)
+
+			time.Sleep(100 * time.Millisecond)
+
+			Expect(limiter.Allow()).To(BeFalse())
+
+			time.Sleep(150 * time.Millisecond)
+
+			Expect(limiter.Allow()).To(BeTrue())
+		})
+
+		It("should ignore a non positive pause", func() {
+			limiter = NewSlidingWindowLimiter(10, time.Minute)
+
+			limiter.Pause(0)
+			limiter.Pause(-time.Minute)
+
+			Expect(limiter.Allow()).To(BeTrue())
+		})
+
+		It("should make Wait block until the pause expires", func() {
+			limiter = NewSlidingWindowLimiter(10, time.Minute)
+
+			limiter.Pause(100 * time.Millisecond)
+
+			start := time.Now()
+			err := limiter.Wait(context.Background())
+
+			Expect(err).To(BeNil())
+			Expect(time.Since(start)).To(BeNumerically(">=", 90*time.Millisecond))
+		})
+
+		It("should respect context cancellation while paused", func() {
+			limiter = NewSlidingWindowLimiter(10, time.Minute)
+
+			limiter.Pause(time.Minute)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+
+			Expect(limiter.Wait(ctx)).To(Equal(context.DeadlineExceeded))
+		})
+	})
+
 	Describe("Wait", func() {
 		BeforeEach(func() {
 			limiter = NewSlidingWindowLimiter(2, 100*time.Millisecond)

--- a/client/http/retry_after.go
+++ b/client/http/retry_after.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// ParseRetryAfter parses the value of a Retry-After response header, which is either a number
+// of seconds or an HTTP-date (RFC 7231 section 7.1.3). The second return value is false when
+// the header is missing, unparsable or already in the past, in which case the caller should
+// fall back to its own backoff.
+func ParseRetryAfter(header string) (time.Duration, bool) {
+	if header == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	date, err := http.ParseTime(header)
+	if err != nil {
+		return 0, false
+	}
+
+	delay := time.Until(date)
+	if delay <= 0 {
+		return 0, false
+	}
+
+	return delay, true
+}

--- a/client/http/retry_after_test.go
+++ b/client/http/retry_after_test.go
@@ -1,0 +1,45 @@
+package http_test
+
+import (
+	"net/http"
+	"time"
+
+	httpModule "github.com/env0/terraform-provider-env0/client/http"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseRetryAfter", func() {
+	It("should parse a number of seconds", func() {
+		delay, ok := httpModule.ParseRetryAfter("30")
+
+		Expect(ok).To(BeTrue())
+		Expect(delay).To(Equal(30 * time.Second))
+	})
+
+	It("should parse an HTTP date", func() {
+		date := time.Now().UTC().Add(42 * time.Second).Format(http.TimeFormat)
+
+		delay, ok := httpModule.ParseRetryAfter(date)
+
+		Expect(ok).To(BeTrue())
+		// The header has a one second resolution, so the parsed delay is 41 or 42 seconds.
+		Expect(delay).To(BeNumerically(">", 40*time.Second))
+		Expect(delay).To(BeNumerically("<=", 42*time.Second))
+	})
+
+	DescribeTable("values that carry no usable delay",
+		func(header string) {
+			delay, ok := httpModule.ParseRetryAfter(header)
+
+			Expect(ok).To(BeFalse())
+			Expect(delay).To(Equal(time.Duration(0)))
+		},
+		Entry("missing header", ""),
+		Entry("unparsable value", "soon"),
+		Entry("zero seconds", "0"),
+		Entry("negative seconds", "-5"),
+		Entry("date in the past", time.Now().UTC().Add(-time.Minute).Format(http.TimeFormat)),
+	)
+})

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -3,6 +3,7 @@ package env0
 import (
 	"context"
 	"math/rand/v2"
+	nethttp "net/http"
 	"os"
 	"time"
 
@@ -184,19 +185,16 @@ func Provider(version string) plugin.ProviderFunc {
 }
 
 const (
-	// Same value as net/http's StatusTooManyRequests, spelled out because importing net/http
-	// here would shadow the provider's own http client package.
-	tooManyRequests = 429
-
 	retryCount = 10
-	// Backoff bounds for retries that aren't rate limits (5xx, networking failures).
+	// Backoff bounds for every retry. Resty applies them to the no-response case (networking
+	// failures) itself, before retryWaitTimeFor gets a say, so both ladders share the cap.
 	retryWaitTime    = time.Second
 	retryMaxWaitTime = time.Second * 30
 	// A 429 is produced by a limit measured over a minute-sized window (API gateway and WAF),
 	// so waiting a second or two only burns another attempt on a request that is still blocked.
-	// Start much higher and allow a whole window to pass before the last attempt gives up.
-	rateLimitWaitTime    = time.Second * 5
-	rateLimitMaxWaitTime = time.Minute
+	// Start much higher than a 5xx does. A Retry-After longer than retryMaxWaitTime is still
+	// honored in full: the rate limiter is paused for its whole duration (see http.NewHttpClient).
+	rateLimitWaitTime = http.DefaultRateLimitPause
 	// Attempts allowed for the integration-test-only empty-list retry, counting the first request.
 	emptyListMaxAttempts = 3
 	// Attempts allowed for the integration-test-only 404 retry, counting the first request.
@@ -208,12 +206,14 @@ const (
 
 // retryWaitTimeFor returns how long to wait before the next attempt of a failed request.
 // Resty clamps the result to the client's [retry wait time, retry max wait time] range, which is
-// what lets the tests shrink the ladder to something that doesn't cost wall time.
+// what lets the tests shrink the ladder to something that doesn't cost wall time. The clamp also
+// means the first non-429 wait is exactly retryWaitTime rather than a jittered value below it,
+// which is what resty's own default backoff did before this function existed.
 func retryWaitTimeFor(r *resty.Response) time.Duration {
 	// Attempt counts the request that just failed, so the first backoff uses exponent 0.
 	exponent := max(r.Request.Attempt-1, 0)
 
-	if r.StatusCode() != tooManyRequests {
+	if r.StatusCode() != nethttp.StatusTooManyRequests {
 		return jitterBackoff(retryWaitTime, retryMaxWaitTime, exponent)
 	}
 
@@ -223,7 +223,7 @@ func retryWaitTimeFor(r *resty.Response) time.Duration {
 		return retryAfter + jitter(retryAfter/4)
 	}
 
-	return jitterBackoff(rateLimitWaitTime, rateLimitMaxWaitTime, exponent)
+	return jitterBackoff(rateLimitWaitTime, retryMaxWaitTime, exponent)
 }
 
 // jitterBackoff doubles base once per previous attempt, up to maxWait, and randomizes the result
@@ -264,8 +264,7 @@ func createRestyClient(ctx context.Context) *resty.Client {
 
 	return resty.New().SetRetryCount(retryCount).
 		SetRetryWaitTime(retryWaitTime).
-		// The upper bound of both ladders: retryWaitTimeFor caps the non-rate-limit one itself.
-		SetRetryMaxWaitTime(rateLimitMaxWaitTime).
+		SetRetryMaxWaitTime(retryMaxWaitTime).
 		SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
 			return retryWaitTimeFor(r), nil
 		}).
@@ -313,7 +312,7 @@ func createRestyClient(ctx context.Context) *resty.Client {
 			// Retry on rate limiting (429 Too Many Requests). The client rate limiter is paused
 			// for the whole client when this response is seen (see http.NewHttpClient), so the
 			// backoff below is only the extra wait this specific request takes.
-			if r.StatusCode() == tooManyRequests {
+			if r.StatusCode() == nethttp.StatusTooManyRequests {
 				tflog.SubsystemWarn(subCtx, "env0_api_client", "Rate limited, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "attempt": r.Request.Attempt, "retry after": r.Header().Get("Retry-After")})
 
 				return true

--- a/env0/provider.go
+++ b/env0/provider.go
@@ -2,6 +2,7 @@ package env0
 
 import (
 	"context"
+	"math/rand/v2"
 	"os"
 	"time"
 
@@ -183,12 +184,74 @@ func Provider(version string) plugin.ProviderFunc {
 }
 
 const (
+	// Same value as net/http's StatusTooManyRequests, spelled out because importing net/http
+	// here would shadow the provider's own http client package.
+	tooManyRequests = 429
+
 	retryCount = 10
+	// Backoff bounds for retries that aren't rate limits (5xx, networking failures).
+	retryWaitTime    = time.Second
+	retryMaxWaitTime = time.Second * 30
+	// A 429 is produced by a limit measured over a minute-sized window (API gateway and WAF),
+	// so waiting a second or two only burns another attempt on a request that is still blocked.
+	// Start much higher and allow a whole window to pass before the last attempt gives up.
+	rateLimitWaitTime    = time.Second * 5
+	rateLimitMaxWaitTime = time.Minute
 	// Attempts allowed for the integration-test-only empty-list retry, counting the first request.
 	emptyListMaxAttempts = 3
 	// Attempts allowed for the integration-test-only 404 retry, counting the first request.
 	notFoundMaxAttempts = 5
+	// Maximum requests the provider sends per minute, shared by all of Terraform's parallel
+	// operations. Retried attempts count against it too.
+	maxRequestsPerMinute = 950
 )
+
+// retryWaitTimeFor returns how long to wait before the next attempt of a failed request.
+// Resty clamps the result to the client's [retry wait time, retry max wait time] range, which is
+// what lets the tests shrink the ladder to something that doesn't cost wall time.
+func retryWaitTimeFor(r *resty.Response) time.Duration {
+	// Attempt counts the request that just failed, so the first backoff uses exponent 0.
+	exponent := max(r.Request.Attempt-1, 0)
+
+	if r.StatusCode() != tooManyRequests {
+		return jitterBackoff(retryWaitTime, retryMaxWaitTime, exponent)
+	}
+
+	if retryAfter, ok := http.ParseRetryAfter(r.Header().Get("Retry-After")); ok {
+		// Every request blocked in the same window gets the same Retry-After, so add jitter to
+		// keep them from coming back as a single burst the moment it expires.
+		return retryAfter + jitter(retryAfter/4)
+	}
+
+	return jitterBackoff(rateLimitWaitTime, rateLimitMaxWaitTime, exponent)
+}
+
+// jitterBackoff doubles base once per previous attempt, up to maxWait, and randomizes the result
+// over [wait/2, wait) so requests that failed together don't retry in lockstep.
+func jitterBackoff(base, maxWait time.Duration, exponent int) time.Duration {
+	wait := base
+
+	for range exponent {
+		if wait >= maxWait {
+			break
+		}
+
+		wait *= 2
+	}
+
+	wait = min(wait, maxWait)
+
+	return wait/2 + jitter(wait/2)
+}
+
+// jitter returns a random duration in [0, d).
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+
+	return rand.N(d)
+}
 
 func createRestyClient(ctx context.Context) *resty.Client {
 	var isIntegrationTest bool
@@ -200,8 +263,12 @@ func createRestyClient(ctx context.Context) *resty.Client {
 	subCtx := tflog.NewSubsystem(ctx, "env0_api_client")
 
 	return resty.New().SetRetryCount(retryCount).
-		SetRetryWaitTime(time.Second).
-		SetRetryMaxWaitTime(time.Second * 30).
+		SetRetryWaitTime(retryWaitTime).
+		// The upper bound of both ladders: retryWaitTimeFor caps the non-rate-limit one itself.
+		SetRetryMaxWaitTime(rateLimitMaxWaitTime).
+		SetRetryAfter(func(c *resty.Client, r *resty.Response) (time.Duration, error) {
+			return retryWaitTimeFor(r), nil
+		}).
 		OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
 			if r != nil {
 				tflog.SubsystemInfo(subCtx, "env0_api_client", "Sending request", map[string]any{"method": r.Method, "url": r.URL})
@@ -243,9 +310,11 @@ func createRestyClient(ctx context.Context) *resty.Client {
 				return true
 			}
 
-			// Retry on rate limiting (429 Too Many Requests)
-			if r.StatusCode() == 429 {
-				tflog.SubsystemWarn(subCtx, "env0_api_client", "Rate limited, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL})
+			// Retry on rate limiting (429 Too Many Requests). The client rate limiter is paused
+			// for the whole client when this response is seen (see http.NewHttpClient), so the
+			// backoff below is only the extra wait this specific request takes.
+			if r.StatusCode() == tooManyRequests {
+				tflog.SubsystemWarn(subCtx, "env0_api_client", "Rate limited, retrying request", map[string]any{"method": r.Request.Method, "url": r.Request.URL, "attempt": r.Request.Attempt, "retry after": r.Header().Get("Retry-After")})
 
 				return true
 			}
@@ -289,7 +358,7 @@ func configureProvider(version string, p *schema.Provider) schema.ConfigureConte
 			UserAgent:   userAgent,
 			RestClient:  createRestyClient(ctx),
 			// env0 backend allows 1000 requests / minute
-			RateLimiter: ratelimiter.NewSlidingWindowLimiter(950, time.Minute),
+			RateLimiter: ratelimiter.NewSlidingWindowLimiter(maxRequestsPerMinute, time.Minute),
 		})
 		if err != nil {
 			return nil, diag.Diagnostics{diag.Diagnostic{Severity: diag.Error, Summary: err.Error()}}

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -335,7 +335,7 @@ func TestRetryWaitTimeFor(t *testing.T) {
 		{"5xx third retry", http.StatusInternalServerError, 3, "", retryWaitTime * 2, retryWaitTime * 4},
 		{"5xx is capped", http.StatusInternalServerError, retryCount, "", retryMaxWaitTime / 2, retryMaxWaitTime},
 		{"429 first retry", http.StatusTooManyRequests, 1, "", rateLimitWaitTime / 2, rateLimitWaitTime},
-		{"429 is capped", http.StatusTooManyRequests, retryCount, "", rateLimitMaxWaitTime / 2, rateLimitMaxWaitTime},
+		{"429 is capped", http.StatusTooManyRequests, retryCount, "", retryMaxWaitTime / 2, retryMaxWaitTime},
 		{"429 with retry after seconds", http.StatusTooManyRequests, 1, "8", time.Second * 8, time.Second * 10},
 		{"429 with unparsable retry after", http.StatusTooManyRequests, 1, "soon", rateLimitWaitTime / 2, rateLimitWaitTime},
 	}
@@ -350,10 +350,13 @@ func TestRetryWaitTimeFor(t *testing.T) {
 	}
 }
 
-// The 429 ladder must not collapse to the 5xx one: a 429 always waits longer than a 5xx would
-// have waited on the same attempt.
+// The 429 ladder must not collapse to the 5xx one: while the shared cap isn't binding yet, a 429
+// waits strictly longer than a 5xx would have waited on the same attempt. Once both ladders
+// saturate at retryMaxWaitTime they converge by design, so only the climbing attempts are checked.
 func TestRetryWaitTimeForRateLimitWaitsLongerThan5xx(t *testing.T) {
-	for attempt := 1; attempt <= retryCount; attempt++ {
+	const climbingAttempts = 4
+
+	for attempt := 1; attempt <= climbingAttempts; attempt++ {
 		rateLimited := retryWaitTimeFor(newRetryTestResponse(http.StatusTooManyRequests, attempt, ""))
 		serverError := retryWaitTimeFor(newRetryTestResponse(http.StatusInternalServerError, attempt, ""))
 

--- a/env0/provider_test.go
+++ b/env0/provider_test.go
@@ -286,3 +286,89 @@ func TestRestyClientNotFoundIsNotRetried(t *testing.T) {
 
 	assert.Equal(t, 1, httpmock.GetTotalCallCount())
 }
+
+// A 429 is the failure this provider has to survive: the whole retry ladder is spent on it.
+func TestRestyClientRateLimitIsRetried(t *testing.T) {
+	client := createRetryTestClient(t)
+	url := "http://fake.env0.com/rate-limited"
+
+	httpmock.ActivateNonDefault(client.GetClient())
+
+	defer httpmock.Deactivate()
+
+	httpmock.Reset()
+	httpmock.RegisterResponder("GET", url, httpmock.NewStringResponder(http.StatusTooManyRequests, "TOO MANY REQUESTS"))
+
+	res, err := client.R().Get(url)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, http.StatusTooManyRequests, res.StatusCode())
+	}
+
+	assert.Equal(t, retryCount+1, httpmock.GetTotalCallCount())
+}
+
+func newRetryTestResponse(statusCode int, attempt int, retryAfter string) *resty.Response {
+	header := http.Header{}
+	if retryAfter != "" {
+		header.Set("Retry-After", retryAfter)
+	}
+
+	return &resty.Response{
+		Request:     &resty.Request{Attempt: attempt},
+		RawResponse: &http.Response{StatusCode: statusCode, Header: header},
+	}
+}
+
+// A 429 comes from a minute-sized window, so its ladder has to start higher and climb further
+// than the one used for a 5xx, and it has to follow Retry-After when the response supplies it.
+func TestRetryWaitTimeFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		attempt    int
+		retryAfter string
+		min        time.Duration
+		max        time.Duration
+	}{
+		{"5xx first retry", http.StatusInternalServerError, 1, "", retryWaitTime / 2, retryWaitTime},
+		{"5xx third retry", http.StatusInternalServerError, 3, "", retryWaitTime * 2, retryWaitTime * 4},
+		{"5xx is capped", http.StatusInternalServerError, retryCount, "", retryMaxWaitTime / 2, retryMaxWaitTime},
+		{"429 first retry", http.StatusTooManyRequests, 1, "", rateLimitWaitTime / 2, rateLimitWaitTime},
+		{"429 is capped", http.StatusTooManyRequests, retryCount, "", rateLimitMaxWaitTime / 2, rateLimitMaxWaitTime},
+		{"429 with retry after seconds", http.StatusTooManyRequests, 1, "8", time.Second * 8, time.Second * 10},
+		{"429 with unparsable retry after", http.StatusTooManyRequests, 1, "soon", rateLimitWaitTime / 2, rateLimitWaitTime},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			waitTime := retryWaitTimeFor(newRetryTestResponse(tt.statusCode, tt.attempt, tt.retryAfter))
+
+			assert.GreaterOrEqual(t, waitTime, tt.min)
+			assert.LessOrEqual(t, waitTime, tt.max)
+		})
+	}
+}
+
+// The 429 ladder must not collapse to the 5xx one: a 429 always waits longer than a 5xx would
+// have waited on the same attempt.
+func TestRetryWaitTimeForRateLimitWaitsLongerThan5xx(t *testing.T) {
+	for attempt := 1; attempt <= retryCount; attempt++ {
+		rateLimited := retryWaitTimeFor(newRetryTestResponse(http.StatusTooManyRequests, attempt, ""))
+		serverError := retryWaitTimeFor(newRetryTestResponse(http.StatusInternalServerError, attempt, ""))
+
+		assert.Greater(t, rateLimited, serverError, "attempt %d", attempt)
+	}
+}
+
+// Requests blocked in the same window all get the same Retry-After. Retrying them all the moment
+// it expires is what got the provider blocked by the WAF, so the wait is jittered.
+func TestRetryWaitTimeForRateLimitIsJittered(t *testing.T) {
+	waitTimes := map[time.Duration]bool{}
+
+	for range 20 {
+		waitTimes[retryWaitTimeFor(newRetryTestResponse(http.StatusTooManyRequests, 1, "10"))] = true
+	}
+
+	assert.Greater(t, len(waitTimes), 1)
+}

--- a/tests/integration/002_project/main.tf
+++ b/tests/integration/002_project/main.tf
@@ -81,12 +81,12 @@ resource "env0_project" "project_by_path1" {
 }
 
 resource "env0_project" "project_by_path2" {
-  name = "project-${random_string.random.result}-p2"
+  name              = "project-${random_string.random.result}-p2"
   parent_project_id = env0_project.project_by_path1.id
 }
 
 resource "env0_project" "project_by_path3" {
-  name = "project-${random_string.random.result}-p3"
+  name              = "project-${random_string.random.result}-p3"
   parent_project_id = env0_project.project_by_path2.id
 }
 


### PR DESCRIPTION
Linear: [ATL-305](https://linear.app/env-zero/issue/ATL-305/change-provider-retry-behavior-on-429-responses)

## Problem

WAF rate limits blocked tens of thousands of provider requests (57k on `/configuration` alone in 7 days). The provider already has a client-side rate limiter, but its 429 handling made a blocked window worse instead of letting it drain:

1. **Retries bypassed the rate limiter.** `Wait()` ran in `HttpClient.request()`, i.e. once per logical request. Resty's retry loop re-executes the request without going through it, so retries were sent on top of the allowed rate — exactly when the server was already pushing back.
2. **A 429 was retried like a 5xx** (1s base, 30s cap). A limit measured over a minute-sized window doesn't clear in a second, so early attempts were spent on requests that were certain to be blocked.
3. **`Retry-After` was ignored.**
4. **Only the blocked request backed off.** With Terraform's default parallelism of 10, the siblings kept firing into the closed window.

## Changes

- **Rate limiting moved into the resty middleware** (`OnBeforeRequest`), so every *attempt* — retries included — waits for a slot.
- **A 429 pauses the whole client.** New `RateLimiter.Pause(d)`: on 429 the limiter holds back every request for `Retry-After`, or 5s when the header is absent. A pause doesn't consume the window budget and is never shortened by a later, smaller pause.
- **429 gets its own retry ladder**: 5s base, jittered over `[wait/2, wait)`, capped at the same 30s max wait as before; `Retry-After` is honored (plus jitter) when present, and a `Retry-After` beyond the cap is still waited out in full by the limiter pause. 5xx and networking failures keep the previous 1s..30s bounds unchanged.
- **The pause wake-up is spread.** A pause is one shared deadline, so waiters would otherwise all resume in the same instant; `nextAvailable` adds a bounded random spread.
- Rate limits themselves are unchanged — still 950 requests/minute.

## Tests

- `ParseRetryAfter`: seconds, HTTP-date, missing/unparsable/past values.
- Limiter `Pause`: blocks, preserves window budget, extends but never shortens, `Wait` blocks and respects context cancellation.
- HTTP client: retried attempts count against the limit; a 429 holds back requests that hadn't been sent yet, until `Retry-After` expires.
- Retry ladder: 429 is retried through the full ladder, always waits longer than a 5xx on the same attempt, honors `Retry-After`, and is jittered.

Each new test was checked to fail without its corresponding change.

## Manual QA (env0 dev, org `TF-provider-integration-tests`)

Provider built from this branch and driven by the real integration harness (`go run tests/harness.go`) against `api-dev.dev.env0.com`.

**Happy flow — unchanged.** `002_project`, `003_configuration_variable`, `009_team`, `020_api_key` → **4/4 passed** (apply → second apply → outputs → destroy). Moving the limiter into the resty middleware does not break auth, pacing or any CRUD path.

**429 flow, with `Retry-After: 2`.** A local proxy in front of the real API answered 429 on every 4th request; `002_project` ran through it: **154 requests, 38 of them 429 → test passed** (~2 min). Proxy timeline shows the wait is the header value, and that the pause applies to the whole client, not just the blocked request:

```
23.216s 429  GET /organizations
25.397s pass GET /organizations                  <- retried after 2.18s (Retry-After + jitter)
25.645s 429  POST /projects
27.969s pass POST /projects                       <- everything held 2.32s
29.631s 429  GET /projects/7ee7e45a...
31.797s pass GET /projects/7ee7e45a...
31.971s 429  POST /projects
34.059s pass PUT  /costs/project/.../budget       <- unrelated request, same pause
```

**429 flow, no `Retry-After` header** (the WAF case). Same setup, header omitted, `009_team`: 30 requests, 3 × 429 → **test passed**, and each 429 held every request for the 5s default plus the wake-up spread:

```
27.142s 429  GET /organizations
32.165s pass GET /organizations                   <- +5.02s
38.225s 429  GET /teams/organizations/...
43.696s pass GET /teams/organizations/...         <- +5.47s
45.846s 429  GET /organizations
51.202s pass GET /organizations                   <- +5.36s
```

All three runs ended with a successful `tofu destroy`; no leftover resources. The injecting proxy was throwaway QA scaffolding and is not part of this PR.

Both 429 scenarios were re-run after the review fixes (shared 30s cap, pause wake-up spread); numbers above are from the re-run.
