### PR TITLE
[APO-717] Feature: expose enable_post_merge_pr_comments on env0_organization_policy

### DIFF
--- a/client/organization.go
+++ b/client/organization.go
@@ -15,6 +15,7 @@ type Organization struct {
 	EnableOidc                          bool    `json:"enableOidc"`
 	EnforcePrCommenterPermissions       bool    `json:"enforcePrCommenterPermissions"`
 	AllowMergeableBypassForPrApply      bool    `json:"allowMergeableBypassForPrApply"`
+	EnablePostMergePrComments           bool    `json:"enablePostMergePrComments"`
 	Description                         string  `json:"description"`
 	PhotoUrl                            string  `json:"photoUrl"`
 	CreatedBy                           string  `json:"createdBy"`
@@ -32,6 +33,7 @@ type OrganizationPolicyUpdatePayload struct {
 	EnableOidc                          *bool   `json:"enableOidc,omitempty"`
 	EnforcePrCommenterPermissions       *bool   `json:"enforcePrCommenterPermissions,omitempty"`
 	AllowMergeableBypassForPrApply      *bool   `json:"allowMergeableBypassForPrApply,omitempty"`
+	EnablePostMergePrComments           *bool   `json:"enablePostMergePrComments,omitempty"`
 }
 
 func (client *ApiClient) Organization() (Organization, error) {

--- a/docs/resources/organization_policy.md
+++ b/docs/resources/organization_policy.md
@@ -30,6 +30,7 @@ resource "env0_organization_policy" "policy_example" {
 - `do_not_consider_merge_commits_for_pr_plans` (Boolean)
 - `do_not_report_skipped_status_checks` (Boolean)
 - `enable_oidc` (Boolean) set to 'true' to enable OIDC token (JWT) availability during env0 deployments (defaults to 'false')
+- `enable_post_merge_pr_comments` (Boolean) set to 'true' to comment on a merged pull request when a deployment it triggered is waiting for approval or has failed (defaults to 'false'). cannot be enabled together with the organization's 'Disable PR Comments' policy
 - `enforce_pr_commenter_permissions` (Boolean) set to 'true' to enforce PR commenter permissions during env0 deployments (defaults to 'false')
 - `max_ttl` (String) the maximum environment time-to-live allowed on deploy time. Format is <number>-<M/w/d/h> (Examples: 12-h, 3-d, 1-w, 1-M). Omit for infinite ttl. must be equal or longer than default_ttl
 

--- a/env0/resource_organization_policy.go
+++ b/env0/resource_organization_policy.go
@@ -57,6 +57,12 @@ func resourceOrganizationPolicy() *schema.Resource {
 				Default:     false,
 				Description: "set to 'true' to allow bypassing the PR mergeability check for env0/Apply status checks on GitHub (defaults to 'false')",
 			},
+			"enable_post_merge_pr_comments": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "set to 'true' to comment on a merged pull request when a deployment it triggered is waiting for approval or has failed (defaults to 'false'). cannot be enabled together with the organization's 'Disable PR Comments' policy",
+			},
 		},
 	}
 }

--- a/env0/resource_organization_policy_test.go
+++ b/env0/resource_organization_policy_test.go
@@ -34,6 +34,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 		EnableOidc:                          false,
 		EnforcePrCommenterPermissions:       false,
 		AllowMergeableBypassForPrApply:      false,
