### PR TITLE
[APO-684] Fix: Clear the module opentofu version when module tests are disabled

### DIFF
--- a/client/module.go
+++ b/client/module.go
@@ -77,6 +77,8 @@ type ModuleCreatePayloadWith struct {
 	OrganizationId string `json:"organizationId"`
 }
 
+// OpentofuVersion is deliberately not 'omitempty': an empty version must be sent so that the backend clears a
+// previously set version - for example when module tests are disabled.
 type ModuleUpdatePayload struct {
 	ModuleName            string         `json:"moduleName,omitempty"`
 	ModuleProvider        string         `json:"moduleProvider,omitempty"`
@@ -90,15 +92,15 @@ type ModuleUpdatePayload struct {
 	BitbucketClientKey    string         `json:"bitbucketClientKey"`
 	IsGitlab              bool           `json:"isGitLab"`
 	IsBitbucketServer     bool           `json:"isBitbucketServer"`
-	IsGitHubEnterprise    bool           `json:"isGitHubEnterprise"        tfschema:"is_github_enterprise"`
-	IsGitLabEnterprise    bool           `json:"isGitLabEnterprise"        tfschema:"is_gitlab_enterprise"`
+	IsGitHubEnterprise    bool           `json:"isGitHubEnterprise"       tfschema:"is_github_enterprise"`
+	IsGitLabEnterprise    bool           `json:"isGitLabEnterprise"       tfschema:"is_gitlab_enterprise"`
 	SshKeys               []ModuleSshKey `json:"sshkeys"`
 	Path                  string         `json:"path"`
 	TagPrefix             string         `json:"tagPrefix,omitempty"`
 	ModuleTestEnabled     bool           `json:"moduleTestEnabled"`
 	RunTestsOnPullRequest bool           `json:"runTestsOnPullRequest"`
-	OpentofuVersion       string         `json:"opentofuVersion,omitempty"`
-	IsAzureDevOps         bool           `json:"isAzureDevOps"             tfschema:"is_azure_devops"`
+	OpentofuVersion       string         `json:"opentofuVersion"`
+	IsAzureDevOps         bool           `json:"isAzureDevOps"            tfschema:"is_azure_devops"`
 }
 
 func (payload *ModuleUpdatePayload) Invalidate() error {

--- a/client/module.go
+++ b/client/module.go
@@ -77,8 +77,6 @@ type ModuleCreatePayloadWith struct {
 	OrganizationId string `json:"organizationId"`
 }
 
-// OpentofuVersion is deliberately not 'omitempty': an empty version must be sent so that the backend clears a
-// previously set version - for example when module tests are disabled.
 type ModuleUpdatePayload struct {
 	ModuleName            string         `json:"moduleName,omitempty"`
 	ModuleProvider        string         `json:"moduleProvider,omitempty"`

--- a/client/module_test.go
+++ b/client/module_test.go
@@ -1,10 +1,14 @@
 package client_test
 
 import (
+	"encoding/json"
+
 	. "github.com/env0/terraform-provider-env0/client"
 	"github.com/jinzhu/copier"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 	"go.uber.org/mock/gomock"
 )
 
@@ -16,6 +20,25 @@ var _ = Describe("Module Client", func() {
 		Repository:     "repository-name",
 		Path:           "path",
 	}
+
+	Describe("ModuleUpdatePayload", func() {
+		DescribeTable("Opentofu Version",
+			func(value string, expected types.GomegaMatcher) {
+				payload := ModuleUpdatePayload{
+					OpentofuVersion: value,
+				}
+				jsonPayload, _ := json.Marshal(payload)
+
+				var parsedPayload map[string]any
+
+				_ = json.Unmarshal(jsonPayload, &parsedPayload)
+				Expect(parsedPayload["opentofuVersion"]).To(expected)
+			},
+			Entry("Has value", "1.7.0", BeEquivalentTo("1.7.0")),
+			// An empty version must still be serialized, otherwise the backend keeps the previously set version.
+			Entry("No value", "", BeEquivalentTo("")),
+		)
+	})
 
 	Describe("Get Single Module", func() {
 		var returnedModule *Module

--- a/env0/resource_module_test.go
+++ b/env0/resource_module_test.go
@@ -167,6 +167,89 @@ func TestUnitModuleResource(t *testing.T) {
 		})
 	})
 
+	t.Run("Success - disabling module test clears the opentofu version", func(t *testing.T) {
+		moduleWithTestsDisabled := module
+		moduleWithTestsDisabled.ModuleTestEnabled = false
+		moduleWithTestsDisabled.RunTestsOnPullRequest = false
+		moduleWithTestsDisabled.OpentofuVersion = ""
+
+		testCase := resource.TestCase{
+			Steps: []resource.TestStep{
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]any{
+						"module_name":               module.ModuleName,
+						"module_provider":           module.ModuleProvider,
+						"repository":                module.Repository,
+						"description":               module.Description,
+						"token_id":                  module.TokenId,
+						"token_name":                module.TokenName,
+						"path":                      module.Path,
+						"tag_prefix":                module.TagPrefix,
+						"module_test_enabled":       module.ModuleTestEnabled,
+						"run_tests_on_pull_request": module.RunTestsOnPullRequest,
+						"opentofu_version":          module.OpentofuVersion,
+					}),
+					Check: resource.TestCheckResourceAttr(accessor, "opentofu_version", module.OpentofuVersion),
+				},
+				{
+					Config: resourceConfigCreate(resourceType, resourceName, map[string]any{
+						"module_name":         module.ModuleName,
+						"module_provider":     module.ModuleProvider,
+						"repository":          module.Repository,
+						"description":         module.Description,
+						"token_id":            module.TokenId,
+						"token_name":          module.TokenName,
+						"path":                module.Path,
+						"tag_prefix":          module.TagPrefix,
+						"module_test_enabled": false,
+					}),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(accessor, "module_test_enabled", "false"),
+						resource.TestCheckResourceAttr(accessor, "run_tests_on_pull_request", "false"),
+						resource.TestCheckResourceAttr(accessor, "opentofu_version", ""),
+					),
+				},
+			},
+		}
+
+		runUnitTest(t, testCase, func(mock *client.MockApiClientInterface) {
+			mock.EXPECT().ModuleCreate(client.ModuleCreatePayload{
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     module.ModuleTestEnabled,
+				RunTestsOnPullRequest: module.RunTestsOnPullRequest,
+				OpentofuVersion:       module.OpentofuVersion,
+			}).Times(1).Return(&module, nil)
+
+			mock.EXPECT().ModuleUpdate(module.Id, client.ModuleUpdatePayload{
+				ModuleName:            module.ModuleName,
+				ModuleProvider:        module.ModuleProvider,
+				Repository:            module.Repository,
+				Description:           module.Description,
+				TokenId:               module.TokenId,
+				TokenName:             module.TokenName,
+				Path:                  module.Path,
+				TagPrefix:             module.TagPrefix,
+				ModuleTestEnabled:     false,
+				RunTestsOnPullRequest: false,
+				OpentofuVersion:       "",
+			}).Times(1).Return(&moduleWithTestsDisabled, nil)
+
+			gomock.InOrder(
+				mock.EXPECT().Module(module.Id).Times(2).Return(&module, nil),
+				mock.EXPECT().Module(module.Id).Times(1).Return(&moduleWithTestsDisabled, nil),
+			)
+
+			mock.EXPECT().ModuleDelete(module.Id).Times(1)
+		})
+	})
+
 	t.Run("Create Failure", func(t *testing.T) {
 		testCase := resource.TestCase{
 			Steps: []resource.TestStep{


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Linear: [APO-684](https://linear.app/env-zero/issue/APO-684/env0-module-opentofu-version-never-clears-after-disabling-module)

`ModuleUpdatePayload.OpentofuVersion` was tagged `omitempty`, so an empty version is stripped from the PATCH body. The backend merges the request over the existing module, so a missing key leaves the old version in place, and `disableModuleTesting` never clears it.

The apply succeeds and writes `""` to state. The next refresh reads `1.6.0` back, so the module drifts on every plan.

Reproduce: create a module with `module_test_enabled = true` and `opentofu_version = "1.6.0"`, then disable tests, drop the version, apply, and plan again.

### Solution

Dropped `omitempty` from `ModuleUpdatePayload.OpentofuVersion`, so an empty version is sent and the backend overwrite clears it. The API accepts it: `BlueprintApi.OpentofuVersion` is a plain string with no enum or `minLength`, and `assertTofuVersion` is skipped on a falsy value.

`ModuleCreatePayload` keeps `omitempty`. There is nothing to clear on create.

Tests cover both layers: the client test asserts `opentofuVersion` survives JSON marshalling when empty, and the resource test asserts the update payload carries an empty version when module tests are disabled.

---
### How I _manually_ verified it works

- [x] Reproduced the bug against the dev stage (`api-dev.dev.env0.com`), driving a provider binary built from the parent commit through a filesystem mirror. Created a module with tests enabled and `opentofu_version = "1.6.0"`, then applied with tests off and the version dropped: state showed `""`, `GET /modules/:id` still returned `"1.6.0"`, and every re-plan showed `- opentofu_version = "1.6.0" -> null`.

- [x] Pointed the same stuck module at a binary built from this branch. One apply cleared it: the server dropped `opentofuVersion` and the re-plan returned `No changes`. Users already drifted recover without touching state.

- [x] Ran a fresh cycle on this branch: create with `1.6.0` (server `"1.6.0"`), disable tests (server key gone, plan clean), re-enable with `1.7.0` (server `"1.7.0"`, plan clean). Setting a version still works, so the fix does not trade one direction for the other.

- [x] Destroyed both modules and confirmed through the API that no QA modules and no module-testing environments were left in the org.

Ran with `terraform`, not `tofu`, which is not installed locally. The provider binary under test is the same either way.