+		EnablePostMergePrComments:           false,
 	}
 
 	organizationUpdated := client.Organization{
@@ -45,6 +46,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 		EnableOidc:                          true,
 		EnforcePrCommenterPermissions:       true,
 		AllowMergeableBypassForPrApply:      true,
+		EnablePostMergePrComments:           true,
 	}
 
 	t.Run("Success", func(t *testing.T) {
@@ -65,6 +67,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "enable_oidc", strconv.FormatBool(organization.EnableOidc)),
 						resource.TestCheckResourceAttr(accessor, "enforce_pr_commenter_permissions", strconv.FormatBool(organization.EnforcePrCommenterPermissions)),
 						resource.TestCheckResourceAttr(accessor, "allow_mergeable_bypass_for_pr_apply", strconv.FormatBool(organization.AllowMergeableBypassForPrApply)),
+						resource.TestCheckResourceAttr(accessor, "enable_post_merge_pr_comments", strconv.FormatBool(organization.EnablePostMergePrComments)),
 					),
 				},
 				{
@@ -74,6 +77,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 						"enable_oidc":                         organizationUpdated.EnableOidc,
 						"enforce_pr_commenter_permissions":    organizationUpdated.EnforcePrCommenterPermissions,
 						"allow_mergeable_bypass_for_pr_apply": organizationUpdated.AllowMergeableBypassForPrApply,
+						"enable_post_merge_pr_comments":       organizationUpdated.EnablePostMergePrComments,
 					}),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(accessor, "id", organization.Id),
@@ -83,6 +87,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 						resource.TestCheckResourceAttr(accessor, "enable_oidc", strconv.FormatBool(organizationUpdated.EnableOidc)),
 						resource.TestCheckResourceAttr(accessor, "enforce_pr_commenter_permissions", strconv.FormatBool(organizationUpdated.EnforcePrCommenterPermissions)),
 						resource.TestCheckResourceAttr(accessor, "allow_mergeable_bypass_for_pr_apply", strconv.FormatBool(organizationUpdated.AllowMergeableBypassForPrApply)),
+						resource.TestCheckResourceAttr(accessor, "enable_post_merge_pr_comments", strconv.FormatBool(organizationUpdated.EnablePostMergePrComments)),
 					),
 				},
 			},
@@ -98,6 +103,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 					EnableOidc:                          new(false),
 					EnforcePrCommenterPermissions:       new(false),
 					AllowMergeableBypassForPrApply:      new(false),
+					EnablePostMergePrComments:           new(false),
 				}).Times(1).Return(&organization, nil),
 				mock.EXPECT().Organization().Times(2).Return(organization, nil),
 				mock.EXPECT().OrganizationPolicyUpdate(client.OrganizationPolicyUpdatePayload{
@@ -106,6 +112,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 					EnableOidc:                          &organizationUpdated.EnableOidc,
 					EnforcePrCommenterPermissions:       &organizationUpdated.EnforcePrCommenterPermissions,
 					AllowMergeableBypassForPrApply:      &organizationUpdated.AllowMergeableBypassForPrApply,
+					EnablePostMergePrComments:           &organizationUpdated.EnablePostMergePrComments,
 					DoNotConsiderMergeCommitsForPrPlans: new(false),
 					MaxTtl:                              new(""),
 				}).Times(1).Return(&organizationUpdated, nil),
@@ -154,6 +161,7 @@ func TestUnitOrganizationPolicyResource(t *testing.T) {
 				EnableOidc:                          new(false),
 				EnforcePrCommenterPermissions:       new(false),
 				AllowMergeableBypassForPrApply:      new(false),
+				EnablePostMergePrComments:           new(false),
 			}).Times(1).Return(nil, errors.New("error"))
 		})
 	})


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request

Linear: [APO-717](https://linear.app/env-zero/issue/APO-717)

`enablePostMergePrComments` is a new organization policy on the env0 API: after a PR is merged, env0 comments on it for each environment whose deployment is waiting for approval or failed. The provider does not expose it, so an organization that manages its policies in Terraform cannot turn it on, and a plan would drift against it.

### Solution

Adds `enable_post_merge_pr_comments` (Boolean, optional, defaults to `false`) to `env0_organization_policy`, plus the matching fields on the client `Organization` and `OrganizationPolicyUpdatePayload`. Docs regenerated with `./generate-docs.sh`.

The API rejects enabling it together with the organization's Disable PR Comments policy (that one is not exposed by the provider), so the description says so and the error surfaces from the API.

Covered by the existing `TestUnitOrganizationPolicyResource` create/update/delete flow, extended with the new attribute:

```
go test ./env0/ -run TestUnitOrganizationPolicyResource -count=1   # ok
```
